### PR TITLE
Agent workflow: GPT-5.5/Opus subagent delegation policy + tracked Playwright e2e suite

### DIFF
--- a/.claude/skills/ui-validate/SKILL.md
+++ b/.claude/skills/ui-validate/SKILL.md
@@ -53,10 +53,12 @@ Launch Chrome/Chromium headless with a DISPOSABLE profile under /tmp
 
 TASK: <what to validate — pages, interactions, expected behavior>
 
-Reuse or extend the existing scripts in artifacts/*.mjs if present; otherwise
-write a repeatable script there. Save screenshots to artifacts/screenshots/
-and JSON reports to artifacts/screenshots/<name>-report.json. Capture console
-errors, page crashes, and element counts at each checkpoint.
+Reuse or extend the tracked scripts in e2e/*.mjs (see e2e/README.md for env
+vars); add new repeatable scripts there. Screenshots and JSON reports go to
+artifacts/screenshots/ (gitignored). Capture console errors, page crashes,
+and element counts at each checkpoint. The app places joints from tracked
+mousemove, not click coords — hover to the target before the finalizing
+click, and prefer the Edit panel's HTML controls over the SVG context menu.
 
 Then LOOK at the screenshots yourself and describe what is visible.
 Report back ONLY a compact summary: PASS/FAIL per case, console error count,
@@ -66,15 +68,16 @@ Do not paste raw logs or DOM dumps.
 
 ## Existing test scripts (reuse before writing new ones)
 
-Kept untracked in `artifacts/` of the user's checkout:
+Tracked in `e2e/` — see `e2e/README.md` for env overrides (`PMKS_URL`,
+`RUN_PREFIX`, `PMKS_PLAYWRIGHT_DIR`, `PMKS_CHROME`, `PMKS_HEADED`):
 
-- `artifacts/pmks-playwright-test.mjs` — broad page/panel coverage
-- `artifacts/pmks-deep-interaction-test.mjs` — deep grid interactions (drag joints, right-click links, templates)
-- `artifacts/pmks-focused-interactions.mjs` — focused workflows; run as
-  `PMKS_URL=http://127.0.0.1:4200/ RUN_PREFIX=focused node artifacts/pmks-focused-interactions.mjs`
+- `e2e/full-tour.mjs` — broad tour: panels, templates, settings, share URL, mobile viewport
+- `e2e/deep-interactions.mjs` — deep grid interactions (drag joints, right-click links, templates)
+- `e2e/focused-interactions.mjs` — focused workflows; run as
+  `RUN_PREFIX=focused node e2e/focused-interactions.mjs`
 
-Outputs land in `artifacts/screenshots/` (PNGs + `*-report.json`). If the scripts
-are absent (fresh clone), tell GPT-5.5 to generate them from the template above.
+Scripts run headless by default with disposable `/tmp` Chrome profiles. Outputs
+land in `artifacts/screenshots/` (PNGs + `*-report.json`), which is gitignored.
 
 ## Interpreting results
 

--- a/.claude/skills/ui-validate/SKILL.md
+++ b/.claude/skills/ui-validate/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: ui-validate
+description: Delegate ALL UI validation, browser automation, screenshots, smoke tests, visual verification, and computer-use tasks to GPT-5.5 via the Codex CLI. Use whenever a change needs visual or behavioral verification in the running app, or the user mentions UI validation, browser testing, screenshots, end-to-end checks, or computer use. Do NOT use claude-in-chrome (mcp__claude-in-chrome__*) tools for this repo.
+---
+
+# UI validation via GPT-5.5 (Codex CLI subagent)
+
+All browser / computer-use work in this repo is delegated to GPT-5.5 running as a
+subagent through the Codex CLI. GPT-5.5 drives Playwright itself, looks at its own
+screenshots, and reports back a compact summary — the heavy tokens (DOM dumps,
+screenshots, logs) stay in Codex's context, not this session's.
+
+**Never** use the claude-in-chrome tools (`mcp__claude-in-chrome__*`) for tasks in
+this repo; they attach to the user's real browser session and flood this context
+with page content.
+
+## Preconditions (check before delegating)
+
+1. **Dev server** — `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:4200/`
+   must return `200`. If not, run `npm start` in the background and wait for the
+   compile to finish before delegating.
+2. **Playwright** — preinstalled at `/tmp/pmks-playwright`. If
+   `/tmp/pmks-playwright/node_modules/playwright` is missing:
+   `mkdir -p /tmp/pmks-playwright && cd /tmp/pmks-playwright && npm i playwright && npx playwright install chromium`
+
+## Invocation
+
+```bash
+codex exec -m gpt-5.5 --sandbox workspace-write \
+  -c sandbox_workspace_write.network_access=true \
+  "<TASK PROMPT>" 2>&1 | tail -30
+```
+
+- Run from the repo root with a generous timeout (10 min).
+- Keep Codex's sandbox ON: do **not** pass `--full-auto` or
+  `--dangerously-bypass-approvals-and-sandbox`. The single config override above
+  only enables (localhost) network inside the sandbox so Playwright can reach the
+  dev server.
+- Read only the tail of the output — GPT-5.5's compact report is printed last.
+- For long test suites, run the Bash call with `run_in_background: true` and
+  collect the report when it finishes.
+
+## Task prompt template
+
+Always include the standing rules so GPT-5.5 behaves consistently:
+
+```
+You are a UI validation subagent for the PMKS+ Angular app.
+Dev server: http://127.0.0.1:4200/. Playwright is preinstalled at
+/tmp/pmks-playwright (use NODE_PATH=/tmp/pmks-playwright/node_modules).
+Launch Chrome/Chromium headless with a DISPOSABLE profile under /tmp
+(e.g. /tmp/pmks-<case>-<timestamp>); never attach to the user's real browser.
+
+TASK: <what to validate — pages, interactions, expected behavior>
+
+Reuse or extend the existing scripts in artifacts/*.mjs if present; otherwise
+write a repeatable script there. Save screenshots to artifacts/screenshots/
+and JSON reports to artifacts/screenshots/<name>-report.json. Capture console
+errors, page crashes, and element counts at each checkpoint.
+
+Then LOOK at the screenshots yourself and describe what is visible.
+Report back ONLY a compact summary: PASS/FAIL per case, console error count,
+key element counts, and 2-3 sentences describing what the screenshots show.
+Do not paste raw logs or DOM dumps.
+```
+
+## Existing test scripts (reuse before writing new ones)
+
+Kept untracked in `artifacts/` of the user's checkout:
+
+- `artifacts/pmks-playwright-test.mjs` — broad page/panel coverage
+- `artifacts/pmks-deep-interaction-test.mjs` — deep grid interactions (drag joints, right-click links, templates)
+- `artifacts/pmks-focused-interactions.mjs` — focused workflows; run as
+  `PMKS_URL=http://127.0.0.1:4200/ RUN_PREFIX=focused node artifacts/pmks-focused-interactions.mjs`
+
+Outputs land in `artifacts/screenshots/` (PNGs + `*-report.json`). If the scripts
+are absent (fresh clone), tell GPT-5.5 to generate them from the template above.
+
+## Interpreting results
+
+- Trust GPT-5.5's PASS/FAIL and description; only open the PNGs/JSON yourself if
+  its report is ambiguous or contradicts expectations.
+- If Codex reports it could not launch a browser or reach the server, re-check the
+  preconditions rather than retrying the same command.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ Thumbs.db
 
 # Local Netlify folder
 .netlify
+
+# Claude Code local state (skills are tracked)
+.claude/settings.local.json
+.claude/worktrees/
+
+# UI-validation subagent outputs (see SKILLS.md)
+artifacts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ the primary context. See `SKILLS.md` for the routing policy and prompt template.
 
 Tests are Vitest but written in Jasmine style (globals via `vitest/globals`). `tsconfig.spec.json` deliberately includes `src/app/app.module.ts` — without it, NgModule-declared components lose their template scope under the per-file test compile and fail with NG8001. Vitest errors on spec files containing no tests.
 
+Unit specs stay co-located in `src/**/*.spec.ts`; browser-driven E2E tests are Playwright scripts in `e2e/*.mjs` (run by the GPT-5.5 subagent — see below), with outputs in gitignored `artifacts/`. Details in `e2e/README.md`.
+
 ## Deployment / branch rules
 
 **Never push directly to `main`** — commits to `main` auto-deploy to production (app.pmksplus.com) and a GitHub Action bumps the package version on every push to `main`. Work in branches/forks and open PRs. Every non-main branch auto-publishes to `https://[BRANCHNAME]--pmks.netlify.app`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,22 @@ Requires Node ≥22.22 (or 24.x). The esbuild `application` builder is used; `ou
 
 There is no lint target (`tslint.json` is vestigial). Formatting follows `.prettierrc`: 100-char width, single quotes, 2-space indent.
 
+## UI validation / computer use → GPT-5.5 via Codex CLI
+
+**Route ALL computer-use tasks (UI validation, browser automation, screenshots, visual
+verification, end-to-end interaction testing) to GPT-5.5 through the Codex CLI.** Do not use
+claude-in-chrome (`mcp__claude-in-chrome__*`) tools in this repo, and do not drive a browser
+yourself. Delegate via the `ui-validate` skill (`.claude/skills/ui-validate/SKILL.md`):
+
+```bash
+codex exec -m gpt-5.5 --sandbox workspace-write \
+  -c sandbox_workspace_write.network_access=true "<task prompt>"
+```
+
+GPT-5.5 runs Playwright with disposable Chrome profiles under `/tmp`, inspects its own
+screenshots, and reports back a compact PASS/FAIL summary — keeping heavy browser output out of
+the primary context. See `SKILLS.md` for the routing policy and prompt template.
+
 Tests are Vitest but written in Jasmine style (globals via `vitest/globals`). `tsconfig.spec.json` deliberately includes `src/app/app.module.ts` — without it, NgModule-declared components lose their template scope under the per-file test compile and fail with NG8001. Vitest errors on spec files containing no tests.
 
 ## Deployment / branch rules

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -27,6 +27,20 @@ Rationale:
 - Repeatable test scripts are tracked in `e2e/` (see `e2e/README.md`); their
   screenshots and JSON reports go to `artifacts/` (gitignored, output-only).
 
+## Delegation policy: save primary-model tokens
+
+Beyond computer use, prefer delegating scouting and mechanical work to cheaper
+subagents and keep the primary (most expensive) model for judgment —
+architecture, tricky debugging, review, and synthesizing reports:
+
+- **Codebase scouting / broad search** — Claude Code `Agent` tool with
+  `subagent_type: Explore` and `model: opus` (Opus 4.8).
+- **Mechanical multi-step tasks** (bulk edits, test-suite runs, log trawls) —
+  `Agent` tool `general-purpose` with `model: opus`, or GPT-5.5 via
+  `codex exec -m gpt-5.5 --sandbox workspace-write -c sandbox_workspace_write.network_access=true "<task>"`.
+- Subagents must report back **compact summaries** (findings, file:line refs,
+  PASS/FAIL), never raw grep/log/DOM output.
+
 ## Test layout
 
 - **Unit / solver tests** — Vitest, co-located in `src/**/*.spec.ts`

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,39 @@
+# SKILLS.md
+
+Project skills for AI coding agents working in this repo. Skills live in
+`.claude/skills/<name>/SKILL.md` and are auto-discovered by Claude Code.
+
+## Routing policy: computer use → GPT-5.5 via Codex CLI
+
+**All computer-use tasks — UI validation, browser automation, screenshots,
+visual/behavioral verification, end-to-end interaction testing — are routed to
+GPT-5.5 through the Codex CLI.** Claude (or any other primary agent) must not
+drive the browser itself and must not use claude-in-chrome
+(`mcp__claude-in-chrome__*`) tools in this repo. Instead, delegate to GPT-5.5 as
+a subagent and consume its compact report:
+
+```bash
+codex exec -m gpt-5.5 --sandbox workspace-write \
+  -c sandbox_workspace_write.network_access=true \
+  "<task prompt>"
+```
+
+Rationale:
+
+- GPT-5.5 runs Playwright with disposable Chrome profiles under `/tmp`, never
+  touching the user's real browser session.
+- It inspects its own screenshots and DOM dumps, so the heavy tokens stay in the
+  subagent; only a short PASS/FAIL summary returns to the primary context.
+- Test scripts and outputs accumulate in `artifacts/` (untracked), making runs
+  repeatable.
+
+## Skills
+
+### `ui-validate` — `.claude/skills/ui-validate/SKILL.md`
+
+Delegates any UI validation or computer-use task to GPT-5.5 via `codex exec`.
+Covers preconditions (dev server on :4200, Playwright at `/tmp/pmks-playwright`),
+the exact invocation, the task-prompt template with standing rules, and the
+existing reusable test scripts in `artifacts/`. Use it whenever a change needs
+to be verified in the running app or the user asks for UI validation, browser
+testing, or screenshots.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -24,8 +24,17 @@ Rationale:
   touching the user's real browser session.
 - It inspects its own screenshots and DOM dumps, so the heavy tokens stay in the
   subagent; only a short PASS/FAIL summary returns to the primary context.
-- Test scripts and outputs accumulate in `artifacts/` (untracked), making runs
-  repeatable.
+- Repeatable test scripts are tracked in `e2e/` (see `e2e/README.md`); their
+  screenshots and JSON reports go to `artifacts/` (gitignored, output-only).
+
+## Test layout
+
+- **Unit / solver tests** — Vitest, co-located in `src/**/*.spec.ts`
+  (`npm test -- --watch=false`); `src/app/app.component.spec.ts` is the
+  MATLAB-verified solver regression suite.
+- **E2E / UI tests** — Playwright scripts in `e2e/*.mjs`, run headless via plain
+  Node by the GPT-5.5 subagent (Playwright lives in `/tmp/pmks-playwright`, not
+  in devDependencies). Details in `e2e/README.md`.
 
 ## Skills
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,49 @@
+# PMKS+ tests
+
+Two layers, organized by what they exercise:
+
+| Layer | Where | Runner | What it covers |
+| --- | --- | --- | --- |
+| Unit / solver | `src/**/*.spec.ts` (co-located with source, Angular convention) | Vitest — `npm test -- --watch=false` | Components; `src/app/app.component.spec.ts` is the MATLAB-verified solver regression suite |
+| E2E / UI | `e2e/*.mjs` (this folder) | Playwright via plain Node | Real-browser interaction: grid clicks/drags, context menus, panels, animation, mobile viewport |
+
+Unit specs stay in `src/` because `tsconfig.spec.json` discovers them via
+`src/**/*.spec.ts` and Angular component specs resolve templates relative to
+their source. Everything browser-driven lives here.
+
+## E2E scripts
+
+- `full-tour.mjs` — broad tour: panels, templates, settings, share URL, help, mobile viewport
+- `deep-interactions.mjs` — deep grid interaction: add links, drag joints, right-click menus
+- `focused-interactions.mjs` — focused workflows (four-bar build, animation, analysis)
+
+## Running
+
+Prerequisites: dev server on http://127.0.0.1:4200/ (`npm start`) and a
+Playwright install at `/tmp/pmks-playwright`
+(`mkdir -p /tmp/pmks-playwright && cd /tmp/pmks-playwright && npm i playwright`).
+Playwright is deliberately **not** a devDependency — it would bloat Netlify
+deploy installs, and these scripts are normally run by a GPT-5.5 subagent
+(see `SKILLS.md` and `.claude/skills/ui-validate/SKILL.md`), not CI.
+
+```bash
+node e2e/focused-interactions.mjs
+```
+
+Environment overrides:
+
+- `PMKS_URL` — app URL (default `http://127.0.0.1:4200/`)
+- `RUN_PREFIX` — prefix for screenshot/report filenames
+- `PMKS_PLAYWRIGHT_DIR` — Playwright install dir (default `/tmp/pmks-playwright`)
+- `PMKS_CHROME` — Chrome executable (default `/Applications/Google Chrome.app/...`)
+- `PMKS_HEADED=1` — show the browser window (headless by default)
+
+Each run launches Chrome with a disposable profile under `/tmp` (never your
+real browser session) and writes screenshots plus a `*-report.json` (console
+errors, crashes, element counts per checkpoint) to `artifacts/screenshots/`,
+which is gitignored — outputs are throwaway, scripts are tracked.
+
+Interaction gotcha baked into these scripts: the app places joints from tracked
+`mousemove`, not click coordinates — always hover/move to the target before the
+finalizing click, and prefer the Edit panel's HTML controls over the SVG
+context menu (its hitboxes drift at some viewports).

--- a/e2e/deep-interactions.mjs
+++ b/e2e/deep-interactions.mjs
@@ -1,0 +1,332 @@
+const { chromium } = await import((process.env.PMKS_PLAYWRIGHT_DIR ?? '/tmp/pmks-playwright') + '/node_modules/playwright/index.mjs');
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const screenshotDir = path.resolve('artifacts/screenshots');
+await fs.mkdir(screenshotDir, { recursive: true });
+
+const baseUrl = process.env.PMKS_URL || 'http://127.0.0.1:4200/';
+const runPrefix = process.env.RUN_PREFIX || 'deep';
+const chromePath = process.env.PMKS_CHROME ?? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const userDataDir = `/tmp/pmks-deep-profile-${Date.now()}`;
+
+const mechanisms = {
+  fourBar:
+    '0P.TY.K,0.101.MA,A,0mv,0VU,0.GB,B,0e_,E6,0.GC,C,l1,WW,0.KD,D,qD,0Pk,0..YRAB,AB,Fe,Fe,0ix,08i,c5cae9,A,B,,.YRBC,BC,Fe,Fe,32,NJ,303e9f,B,C,,.YRCD,CD,Fe,Fe,nd,3P,0d125a,C,D,,...JBq',
+  wattI:
+    '0P.TY.K,0.101.MA,A,0Qh,0Kn,0.GB,B,0e1,9i,0.GC,C,bT,LF,0.GD,D,0G5,tZ,0.GE,E,V5,1_z,0.GF,F,1mM,1Gv,0.KG,G,1rt,0ey,0..YRAB,AB,Fe,Fe,0XM,05Z,c5cae9,A,B,,.YRBCD,BCD,Fe,Fe,06D,Sr,303e9f,B,C,D,,.YRDE,DE,Fe,Fe,7W,1RG,0d125a,D,E,,.YREF,EF,Fe,Fe,17j,1dx,B2DFDB,E,F,,.YRFCG,FCG,Fe,Fe,1PE,KQ,26A69A,F,C,G,,...JAp',
+  wattII:
+    '0P.TY.K,0.101.MA,A,0Vf,0Vd,0.GB,B,0mZ,08A,0.GC,C,06Y,LC,0.GD,D,1MR,J2,0.KE,E,rw,0j2,0.GF,F,2ic,ID,0.KG,G,2lk,0Zt,0..YRAB,AB,Fe,Fe,0e6,0Ju,c5cae9,A,B,,.YRBC,BC,Fe,Fe,0RY,6X,303e9f,B,C,,.YRCDE,CDE,Fe,Fe,ic,01d,0d125a,C,D,E,,.YRDF,DF,Fe,Fe,21X,Id,B2DFDB,D,F,,.YRFG,FG,Fe,Fe,2kA,08r,26A69A,F,G,,...JBm',
+  stephensonIII:
+    '0P.TY.K,0.101.MA,A,0YP,0ce,0.GB,B,0cQ,0FI,0.GC,C,lC,1-,0.KD,D,ow,0U1,0.GE,E,033,D-,0.GF,F,Dc,nj,0.KG,G,1M0,GJ,0..YRAB,AB,Fe,Fe,0aP,0Qz,c5cae9,A,B,,.YRBCE,BCE,Fe,Fe,1w,E,303e9f,B,C,E,,.YRCD,CD,Fe,Fe,n3,0E1,0d125a,C,D,,.YREF,EF,Fe,Fe,5H,Vs,B2DFDB,E,F,,.YRFG,FG,Fe,Fe,np,X0,26A69A,F,G,,...JBe',
+  sliderCrank:
+    '0P.TY.K,0.101.MA,A,0mA,0c,0.GB,B,0Yt,bK,0.GC,C,il,H-,0.LD,D,il,H-,0..YRAB,AB,Fe,Fe,0fW,IN,c5cae9,A,B,,.YRBC,BC,Fe,Fe,4y,Rf,303e9f,B,C,,.YPCD,CD,Fe,0,0,0,,C,D,,...JAe',
+  force:
+    '0v.cc.K,0.101.Ma,a,0,0,0.Gb,b,fk,1Jz,0.Gc,c,2o7,1sD,0.Kd,d,3Qm,0,0..YRab,Crank,Fe,Fe,Kt,f-,c5cae9,a,b,,.YRbc,Coupler,Fe,Fe,1jw,1b5,303e9f,b,c,,.YRcd,Follower,Fe,Fe,36S,x7,c5cae9,c,d,,..2F1,bc,F1,1AR,1SH,1AR,JF,Fe.R',
+};
+
+const issues = [];
+const events = [];
+const snapshots = [];
+
+function issue(title, details = {}) {
+  issues.push({ title, ...details });
+}
+
+async function shot(page, name) {
+  const file = path.join(screenshotDir, `${runPrefix}-${name}`);
+  await page.screenshot({ path: file, fullPage: true });
+  return file;
+}
+
+async function dismissIntro(page) {
+  if (await page.locator('.introjs-tooltip, .introjs-overlay').first().isVisible().catch(() => false)) {
+    await page.locator('.introjs-skipbutton').first().click({ force: true }).catch(async () => page.keyboard.press('Escape'));
+    await page.waitForTimeout(350);
+    events.push({ action: 'dismiss-intro' });
+  }
+}
+
+async function snapshot(page, label) {
+  return await page.evaluate((name) => {
+    const text = document.body.innerText;
+    const visible = (el) => {
+      const r = el.getBoundingClientRect();
+      const s = getComputedStyle(el);
+      return r.width > 0 && r.height > 0 && s.display !== 'none' && s.visibility !== 'hidden';
+    };
+    const rectOf = (el) => {
+      const r = el.getBoundingClientRect();
+      return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
+    };
+    return {
+      label: name,
+      url: location.href,
+      text: text.slice(0, 2500),
+      dof: (text.match(/Degrees of Freedom:\s*([^\n]+)/i) || [])[1],
+      bodyScrollWidth: document.documentElement.scrollWidth,
+      bodyClientWidth: document.documentElement.clientWidth,
+      contextMenuItems: [...document.querySelectorAll('#contextMenu #menu-item')].filter(visible).map((el) => el.innerText.trim()),
+      selectedPanelTitle: [...document.querySelectorAll('h1,h2,h3,.title,.label')].filter(visible).map((el) => el.textContent?.trim()).filter(Boolean).slice(0, 20),
+      links: [...document.querySelectorAll('#linkHolder path')].filter(visible).map((el) => ({ id: el.id, cls: String(el.getAttribute('class') || ''), rect: rectOf(el) })).slice(0, 30),
+      joints: [...document.querySelectorAll('#jointHolder svg')].filter(visible).map((el) => ({ rect: rectOf(el), html: el.outerHTML.slice(0, 160) })).slice(0, 30),
+      forces: [...document.querySelectorAll('#forcesHolder')].filter(visible).map((el) => ({ rect: rectOf(el), id: el.querySelector('[id]')?.id || '' })).slice(0, 10),
+      tooltips: [...document.querySelectorAll('.mat-mdc-tooltip, .mdc-tooltip, [role="tooltip"]')].filter(visible).map((el) => el.textContent?.trim()),
+      modals: [...document.querySelectorAll('.mat-mdc-dialog-container')].filter(visible).map((el) => el.innerText.slice(0, 500)),
+    };
+  }, label);
+}
+
+async function checkCommon(page, label) {
+  const s = await snapshot(page, label);
+  if (/NaN/.test(s.text)) issue('Visible NaN in UI', { severity: 'medium', label, excerpt: s.text.match(/.{0,30}NaN.{0,60}/)?.[0] });
+  if (s.bodyScrollWidth > s.bodyClientWidth + 2) issue('Horizontal overflow', { severity: s.bodyClientWidth < 600 ? 'high' : 'medium', label, scrollWidth: s.bodyScrollWidth, clientWidth: s.bodyClientWidth });
+  return s;
+}
+
+async function safe(name, fn) {
+  try {
+    events.push({ action: 'step-start', name });
+    const result = await fn();
+    events.push({ action: 'step-ok', name });
+    await flushReport();
+    return result;
+  } catch (error) {
+    issue(`Step failed: ${name}`, { severity: 'high', error: error?.stack || error?.message || String(error) });
+    events.push({ action: 'step-failed', name });
+    await flushReport().catch(() => {});
+  }
+}
+
+async function flushReport() {
+  await fs.writeFile(path.join(screenshotDir, `${runPrefix}-workflow-report.json`), JSON.stringify({ baseUrl, userDataDir, issues, events, snapshots }, null, 2));
+}
+
+async function canvasBox(page) {
+  const box = await page.locator('#canvas').boundingBox();
+  if (!box) throw new Error('No #canvas bounding box');
+  return box;
+}
+
+async function rightClickAt(page, x, y, label) {
+  await page.mouse.click(x, y, { button: 'right' });
+  await page.waitForTimeout(350);
+  const items = await page.locator('#contextMenu #menu-item').evaluateAll((els) => els.filter((el) => {
+    const r = el.getBoundingClientRect();
+    return r.width && r.height;
+  }).map((el) => el.innerText.trim()));
+  events.push({ action: 'right-click', label, x: Math.round(x), y: Math.round(y), items });
+  return items;
+}
+
+async function loadMechanism(page, name, query) {
+  await page.goto(`${baseUrl}?${query}`, { waitUntil: 'networkidle', timeout: 60000 });
+  await page.waitForTimeout(900);
+  await dismissIntro(page);
+  await page.waitForTimeout(500);
+  await shot(page, `mechanism-${name}-loaded.png`);
+  return await checkCommon(page, `mechanism ${name}`);
+}
+
+async function firstJointCenter(page, index = 0) {
+  const joints = await snapshot(page, 'joint-center');
+  const j = joints.joints[index] || joints.joints[0];
+  if (!j) throw new Error('No visible joints');
+  return { x: j.rect.x + j.rect.w / 2, y: j.rect.y + j.rect.h / 2, rect: j.rect };
+}
+
+async function firstLinkCenter(page, index = 0) {
+  const links = await snapshot(page, 'link-center');
+  const l = links.links.find((link) => link.rect.w > 15 && link.rect.h > 15) || links.links[index];
+  if (!l) throw new Error('No visible links');
+  return { x: l.rect.x + l.rect.w / 2, y: l.rect.y + l.rect.h / 2, rect: l.rect, id: l.id };
+}
+
+const context = await chromium.launchPersistentContext(userDataDir, {
+  executablePath: chromePath,
+  headless: !process.env.PMKS_HEADED,
+  viewport: { width: 1440, height: 1000 },
+  deviceScaleFactor: 1,
+  acceptDownloads: true,
+  args: ['--no-first-run', '--no-default-browser-check', '--disable-crash-reporter'],
+});
+
+const page = context.pages()[0] || await context.newPage();
+page.setDefaultTimeout(8000);
+
+page.on('console', (msg) => {
+  const text = msg.text();
+  events.push({ action: 'console', type: msg.type(), text });
+  if (['error', 'warning'].includes(msg.type()) && !/Angular is running in development mode|favicon|google-analytics/i.test(text)) {
+    issue(`Console ${msg.type()}: ${text.slice(0, 180)}`, { severity: msg.type() === 'error' ? 'medium' : 'low' });
+  }
+});
+page.on('pageerror', (error) => issue('Uncaught page error', { severity: 'high', error: error.stack || error.message }));
+page.on('requestfailed', (request) => {
+  if (!/google-analytics|google\.com\/g\/collect/.test(request.url())) {
+    issue(`Request failed: ${request.url()}`, { severity: 'medium', failure: request.failure()?.errorText });
+  }
+});
+
+await safe('empty grid right-click creates link', async () => {
+  await page.goto(baseUrl, { waitUntil: 'networkidle', timeout: 60000 });
+  await dismissIntro(page);
+  const box = await canvasBox(page);
+  const x1 = box.x + box.width * 0.45;
+  const y1 = box.y + box.height * 0.48;
+  const items = await rightClickAt(page, x1, y1, 'empty grid');
+  if (!items.includes('Add Link')) issue('Grid context menu missing Add Link', { severity: 'high', items });
+  await page.locator('#contextMenu #menu-item', { hasText: 'Add Link' }).click();
+  await page.waitForTimeout(300);
+  await page.mouse.move(x1 + 170, y1 + 70);
+  await page.waitForTimeout(250);
+  await shot(page, 'grid-add-link-preview.png');
+  await page.mouse.click(x1 + 170, y1 + 70);
+  await page.waitForTimeout(800);
+  const s = await checkCommon(page, 'after grid add link');
+  snapshots.push(s);
+  if (s.links.length < 1 || s.joints.length < 2) issue('Add Link did not create a visible link with two joints', { severity: 'high', links: s.links.length, joints: s.joints.length });
+  await shot(page, 'grid-add-link-created.png');
+});
+
+await safe('joint right-click, hover tooltip, drag joint', async () => {
+  const before = await firstJointCenter(page, 1);
+  await page.mouse.move(before.x, before.y);
+  await page.waitForTimeout(1200);
+  await shot(page, 'joint-hover.png');
+  const hover = await snapshot(page, 'joint hover');
+  snapshots.push(hover);
+  const items = await rightClickAt(page, before.x, before.y, 'created joint');
+  for (const expected of ['Delete Joint', 'Attach Link', 'Add Ground', 'Add Slider']) {
+    if (!items.includes(expected)) issue(`Joint context menu missing ${expected}`, { severity: 'medium', items });
+  }
+  await page.keyboard.press('Escape');
+  await page.mouse.move(before.x, before.y);
+  await page.mouse.down();
+  await page.mouse.move(before.x + 140, before.y + 55, { steps: 12 });
+  await page.waitForTimeout(250);
+  await shot(page, 'joint-drag-mid.png');
+  await page.mouse.up();
+  await page.waitForTimeout(700);
+  const after = await firstJointCenter(page, 1);
+  events.push({ action: 'drag-joint', before, after });
+  if (Math.abs(after.x - before.x) < 20 && Math.abs(after.y - before.y) < 20) issue('Joint drag did not visibly move selected joint', { severity: 'high', before, after });
+  await shot(page, 'joint-drag-after.png');
+});
+
+await safe('load and stress built-in mechanism types', async () => {
+  for (const [name, query] of Object.entries(mechanisms)) {
+    const s = await loadMechanism(page, name, query);
+    snapshots.push(s);
+    if (!s.links.length || !s.joints.length) issue(`Mechanism ${name} loaded with no visible links/joints`, { severity: 'high' });
+    const link = await firstLinkCenter(page).catch(() => null);
+    const joint = await firstJointCenter(page, Math.min(2, Math.max(0, s.joints.length - 1))).catch(() => null);
+    if (link) {
+      await page.mouse.move(link.x, link.y);
+      await page.waitForTimeout(300);
+      const linkItems = await rightClickAt(page, link.x, link.y, `${name} link ${link.id}`);
+      if (!linkItems.includes('Delete Link') || !linkItems.includes('Attach Link')) issue(`Link context menu incomplete for ${name}`, { severity: 'medium', items: linkItems });
+      await page.keyboard.press('Escape');
+    }
+    if (joint) {
+      await page.mouse.move(joint.x, joint.y);
+      await page.mouse.down();
+      await page.mouse.move(joint.x + 35, joint.y - 25, { steps: 8 });
+      await page.mouse.up();
+      await page.waitForTimeout(400);
+      await shot(page, `mechanism-${name}-after-joint-drag.png`);
+      await checkCommon(page, `${name} after joint drag`);
+    }
+  }
+});
+
+await safe('force mechanism force context and force drag', async () => {
+  await loadMechanism(page, 'force-repeat', mechanisms.force);
+  const s = await snapshot(page, 'force loaded');
+  if (!s.forces.length) {
+    issue('Force mechanism did not show a force element', { severity: 'high' });
+    return;
+  }
+  const f = s.forces[0];
+  const x = f.rect.x + f.rect.w / 2;
+  const y = f.rect.y + f.rect.h / 2;
+  const items = await rightClickAt(page, x, y, 'force');
+  for (const expected of ['Delete Force', 'Make Force Local', 'Switch Force Direction']) {
+    if (!items.includes(expected)) issue(`Force context menu missing ${expected}`, { severity: 'medium', items });
+  }
+  await page.keyboard.press('Escape');
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x + 80, y - 50, { steps: 10 });
+  await page.mouse.up();
+  await page.waitForTimeout(500);
+  await shot(page, 'force-drag-after.png');
+  await checkCommon(page, 'force drag after');
+});
+
+await safe('pan, wheel zoom, buttons, and animation slider', async () => {
+  await loadMechanism(page, 'sliderCrank-panzoom', mechanisms.sliderCrank);
+  const before = await snapshot(page, 'before pan zoom');
+  const box = await canvasBox(page);
+  await page.mouse.move(box.x + box.width * 0.65, box.y + box.height * 0.45);
+  await page.mouse.down({ button: 'middle' }).catch(async () => page.mouse.down());
+  await page.mouse.move(box.x + box.width * 0.72, box.y + box.height * 0.55, { steps: 8 });
+  await page.mouse.up();
+  await page.mouse.wheel(0, -450);
+  await page.waitForTimeout(500);
+  await shot(page, 'pan-wheel-zoom.png');
+  await page.locator('button:has-text("zoom_in")').click().catch(() => {});
+  await page.locator('button:has-text("zoom_out")').click().catch(() => {});
+  const slider = page.locator('#slider');
+  if (await slider.isVisible().catch(() => false)) {
+    const r = await slider.boundingBox();
+    await page.mouse.move(r.x + r.width * 0.1, r.y + r.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(r.x + r.width * 0.75, r.y + r.height / 2, { steps: 10 });
+    await page.mouse.up();
+  } else {
+    issue('Animation slider not visible', { severity: 'medium' });
+  }
+  await page.locator('button:has-text("play_arrow")').click().catch(() => issue('Play button click failed', { severity: 'medium' }));
+  await page.waitForTimeout(900);
+  await shot(page, 'animation-slider-after.png');
+  const after = await checkCommon(page, 'after pan zoom animation');
+  snapshots.push(before, after);
+});
+
+await safe('template hover and new-tab behavior', async () => {
+  await page.goto(baseUrl, { waitUntil: 'networkidle', timeout: 60000 });
+  await dismissIntro(page);
+  await page.locator('button:has-text("Templates")').click();
+  await page.waitForTimeout(500);
+  const card = page.locator('.mat-mdc-dialog-container panel-section').first();
+  await card.hover();
+  await page.waitForTimeout(700);
+  await shot(page, 'template-card-hover.png');
+  const popup = context.waitForEvent('page', { timeout: 3000 }).catch(() => null);
+  await card.click();
+  const newPage = await popup;
+  if (!newPage) {
+    issue('Template card click did not open a new page/tab', { severity: 'medium' });
+  } else {
+    await newPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+    await newPage.waitForTimeout(1000);
+    await dismissIntro(newPage);
+    await shot(newPage, 'template-new-tab-loaded.png');
+    const s = await checkCommon(newPage, 'template new tab');
+    snapshots.push(s);
+    if (!s.links.length) issue('Template new tab loaded without visible mechanism links', { severity: 'high', url: newPage.url() });
+  }
+});
+
+await safe('mobile deep layout', async () => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.waitForTimeout(500);
+  await shot(page, 'mobile-deep.png');
+  snapshots.push(await checkCommon(page, 'mobile deep'));
+});
+
+await flushReport();
+await context.close().catch(() => {});
+
+console.log(JSON.stringify({ baseUrl, userDataDir, issueCount: issues.length, issues, screenshots: (await fs.readdir(screenshotDir)).filter((f) => f.startsWith(`${runPrefix}-`)) }, null, 2));

--- a/e2e/focused-interactions.mjs
+++ b/e2e/focused-interactions.mjs
@@ -1,0 +1,228 @@
+const { chromium } = await import((process.env.PMKS_PLAYWRIGHT_DIR ?? '/tmp/pmks-playwright') + '/node_modules/playwright/index.mjs');
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const screenshotDir = path.resolve('artifacts/screenshots');
+await fs.mkdir(screenshotDir, { recursive: true });
+
+const baseUrl = process.env.PMKS_URL || 'http://127.0.0.1:4200/';
+const runPrefix = process.env.RUN_PREFIX || 'focused';
+const chromePath = process.env.PMKS_CHROME ?? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+const mechanisms = {
+  fourBar:
+    '0P.TY.K,0.101.MA,A,0mv,0VU,0.GB,B,0e_,E6,0.GC,C,l1,WW,0.KD,D,qD,0Pk,0..YRAB,AB,Fe,Fe,0ix,08i,c5cae9,A,B,,.YRBC,BC,Fe,Fe,32,NJ,303e9f,B,C,,.YRCD,CD,Fe,Fe,nd,3P,0d125a,C,D,,...JBq',
+  sliderCrank:
+    '0P.TY.K,0.101.MA,A,0mA,0c,0.GB,B,0Yt,bK,0.GC,C,il,H-,0.LD,D,il,H-,0..YRAB,AB,Fe,Fe,0fW,IN,c5cae9,A,B,,.YRBC,BC,Fe,Fe,4y,Rf,303e9f,B,C,,.YPCD,CD,Fe,0,0,0,,C,D,,...JAe',
+  force:
+    '0v.cc.K,0.101.Ma,a,0,0,0.Gb,b,fk,1Jz,0.Gc,c,2o7,1sD,0.Kd,d,3Qm,0,0..YRab,Crank,Fe,Fe,Kt,f-,c5cae9,a,b,,.YRbc,Coupler,Fe,Fe,1jw,1b5,303e9f,b,c,,.YRcd,Follower,Fe,Fe,36S,x7,c5cae9,c,d,,..2F1,bc,F1,1AR,1SH,1AR,JF,Fe.R',
+};
+
+const issues = [];
+const events = [];
+const snapshots = [];
+
+function issue(title, details = {}) {
+  issues.push({ title, ...details });
+}
+
+async function launch(label) {
+  const context = await chromium.launchPersistentContext(`/tmp/pmks-focused-${label}-${Date.now()}`, {
+    executablePath: chromePath,
+    headless: !process.env.PMKS_HEADED,
+    viewport: { width: 1440, height: 1000 },
+    deviceScaleFactor: 1,
+    acceptDownloads: true,
+    args: ['--no-first-run', '--no-default-browser-check', '--disable-crash-reporter'],
+  });
+  const page = context.pages()[0] || await context.newPage();
+  page.setDefaultTimeout(8000);
+  page.on('console', (msg) => {
+    const text = msg.text();
+    events.push({ action: 'console', label, type: msg.type(), text });
+    if (['error', 'warning'].includes(msg.type()) && !/Angular is running in development mode|favicon|google-analytics/i.test(text)) {
+      issue(`Console ${msg.type()}: ${text.slice(0, 180)}`, { severity: msg.type() === 'error' ? 'medium' : 'low', label });
+    }
+  });
+  page.on('pageerror', (error) => issue('Uncaught page error', { severity: 'high', label, error: error.stack || error.message }));
+  return { context, page };
+}
+
+async function shot(page, name) {
+  const file = path.join(screenshotDir, `${runPrefix}-${name}`);
+  await page.screenshot({ path: file, fullPage: true });
+}
+
+async function dismissIntro(page) {
+  if (await page.locator('.introjs-tooltip, .introjs-overlay').first().isVisible().catch(() => false)) {
+    await page.locator('.introjs-skipbutton').first().click({ force: true }).catch(async () => page.keyboard.press('Escape'));
+    await page.waitForTimeout(350);
+  }
+}
+
+async function menuItems(page) {
+  return await page.locator('#contextMenu #menu-item').evaluateAll((els) => els.filter((el) => {
+    const r = el.getBoundingClientRect();
+    const s = getComputedStyle(el);
+    return r.width > 0 && r.height > 0 && s.visibility !== 'hidden' && s.display !== 'none';
+  }).map((el) => el.innerText.trim()));
+}
+
+async function snap(page, label) {
+  const s = await page.evaluate((snapshotLabel) => {
+    const visible = (el) => {
+      const r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    };
+    const rect = (el) => {
+      const r = el.getBoundingClientRect();
+      return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
+    };
+    return {
+      label: snapshotLabel,
+      url: location.href,
+      text: document.body.innerText.slice(0, 2000),
+      links: [...document.querySelectorAll('#linkHolder path')].filter(visible).map((el) => ({ id: el.id, rect: rect(el), cls: el.getAttribute('class') || '' })),
+      joints: [...document.querySelectorAll('#jointHolder svg')].filter(visible).map((el) => ({ rect: rect(el) })),
+      forces: [...document.querySelectorAll('#forcesHolder')].filter(visible).map((el) => ({ rect: rect(el), text: el.outerHTML.slice(0, 250) })),
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    };
+  }, label);
+  snapshots.push(s);
+  if (/NaN/.test(s.text)) issue('Visible NaN in UI', { severity: 'medium', label, excerpt: s.text.match(/.{0,30}NaN.{0,60}/)?.[0] });
+  if (s.scrollWidth > s.clientWidth + 2) issue('Horizontal overflow', { severity: s.clientWidth < 600 ? 'high' : 'medium', label, scrollWidth: s.scrollWidth, clientWidth: s.clientWidth });
+  return s;
+}
+
+async function runCase(name, fn) {
+  const { context, page } = await launch(name);
+  try {
+    events.push({ action: 'case-start', name });
+    await fn(page, context);
+    events.push({ action: 'case-ok', name });
+  } catch (error) {
+    issue(`Case failed: ${name}`, { severity: 'high', error: error?.stack || error?.message || String(error) });
+    events.push({ action: 'case-failed', name });
+  } finally {
+    await fs.writeFile(path.join(screenshotDir, `${runPrefix}-workflow-report.json`), JSON.stringify({ baseUrl, issues, events, snapshots }, null, 2));
+    await context.close().catch(() => {});
+  }
+}
+
+await runCase('link-context', async (page) => {
+  await page.goto(`${baseUrl}?${mechanisms.fourBar}`, { waitUntil: 'networkidle', timeout: 60000 });
+  await dismissIntro(page);
+  await shot(page, 'link-context-loaded.png');
+  const s = await snap(page, 'link context loaded');
+  if (!s.links.length) throw new Error('No link paths');
+
+  const link = page.locator('#linkHolder path').first();
+  await link.hover({ force: true });
+  await page.waitForTimeout(400);
+  await shot(page, 'link-hover.png');
+  await link.click({ button: 'right', force: true });
+  await page.waitForTimeout(400);
+  const items = await menuItems(page);
+  events.push({ action: 'element-right-click', target: 'first link path', items });
+  if (!items.includes('Delete Link') || !items.includes('Attach Link')) {
+    issue('Right-clicking a visible link path did not show link context menu', { severity: 'high', items });
+  }
+  await shot(page, 'link-context-menu.png');
+});
+
+await runCase('force-load-context-drag', async (page) => {
+  await page.goto(`${baseUrl}?${mechanisms.force}`, { waitUntil: 'networkidle', timeout: 60000 });
+  await dismissIntro(page);
+  await page.waitForTimeout(800);
+  await shot(page, 'force-loaded.png');
+  const s = await snap(page, 'force loaded');
+  if (!s.forces.length) {
+    issue('Force example loaded without visible force group', { severity: 'high' });
+    return;
+  }
+  const force = page.locator('#forcesHolder').first();
+  await force.click({ button: 'right', force: true });
+  await page.waitForTimeout(400);
+  const items = await menuItems(page);
+  events.push({ action: 'element-right-click', target: 'force group', items });
+  for (const expected of ['Delete Force', 'Make Force Local', 'Switch Force Direction']) {
+    if (!items.includes(expected)) issue(`Force context menu missing ${expected}`, { severity: 'medium', items });
+  }
+  await page.keyboard.press('Escape');
+  const box = await force.boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + 70, box.y + box.height / 2 - 45, { steps: 10 });
+  await page.mouse.up();
+  await page.waitForTimeout(500);
+  await shot(page, 'force-drag-after.png');
+  await snap(page, 'force drag after');
+});
+
+await runCase('pan-zoom-slider', async (page) => {
+  await page.goto(`${baseUrl}?${mechanisms.sliderCrank}`, { waitUntil: 'networkidle', timeout: 60000 });
+  await dismissIntro(page);
+  await page.waitForTimeout(700);
+  await shot(page, 'panzoom-loaded.png');
+  const canvas = await page.locator('#canvas').boundingBox();
+  await page.mouse.move(canvas.x + canvas.width * 0.7, canvas.y + canvas.height * 0.45);
+  await page.mouse.down();
+  await page.mouse.move(canvas.x + canvas.width * 0.78, canvas.y + canvas.height * 0.55, { steps: 12 });
+  await page.mouse.up();
+  await page.mouse.wheel(0, -500);
+  await page.waitForTimeout(500);
+  await page.locator('button:has-text("zoom_in")').click();
+  await page.locator('button:has-text("zoom_out")').click();
+  const slider = page.locator('#slider');
+  const beforeValue = await slider.inputValue().catch(() => null);
+  const r = await slider.boundingBox();
+  await page.mouse.move(r.x + r.width * 0.15, r.y + r.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(r.x + r.width * 0.82, r.y + r.height / 2, { steps: 12 });
+  await page.mouse.up();
+  await page.waitForTimeout(400);
+  const afterValue = await slider.inputValue().catch(() => null);
+  events.push({ action: 'slider-drag', beforeValue, afterValue });
+  if (beforeValue === afterValue) issue('Animation slider drag did not change slider value', { severity: 'medium', beforeValue, afterValue });
+  await page.locator('button:has-text("play_arrow")').click();
+  await page.waitForTimeout(1000);
+  await shot(page, 'panzoom-slider-after.png');
+  await snap(page, 'pan zoom slider after');
+});
+
+await runCase('template-new-tab', async (page, context) => {
+  await page.goto(baseUrl, { waitUntil: 'networkidle', timeout: 60000 });
+  await dismissIntro(page);
+  await page.locator('button:has-text("Templates")').click();
+  await page.waitForTimeout(600);
+  const card = page.locator('.mat-mdc-dialog-container panel-section').first();
+  await card.hover();
+  await page.waitForTimeout(700);
+  await shot(page, 'template-hover.png');
+  const popup = context.waitForEvent('page', { timeout: 5000 }).catch(() => null);
+  await card.click();
+  const newPage = await popup;
+  if (!newPage) {
+    issue('Template card click did not open a new page/tab', { severity: 'high' });
+    return;
+  }
+  await newPage.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+  await newPage.waitForTimeout(1000);
+  await dismissIntro(newPage);
+  await shot(newPage, 'template-new-tab.png');
+  const s = await snap(newPage, 'template new tab');
+  if (!s.links.length) issue('Template new tab has no visible links', { severity: 'high', url: newPage.url() });
+});
+
+await runCase('mobile-layout', async (page) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(`${baseUrl}?${mechanisms.sliderCrank}`, { waitUntil: 'networkidle', timeout: 60000 });
+  await dismissIntro(page);
+  await page.waitForTimeout(800);
+  await shot(page, 'mobile-slidercrank.png');
+  await snap(page, 'mobile slider crank');
+});
+
+await fs.writeFile(path.join(screenshotDir, `${runPrefix}-workflow-report.json`), JSON.stringify({ baseUrl, issues, events, snapshots }, null, 2));
+console.log(JSON.stringify({ baseUrl, issueCount: issues.length, issues, screenshots: (await fs.readdir(screenshotDir)).filter((f) => f.startsWith(`${runPrefix}-`)) }, null, 2));

--- a/e2e/full-tour.mjs
+++ b/e2e/full-tour.mjs
@@ -1,0 +1,304 @@
+const { chromium } = await import((process.env.PMKS_PLAYWRIGHT_DIR ?? '/tmp/pmks-playwright') + '/node_modules/playwright/index.mjs');
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const screenshotDir = path.resolve('artifacts/screenshots');
+await fs.mkdir(screenshotDir, { recursive: true });
+
+const chromePath = process.env.PMKS_CHROME ?? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const userDataDir = `/tmp/pmks-playwright-profile-${Date.now()}`;
+const baseUrl = process.env.PMKS_URL || 'http://127.0.0.1:4200/';
+const verificationQuery = '0P.SS.K,0.101.MA,A,0wS,0bg,0.GB,B,0gW,EE,0.GC,C,Oi,6k,0.GD,D,03m,_g,0.GE,E,1FO,1I_,0.GF,F,1-C,qM,0.KG,G,1oO,0ss,0..YRAB,AB,Fe,Fe,0oU,0Bk,c5cae9,A,B,,.YRBCD,BCD,Fe,Fe,07C,Rt,303e9f,B,C,D,,.YRDE,DE,Fe,Fe,bq,18q,0d125a,D,E,,.YREF,EF,Fe,Fe,1dI,13g,B2DFDB,E,F,,.YRFCG,FCG,Fe,Fe,1Om,1Q,26A69A,F,C,G,,...JGp';
+const runPrefix = process.env.RUN_PREFIX || 'tour';
+const issues = [];
+const events = [];
+
+function recordIssue(title, details = {}) {
+  issues.push({ title, ...details });
+}
+
+async function shot(page, name, fullPage = true) {
+  const file = path.join(screenshotDir, `${runPrefix}-${name}`);
+  await page.screenshot({ path: file, fullPage });
+  return file;
+}
+
+async function appSnapshot(page, label) {
+  return await page.evaluate((snapshotLabel) => {
+    const visible = (el) => {
+      const rect = el.getBoundingClientRect();
+      const style = getComputedStyle(el);
+      return rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+    };
+    return {
+      label: snapshotLabel,
+      title: document.title,
+      url: location.href,
+      hash: location.hash,
+      bodyText: document.body.innerText.slice(0, 3500),
+      buttons: [...document.querySelectorAll('button,[role=button]')]
+        .filter(visible)
+        .slice(0, 120)
+        .map((el, i) => ({
+          i,
+          text: el.innerText.trim(),
+          aria: el.getAttribute('aria-label'),
+          title: el.getAttribute('title'),
+          id: el.id,
+          className: String(el.className).slice(0, 180),
+          rect: (() => {
+            const r = el.getBoundingClientRect();
+            return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
+          })(),
+        })),
+      inputs: [...document.querySelectorAll('input, textarea, select')]
+        .filter(visible)
+        .slice(0, 120)
+        .map((el, i) => ({
+          i,
+          tag: el.tagName.toLowerCase(),
+          type: el.getAttribute('type'),
+          value: el.value,
+          placeholder: el.getAttribute('placeholder'),
+          aria: el.getAttribute('aria-label'),
+          id: el.id,
+          className: String(el.className).slice(0, 180),
+        })),
+      svgs: [...document.querySelectorAll('svg')].slice(0, 30).map((el, i) => {
+        const r = el.getBoundingClientRect();
+        return { i, id: el.id, className: String(el.className).slice(0, 120), rect: { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) } };
+      }),
+    };
+  }, label);
+}
+
+async function clickFirst(page, candidates, label) {
+  for (const candidate of candidates) {
+    const loc = page.locator(candidate);
+    if (await loc.count()) {
+      const first = loc.first();
+      if (await first.isVisible().catch(() => false)) {
+        await first.click({ timeout: 5000 });
+        events.push({ action: 'click', label, selector: candidate });
+        return true;
+      }
+    }
+  }
+  recordIssue(`Could not find control: ${label}`, { severity: 'test-blocker', candidates });
+  return false;
+}
+
+async function dismissIntro(page) {
+  const intro = page.locator('.introjs-tooltip, .introjs-overlay').first();
+  if (await intro.isVisible().catch(() => false)) {
+    const closeButton = page.locator('.introjs-skipbutton, .introjs-tooltipbuttons [role=button]').first();
+    if (await closeButton.isVisible().catch(() => false)) {
+      await closeButton.click({ force: true });
+    } else {
+      await page.keyboard.press('Escape');
+    }
+    await page.waitForTimeout(500);
+    events.push({ action: 'dismiss-intro' });
+  }
+}
+
+async function clickByText(page, re, label) {
+  const loc = page.locator('button,[role=button],a', { hasText: re }).first();
+  if (await loc.isVisible().catch(() => false)) {
+    await loc.click({ timeout: 5000 });
+    events.push({ action: 'clickText', label, text: String(re) });
+    return true;
+  }
+  return false;
+}
+
+async function clickToolbar(page, labelText) {
+  return await clickFirst(page, [
+    `button:has-text("${labelText}")`,
+    `[role=button]:has-text("${labelText}")`,
+    `text="${labelText}"`,
+  ], labelText);
+}
+
+async function checkLayout(page, label) {
+  const state = await page.evaluate((snapshotLabel) => ({
+    label: snapshotLabel,
+    text: document.body.innerText,
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+    innerWidth,
+    visibleModal: !!document.querySelector('.mat-mdc-dialog-container, .introjs-tooltip'),
+  }), label);
+  if (/Degrees of Freedom:\s*NaN/i.test(state.text)) {
+    recordIssue('Degrees of Freedom displays NaN', { severity: 'medium', label });
+  }
+  if (state.scrollWidth > state.clientWidth + 2) {
+    recordIssue('Page has horizontal overflow', {
+      severity: state.clientWidth < 600 ? 'high' : 'medium',
+      label,
+      scrollWidth: state.scrollWidth,
+      clientWidth: state.clientWidth,
+    });
+  }
+  return state;
+}
+
+async function safeStep(name, fn) {
+  try {
+    events.push({ action: 'step-start', name });
+    await fn();
+    events.push({ action: 'step-ok', name });
+  } catch (error) {
+    recordIssue(`Workflow step failed: ${name}`, {
+      severity: 'high',
+      error: error?.stack || error?.message || String(error),
+    });
+    events.push({ action: 'step-failed', name });
+  }
+}
+
+const context = await chromium.launchPersistentContext(userDataDir, {
+  executablePath: chromePath,
+  headless: !process.env.PMKS_HEADED,
+  viewport: { width: 1440, height: 1000 },
+  deviceScaleFactor: 1,
+  args: ['--no-first-run', '--no-default-browser-check', '--disable-crash-reporter'],
+});
+
+const page = context.pages()[0] || await context.newPage();
+page.setDefaultTimeout(8000);
+
+page.on('console', (msg) => {
+  const text = msg.text();
+  events.push({ action: 'console', type: msg.type(), text });
+  if (['error', 'warning'].includes(msg.type()) && !/favicon|Angular is running in development mode/i.test(text)) {
+    recordIssue(`Console ${msg.type()}: ${text.slice(0, 180)}`, { severity: msg.type() === 'error' ? 'medium' : 'low' });
+  }
+});
+page.on('pageerror', (error) => recordIssue('Uncaught page error', { severity: 'high', error: error.stack || error.message }));
+page.on('requestfailed', (request) => {
+  const failure = request.failure();
+  recordIssue(`Request failed: ${request.url()}`, { severity: 'medium', failure: failure?.errorText });
+});
+
+await safeStep('initial load', async () => {
+  await page.goto(baseUrl, { waitUntil: 'networkidle', timeout: 60000 });
+  await page.waitForTimeout(1000);
+  await shot(page, '01-initial-load.png');
+  await checkLayout(page, 'first load with intro');
+  await dismissIntro(page);
+  await shot(page, '01b-after-intro-dismissed.png');
+  await checkLayout(page, 'empty project');
+});
+
+const snapshots = [await appSnapshot(page, 'initial')];
+
+await safeStep('open templates/library', async () => {
+  await clickToolbar(page, 'Templates');
+  await page.waitForTimeout(700);
+  await shot(page, '02-template-or-library.png');
+  snapshots.push(await appSnapshot(page, 'template/library'));
+  const firstTemplateOpen = page.locator('.mat-mdc-dialog-container button:has-text("Open")').first();
+  if (await firstTemplateOpen.isVisible().catch(() => false)) {
+    await firstTemplateOpen.click();
+    events.push({ action: 'click', label: 'open first template', selector: '.mat-mdc-dialog-container button:has-text("Open")' });
+  } else {
+    recordIssue('Template library opened but no template Open button was visible', { severity: 'high' });
+  }
+  await page.waitForTimeout(1000);
+  await shot(page, '02b-template-opened.png');
+  if (await page.locator('.mat-mdc-dialog-container').first().isVisible().catch(() => false)) {
+    recordIssue('Template Open did not dismiss the Linkage Library modal', { severity: 'high' });
+  }
+  await checkLayout(page, 'template opened');
+  await page.keyboard.press('Escape').catch(() => {});
+});
+
+await safeStep('toolbar controls and project actions', async () => {
+  await clickToolbar(page, 'Share Project');
+  await page.waitForTimeout(500);
+  await shot(page, '03-share-url.png');
+  await page.keyboard.press('Escape').catch(() => {});
+
+  const downloadPromise = page.waitForEvent('download', { timeout: 3000 }).catch(() => null);
+  await clickToolbar(page, 'Save');
+  const download = await downloadPromise;
+  if (download) {
+    events.push({ action: 'download', suggestedFilename: download.suggestedFilename() });
+  } else {
+    recordIssue('Save did not start a download within 3 seconds', { severity: 'medium' });
+  }
+  await page.waitForTimeout(500);
+  snapshots.push(await appSnapshot(page, 'toolbar actions'));
+});
+
+await safeStep('load verification mechanism from shared URL', async () => {
+  await page.goto(`${baseUrl}?${verificationQuery}`, { waitUntil: 'networkidle', timeout: 60000 });
+  await page.waitForTimeout(1500);
+  await dismissIntro(page);
+  await shot(page, '03b-verification-mechanism.png');
+  await checkLayout(page, 'verification mechanism');
+  snapshots.push(await appSnapshot(page, 'verification mechanism'));
+});
+
+await safeStep('left panels edit analysis synthesis', async () => {
+  const leftButtons = page.locator('button.leftButton');
+  for (const [name, index] of [
+    ['analysis', 0],
+    ['edit', 1],
+    ['synthesis', 2],
+  ]) {
+    await leftButtons.nth(index).click();
+    await page.waitForTimeout(700);
+    await shot(page, `04-panel-${name}.png`);
+    snapshots.push(await appSnapshot(page, `panel ${name}`));
+  }
+});
+
+await safeStep('settings and equations panels', async () => {
+  for (const name of ['Settings', 'Help / Feedback']) {
+    await clickToolbar(page, name);
+    await page.waitForTimeout(700);
+    await shot(page, `05-right-${name.toLowerCase().replace(/[^a-z]+/g, '-')}.png`);
+    snapshots.push(await appSnapshot(page, `right ${name}`));
+  }
+});
+
+await safeStep('canvas interaction', async () => {
+  const svg = page.locator('svg').first();
+  const box = await svg.boundingBox();
+  if (!box) throw new Error('No visible SVG canvas found');
+  await page.mouse.click(box.x + box.width * 0.45, box.y + box.height * 0.45);
+  await page.waitForTimeout(300);
+  await page.mouse.dblclick(box.x + box.width * 0.55, box.y + box.height * 0.55);
+  await page.waitForTimeout(500);
+  await shot(page, '06-canvas-interaction.png');
+  snapshots.push(await appSnapshot(page, 'canvas interaction'));
+});
+
+await safeStep('animation controls', async () => {
+  await clickFirst(page, [
+    'button:has-text("play_arrow")',
+    'button:has-text("pause")',
+    'button >> text=play_arrow',
+  ], 'play/pause');
+  await page.waitForTimeout(1100);
+  await shot(page, '07-animation-controls.png');
+  snapshots.push(await appSnapshot(page, 'animation'));
+});
+
+await safeStep('mobile viewport smoke', async () => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.waitForTimeout(1000);
+  await shot(page, '08-mobile-load.png');
+  await checkLayout(page, 'mobile');
+  snapshots.push(await appSnapshot(page, 'mobile'));
+});
+
+await fs.writeFile(
+  path.resolve(`artifacts/screenshots/${runPrefix}-workflow-report.json`),
+  JSON.stringify({ baseUrl, userDataDir, issues, events, snapshots }, null, 2),
+);
+
+await context.close();
+console.log(JSON.stringify({ baseUrl, userDataDir, issueCount: issues.length, issues, screenshots: await fs.readdir(screenshotDir) }, null, 2));


### PR DESCRIPTION
## Summary

Sets up the AI-agent workflow for this repo — all computer-use work is delegated to **GPT-5.5 via the Codex CLI** (instead of claude-in-chrome), scouting/mechanical work goes to cheaper subagents, and the Playwright e2e scripts are now tracked and organized alongside a documented test layout.

## Changes

### Subagent routing & delegation policy
- **`.claude/skills/ui-validate/SKILL.md`** (new) — project skill auto-discovered by Claude Code. Covers preconditions (dev server on :4200, Playwright at `/tmp/pmks-playwright`), the exact invocation — `codex exec -m gpt-5.5 --sandbox workspace-write -c sandbox_workspace_write.network_access=true` (Codex sandbox stays ON; only localhost network is enabled) — plus a task-prompt template with standing rules: disposable Chrome profiles under `/tmp` (never the user's real browser), the subagent inspects its own screenshots, and reports back a compact PASS/FAIL summary so heavy browser tokens never enter the primary context. Includes PMKS-specific interaction gotchas (hover-before-click, Edit panel over SVG context menu).
- **`SKILLS.md`** (new, root) — the policy doc:
  - *Computer use → GPT-5.5*: UI validation, browser automation, screenshots, e2e checks are always delegated; `mcp__claude-in-chrome__*` is banned in this repo.
  - *Delegation policy*: codebase scouting → Claude `Explore` subagent on Opus 4.8; mechanical multi-step tasks (bulk edits, test runs, log trawls) → Opus 4.8 `general-purpose` or GPT-5.5 via codex; the primary model is reserved for judgment. Subagents return compact summaries, never raw output.
  - *Test layout* reference (below).
- **`CLAUDE.md`** — new section directing agents to the skill, and a note on the unit-vs-e2e test split.

### Playwright e2e suite (now tracked)
- **`e2e/`** (new) — the three interaction scripts, moved from untracked `artifacts/` and made portable:
  - `full-tour.mjs` — broad tour: panels, templates, settings, share URL, help, mobile viewport
  - `deep-interactions.mjs` — deep grid interaction: add links, drag joints, right-click menus
  - `focused-interactions.mjs` — focused workflows: four-bar build, animation, analysis
  - Portability patches: `PMKS_PLAYWRIGHT_DIR`, `PMKS_CHROME`, `PMKS_URL`, `RUN_PREFIX` env overrides; **headless by default** (`PMKS_HEADED=1` to watch); URL defaults normalized to :4200.
- **`e2e/README.md`** — test layout and run instructions. Vitest unit specs deliberately stay co-located in `src/**/*.spec.ts` (the `tsconfig.spec.json` glob and Angular template resolution depend on it; `app.component.spec.ts` is the MATLAB-verified solver regression suite); everything browser-driven lives in `e2e/`. Playwright is intentionally not a devDependency (would bloat Netlify installs; the GPT-5.5 subagent runs these, not CI).
- **`.gitignore`** — ignores `artifacts/` (scripts tracked, outputs throwaway: screenshots + `*-report.json`) and Claude local state (`.claude/settings.local.json`, `.claude/worktrees/`).

## Verified

- **GPT-5.5 delegation smoke test** — launched headless Chromium via Playwright with a disposable profile against the live dev server, screenshotted it, and returned a compact PASS report (0 console errors) while ~30k tokens of browser work stayed in the subagent.
- **Relocated scripts** — GPT-5.5 ran `RUN_PREFIX=e2emove node e2e/focused-interactions.mjs` end-to-end: 8 screenshots + JSON report, headless, disposable profiles. Surfaced 4 pre-existing app findings (`Unknown object type clicked: _RealLink` console error, link context menu not opening on right-click, page crash loading a force-encoded URL, horizontal overflow at 390px) — real signal, to be tracked separately from this PR.
- **Opus 4.8 scout** — `Explore` subagent with `model: opus` returned a precise file:line report on a codebase search task.

## Commits

- `9ccc05a` docs: route UI validation / computer use to GPT-5.5 via Codex CLI
- `bb03562` test: track Playwright e2e scripts in e2e/, document test layout
- `85d1615` docs: point skill and CLAUDE.md/SKILLS.md at tracked e2e/ scripts
- `147734a` docs: add subagent delegation policy to SKILLS.md *(drop this one if the delegation policy shouldn't live in the repo)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)