### PR TITLE
Utilize capital letters for joints and link IDs

### DIFF
--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -174,7 +174,7 @@ export class MechanismService {
   determineNextLetter(additionalLetters?: string[]) {
     let lastLetter = '';
     if (this.joints.length === 0 && additionalLetters === undefined) {
-      return 'a';
+      return 'A';
     }
     this.joints.forEach((j) => {
       if (j.id > lastLetter) {


### PR DESCRIPTION
I capitalize all the letters within joints and links for their IDs.

For example, instead of having joint a and link ab, it is now joint A and link AB. 