### PR TITLE
Remove slider sets joint's ground to false

### DIFF
--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -681,7 +681,7 @@ export class MechanismService {
       this.joints.splice(prismaticJointIndex, 1);
       this.links.splice(pistonIndex, 1);
 
-      this.activeObjService.selectedJoint.ground = true;
+      this.activeObjService.selectedJoint.ground = false;
     }
     this.updateMechanism();
     console.log(this.joints);


### PR DESCRIPTION
Removing a slider will now set the joint as a tracer joint rather than a grounded joint