### PR TITLE
Adjusted rpm and deg/s to rad/s

### DIFF
--- a/src/app/component/settings-panel/settings-panel.component.html
+++ b/src/app/component/settings-panel/settings-panel.component.html
@@ -34,11 +34,11 @@
       </radio-block>
 
       <input-block
-        unit='deg/sec'
+        unit='rad/sec'
         type='number'
         [formGroup]='this.settingsForm'
         _formControl='speed'
-        tooltip='The speed that the animation will run at. (rpm - I think)'
+        tooltip='The speed that the animation will run at rad/s'
       >Input Speed
       </input-block>
     </collapsible-subseciton>

--- a/src/app/component/settings-panel/settings-panel.component.html
+++ b/src/app/component/settings-panel/settings-panel.component.html
@@ -34,11 +34,11 @@
       </radio-block>
 
       <input-block
-        unit='rad/sec'
+        unit='deg/sec'
         type='number'
         [formGroup]='this.settingsForm'
         _formControl='speed'
-        tooltip='The speed that the animation will run at rad/s'
+        tooltip='The speed that the animation will run at rpm'
       >Input Speed
       </input-block>
     </collapsible-subseciton>

--- a/src/app/component/settings-panel/settings-panel.component.ts
+++ b/src/app/component/settings-panel/settings-panel.component.ts
@@ -93,6 +93,9 @@ export class SettingsPanelComponent {
       this.mechanismSrv.updateMechanism();
     });
     this.settingsForm.controls['speed'].valueChanges.subscribe((val) => {
+      if (val?.includes('-')) {
+        this.sendNotification("Input Speed is a magnitude. Change cw or ccw from Input Direction");
+      }
         const [success, value] = this.nup.parseAngVelString(
           val!,
           this.settingsService.angVelUnit.getValue()
@@ -251,6 +254,10 @@ export class SettingsPanelComponent {
 
   sendComingSoon(): void {
     NewGridComponent.sendNotification('This feature is coming soon!');
+  }
+
+  sendNotification(message: string): void {
+    NewGridComponent.sendNotification(message);
   }
 
   updateObjectScale() {

--- a/src/app/component/settings-panel/settings-panel.component.ts
+++ b/src/app/component/settings-panel/settings-panel.component.ts
@@ -14,6 +14,8 @@ import { MatDialog } from '@angular/material/dialog';
 import { EnableForcesComponent } from '../MODALS/enable-forces/enable-forces.component';
 import { EnableWeldedComponent } from '../MODALS/enable-welded/enable-welded.component';
 import { EnableEquationsComponent } from '../MODALS/enable-equations/enable-equations.component';
+import { getChartByID } from 'apexcharts';
+import { AnalysisGraphComponent } from '../analysis-graph/analysis-graph.component';
 
 @Component({
   selector: 'app-settings-panel',
@@ -91,21 +93,25 @@ export class SettingsPanelComponent {
       this.mechanismSrv.updateMechanism();
     });
     this.settingsForm.controls['speed'].valueChanges.subscribe((val) => {
-      if (this.settingsForm.controls['speed'].invalid) {
-        const [success, value] = this.nup.parseAngVelString(val!, this.settingsService.angVelUnit.getValue());
-        const str = this.nup.formatValueAndUnit(value, this.settingsService.angVelUnit.getValue());
-        this.settingsForm.patchValue(
-          { speed: str},
-          {emitEvent: false });
-        this.settingsService.inputSpeed.next(value);
-        // this.settingsForm.patchValue({ speed: this.nup.formatValueAndUnit(value, this.settingsService.angVelUnit.getValue()) });
-      } else {
-        this.currentSpeedSetting = Number(val);
-        this.settingsForm.patchValue({ speed:this.currentSpeedSetting.toString() });
-        // this.settingsForm.patchValue({ speed: this.nup.formatValueAndUnit(this.currentSpeedSetting, this.settingsService.angVelUnit.getValue()) });
-        this.settingsService.inputSpeed.next(this.currentSpeedSetting);
-      }
+        const [success, value] = this.nup.parseAngVelString(
+          val!,
+          this.settingsService.angVelUnit.getValue()
+        );
+        if (!success) {
+          this.settingsForm.patchValue(
+            { speed: this.currentSpeedSetting.toString() },
+          { emitEvent: false },
+            );
+        } else {
+          this.currentSpeedSetting = value;
+          this.settingsService.inputSpeed.next(value);
+          this.settingsForm.patchValue(
+            {speed: this.nup.formatValueAndUnit(value, this.settingsService.angVelUnit.getValue())},
+          { emitEvent: false },
+          );
+        }
       this.mechanismSrv.updateMechanism();
+        this.mechanismSrv.onMechUpdateState.next(2);
     });
     this.settingsForm.controls['objectScale'].valueChanges.subscribe((val) => {
       if (this.settingsForm.controls['objectScale'].invalid) {
@@ -120,6 +126,7 @@ export class SettingsPanelComponent {
       this.currentAngleUnit = ParseAngleUnit(String(val));
       this.settingsService.angleUnit.next(this.currentAngleUnit);
       this.mechanismSrv.updateMechanism();
+      // if (AnalysisGraphComponent.)
     });
     this.settingsForm.controls['globalunit'].valueChanges.subscribe((val) => {
       this.currentGlobalUnit = ParseGlobalUnit(val);
@@ -229,7 +236,7 @@ export class SettingsPanelComponent {
   numRegex = '^-?[0-9]+(.[0-9]{0,10})?$';
   settingsForm = this.fb.group(
     {
-      speed: ['', [Validators.required, Validators.pattern(this.numRegex)]],
+      speed: ['', [Validators.required]],
       objectScale: ['', [Validators.required, Validators.pattern(this.numRegex)]],
       rotation: ['', { updateOn: 'change' }],
       lengthunit: ['', { updateOn: 'change' }],

--- a/src/app/component/settings-panel/settings-panel.component.ts
+++ b/src/app/component/settings-panel/settings-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { SettingsService } from 'src/app/services/settings.service';
-import { LengthUnit, AngleUnit, ForceUnit, GlobalUnit } from 'src/app/model/utils';
+import { LengthUnit, AngleUnit, ForceUnit, GlobalUnit, RotationUnit } from 'src/app/model/utils';
 import { FormBuilder, Validators } from '@angular/forms';
 import { NewGridComponent } from '../new-grid/new-grid.component';
 import { MechanismService } from '../../services/mechanism.service';
@@ -35,6 +35,7 @@ export class SettingsPanelComponent {
   currentAngleUnit!: AngleUnit;
   // currentTorqueUnit!: TorqueUnit;
   currentGlobalUnit!: GlobalUnit;
+  currentRotationalUnit!: RotationUnit;
   rotateDirection!: boolean;
   currentSpeedSetting!: number;
   currentObjectScaleSetting!: number;
@@ -43,6 +44,7 @@ export class SettingsPanelComponent {
     this.currentLengthUnit = this.settingsService.lengthUnit.value;
     this.currentAngleUnit = this.settingsService.angleUnit.value;
     this.currentGlobalUnit = this.settingsService.globalUnit.value;
+    this.currentRotationalUnit = this.settingsService.rotationalUnit.value;
     this.rotateDirection = this.settingsService.isInputCW.value;
     this.currentSpeedSetting = this.settingsService.inputSpeed.value;
     this.currentObjectScaleSetting = SettingsService.objectScale;
@@ -65,7 +67,10 @@ export class SettingsPanelComponent {
       this.currentObjectScaleSetting = val;
       this.settingsForm.patchValue(
         { objectScale: this.currentObjectScaleSetting.toString() },
-        { emitEvent: false }
+        { emitEvent: false },
+      );
+      this.settingsForm.patchValue(
+        { speed: this.nup.formatValueAndUnit(20, this.settingsService.rotationalUnit.getValue()) }
       );
 
       //Werid place to put this but
@@ -87,7 +92,8 @@ export class SettingsPanelComponent {
     });
     this.settingsForm.controls['speed'].valueChanges.subscribe((val) => {
       if (this.settingsForm.controls['speed'].invalid) {
-        this.settingsForm.patchValue({ speed: this.currentSpeedSetting.toString() });
+        this.settingsForm.patchValue({ speed: this.nup.formatValueAndUnit(Number(val), this.settingsService.rotationalUnit.getValue()),
+        });
       } else {
         this.currentSpeedSetting = Number(val);
         this.settingsService.inputSpeed.next(this.currentSpeedSetting);
@@ -213,7 +219,7 @@ export class SettingsPanelComponent {
     }
   }
 
-  numRegex = '^-?[0-9]+(.[0-9]{0,10})?$';
+  numRegex = '^-?[0-9]+(\\.[0-9]{0,10})?\\s*[a-zA-Z]*$';
   settingsForm = this.fb.group(
     {
       speed: ['', [Validators.required, Validators.pattern(this.numRegex)]],

--- a/src/app/component/settings-panel/settings-panel.component.ts
+++ b/src/app/component/settings-panel/settings-panel.component.ts
@@ -99,7 +99,7 @@ export class SettingsPanelComponent {
         );
         if (!success) {
           this.settingsForm.patchValue(
-            { speed: this.currentSpeedSetting.toString() },
+            { speed: this.nup.formatValueAndUnit(this.currentSpeedSetting, this.settingsService.angVelUnit.getValue()) },
           { emitEvent: false },
             );
         } else {

--- a/src/app/model/utils.ts
+++ b/src/app/model/utils.ts
@@ -21,7 +21,7 @@ export enum AngleUnit {
   NULL = 12,
 }
 
-export enum RotationUnit {
+export enum AngVelUnit {
   RPM = 15, // revolutions per minute
   DPS = 16, // degrees per second
   RPS = 17, // Radians per second

--- a/src/app/model/utils.ts
+++ b/src/app/model/utils.ts
@@ -21,6 +21,12 @@ export enum AngleUnit {
   NULL = 12,
 }
 
+export enum RotationUnit {
+  RPM = 15, // revolutions per minute
+  DPS = 16, // degrees per second
+  RPS = 17, // Radians per second
+}
+
 export enum ForceUnit {
   LBF = 20,
   NEWTON = 21,

--- a/src/app/model/utils.ts
+++ b/src/app/model/utils.ts
@@ -27,6 +27,11 @@ export enum AngVelUnit {
   RPS = 17, // Radians per second
 }
 
+export enum AngAccUnit {
+  RPS_square = 18, // rad per second square (rad/s^2)
+  DPS_square = 19, // degrees per second square (deg/s^2)
+}
+
 export enum ForceUnit {
   LBF = 20,
   NEWTON = 21,

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -164,7 +164,7 @@ export class MechanismService {
   }
 
   updateLinkageUnits(fromUnits: LengthUnit, toUnits: LengthUnit) {
-    //Scale the linkage based on teh units
+    //Scale the linkage based on the units
     // For each joint, move the joint
     this.joints.forEach((joint) => {
       //If joint is of type Rev joint only, move the joint
@@ -179,7 +179,7 @@ export class MechanismService {
         );
       }
     });
-    this.updateMechanism();
+    // this.updateMechanism();
     // this.settingsService.lengthUnit.subscribe((val) => {
     //For each jo
     // let unit = this.settingsService.lengthUnit.value;

--- a/src/app/services/number-unit-parser.service.ts
+++ b/src/app/services/number-unit-parser.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { LengthUnit, AngleUnit, ForceUnit } from '../model/utils';
+import { AngleUnit, ForceUnit, LengthUnit, RotationUnit } from '../model/utils';
 
 @Injectable({
   providedIn: 'root',
@@ -7,7 +7,7 @@ import { LengthUnit, AngleUnit, ForceUnit } from '../model/utils';
 export class NumberUnitParserService {
   constructor() {}
 
-  public formatValueAndUnit(value: number, units: LengthUnit | AngleUnit | ForceUnit): string {
+  public formatValueAndUnit(value: number, units: LengthUnit | AngleUnit | ForceUnit | RotationUnit): string {
     switch (units) {
       case LengthUnit.CM:
         return value.toFixed(2) + ' cm';
@@ -23,6 +23,12 @@ export class NumberUnitParserService {
         return value.toFixed(2) + ' lbf';
       case ForceUnit.NEWTON:
         return value.toFixed(2) + ' N';
+      case RotationUnit.RPM:
+        return value.toFixed(2) + ' rpm';
+      case RotationUnit.RPS:
+        return value.toFixed(2) + ' rev/s';
+      case RotationUnit.DPS:
+        return value.toFixed(2) + ' deg/s';
     }
     return 'Error in formatValueAndUnit()';
   }

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { LengthUnit, AngleUnit, GlobalUnit, ForceUnit } from '../model/utils';
+import { LengthUnit, AngleUnit, GlobalUnit, ForceUnit, RotationUnit } from '../model/utils';
 
 @Injectable({
   providedIn: 'root',
@@ -9,6 +9,7 @@ export class SettingsService {
   lengthUnit = new BehaviorSubject(LengthUnit.CM);
   angleUnit = new BehaviorSubject(AngleUnit.DEGREE);
   forceUnit = new BehaviorSubject(ForceUnit.NEWTON);
+  rotationalUnit = new BehaviorSubject(RotationUnit.RPM);
   // inputTorque = new BehaviorSubject(TorqueUnit.CM_N);
   globalUnit = new BehaviorSubject(GlobalUnit.METRIC);
   isInputCW = new BehaviorSubject(true);

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { LengthUnit, AngleUnit, GlobalUnit, ForceUnit, AngVelUnit } from '../model/utils';
+import { LengthUnit, AngleUnit, GlobalUnit, ForceUnit, AngVelUnit, AngAccUnit } from '../model/utils';
 
 @Injectable({
   providedIn: 'root',
@@ -10,6 +10,7 @@ export class SettingsService {
   angleUnit = new BehaviorSubject(AngleUnit.DEGREE);
   forceUnit = new BehaviorSubject(ForceUnit.NEWTON);
   angVelUnit = new BehaviorSubject(AngVelUnit.RPM);
+  angAccUnit = new BehaviorSubject(AngAccUnit.RPS_square);
   // inputTorque = new BehaviorSubject(TorqueUnit.CM_N);
   globalUnit = new BehaviorSubject(GlobalUnit.METRIC);
   isInputCW = new BehaviorSubject(true);

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { LengthUnit, AngleUnit, GlobalUnit, ForceUnit, RotationUnit } from '../model/utils';
+import { LengthUnit, AngleUnit, GlobalUnit, ForceUnit, AngVelUnit } from '../model/utils';
 
 @Injectable({
   providedIn: 'root',
@@ -9,7 +9,7 @@ export class SettingsService {
   lengthUnit = new BehaviorSubject(LengthUnit.CM);
   angleUnit = new BehaviorSubject(AngleUnit.DEGREE);
   forceUnit = new BehaviorSubject(ForceUnit.NEWTON);
-  rotationalUnit = new BehaviorSubject(RotationUnit.RPM);
+  angVelUnit = new BehaviorSubject(AngVelUnit.RPM);
   // inputTorque = new BehaviorSubject(TorqueUnit.CM_N);
   globalUnit = new BehaviorSubject(GlobalUnit.METRIC);
   isInputCW = new BehaviorSubject(true);


### PR DESCRIPTION
This PR resolves multiple issues:
1. The input speed (in yellow) should always show rpm even if another unit is entered (used to have no units). This box should not allow negative numbers.
2. The angular velocity (in red) should changed between deg/s and rad/s based on the angle unit set on the setting panel.
3. Changing input direction should change the analysis graphs. For example angular velocity of the crank should be positive when CCW. 
4. Fix error messages caused by graph subscriptions that were not properly unsubscribed.

![Screenshot 2024-02-19 at 3 20 28 PM](https://github.com/PMKS-Web/PMKSWeb/assets/19924289/f4a20bd2-35eb-4032-98b4-096458e164dc)