### PR TITLE
Ungrounding a joint will set that joint's input to false

### DIFF
--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -603,6 +603,7 @@ export class MechanismService {
       // this.joints[selectedJointIndex] = joint;
     } else {
       this.activeObjService.selectedJoint.ground = !this.activeObjService.selectedJoint.ground;
+      this.activeObjService.selectedJoint.input = false;
     }
     this.updateMechanism();
   }


### PR DESCRIPTION
Ungrounding a joint will set that joint's input to false