### PR TITLE
Position Solver for Tracer Points. Fixes #10

### DIFF
--- a/src/app/model/mechanism/position-solver.ts
+++ b/src/app/model/mechanism/position-solver.ts
@@ -295,11 +295,16 @@ export class PositionSolver {
           );
           break;
         case 'determineTracerJoint':
-          this.determineTracerJoint(
-            joints[connected_joint_indices[0]],
-            joints[connected_joint_indices[1]],
-            joint
+          this.twoCircleIntersectionPoints(
+              joints[connected_joint_indices[0]],
+              joints[connected_joint_indices[1]],
+              joint
           );
+          // this.determineTracerJoint(
+          //   joints[connected_joint_indices[0]],
+          //   joints[connected_joint_indices[1]],
+          //   joint
+          // );
           possible = true;
           break;
         default:


### PR DESCRIPTION
Commented out logic utilizing trig to determine tracer point and instead utilized two circle intersection method. 