### PR TITLE
Phase 0: groundwork for floating sliders

### DIFF
--- a/docs/joint-types-plan.md
+++ b/docs/joint-types-plan.md
@@ -1,0 +1,638 @@
+# Joint types: floating sliders, prismatic joints, and cylinders
+
+Plan of record for extending PMKS+ from "revolute joints plus one grounded slider" to the
+joint set needed for the standard 2D kinematics curriculum.
+
+Branch: `floating-sliders`.
+
+---
+
+## 1. Scope
+
+### In
+
+| Joint | Grounded | Floating | Driven |
+| --- | --- | --- | --- |
+| Pin (R) | have | have | grounded: have · floating: **new** |
+| Slot (RP) | have | **new** | grounded: have · floating: **new** |
+| Slide (P) | **new** | **new** | **new** (this is the cylinder) |
+
+### Explicitly out
+
+- **Gear (G) joints.** A gear is irreducibly a 2-DOF relation between two named links with no
+  block-body decomposition available. Excluding it is what lets us keep the point-centric model
+  (see §2.2).
+- **Driving the R half of an RP.** Kinematically it is a reparameterisation of driving the P half
+   — same configurations, different time mapping — and a rotary actuator on a linear carriage is
+  rare. Excluding it means every joint type has exactly one drivable DOF, so **"driven" stays a
+  plain boolean** with no "which DOF?" follow-up control.
+- **Stroke limits.** See §2.6.
+- **Multiple simultaneous inputs.** Still one input, still `dof === 1`
+  ([`mechanism.ts:97-98`](../src/app/model/mechanism/mechanism.ts)). See §6 — the error message
+  matters more than it used to.
+
+---
+
+## 2. Locked decisions
+
+### 2.1 The joint model is a 2×2, not a 3-way type
+
+`isWelded` is already a boolean on `RealJoint`
+([`joint.ts:55`](../src/app/model/joint.ts)). Keep it that way — weldedness is a property of the
+*joint*, and any link attached there inherits it. Combined with "does this joint have a slider",
+that gives:
+
+|  | Not welded | Welded |
+| --- | --- | --- |
+| **No slider** | Pin (R) | rigid joint → compound link |
+| **Slider** | Slot (RP) | Slide (P) |
+
+This is a property of the **assembly**, not of one serialized joint — `isPrismatic` lives on the
+`PrisJoint` and `isWelded` on the coincident `RevJoint`. See §2.10 before implementing anything
+that reads or writes it.
+
+Consequences:
+
+- The panel has **two toggles** (Slider, Weld), not a three-way Type control plus a Weld button.
+- Unweld at a Slide gives a **Slot**, not a pin. Each control changes exactly one axis.
+- The `+` glyph is the same mark in both welded cells because it is the same flag.
+- **Cost:** no compound rider on a Slot (two links rigidly joined to each other but both free to
+  rotate in the slot). None of the scoped mechanisms need it. Recoverable later by promoting the
+  weld flag to a per-link-pair set.
+
+### 2.2 Keep the zero-length-block decomposition
+
+A slider stays `PrisJoint` + zero-length `SliderBlock` link + `RevJoint`
+([`mechanism.service.ts:1033-1050`](../src/app/services/mechanism.service.ts)). This already gives
+the invariant that a full joint-between-two-links refactor would buy: every joint relates exactly
+two bodies, and "which pair slides" can never be ambiguous because the block mediates.
+
+### 2.3 Carrier recording: Option A
+
+The `PrisJoint` gets a **`carrier` reference**. It does *not* become a member of the carrier's
+`joints` array.
+
+```
+Option A (chosen)                    Option B (rejected)
+Link3.joints = [B, C]                Link3.joints = [B, C, P]
+P.links      = [block]               P.links      = [block, Link3]
+P.carrier    = Link3   ← new field   P.slidesOnLink = true  ← new flag
+```
+
+Why: a link's hull comes from `this.joints.map(...)`
+([`link.ts:317`](../src/app/model/link.ts)) and its reference angle from `joints[0]`/`joints[1]`
+([`link.ts:275-276`](../src/app/model/link.ts)). `P` slides, so under Option B every consumer of a
+link's joint list must skip it — and `.joints` has **284 usages across 20 files**, including all
+five solvers.
+
+Option A's URL cost is three appended tokens (carrier id, slot joint A, slot joint B — see §2.4).
+`encodeJoint` emits `flags + id, name, x, y, angle`
+([`string-transcoder.ts:49-63`](../src/app/services/transcoding/string-transcoder.ts)); old URLs
+have five tokens and the disassembler returns `""` for the missing ones, which decodes as
+**grounded**. See §2.4a for why that default is safe.
+
+### 2.4 A floating slot is defined by two joints of its carrier — no offset angle
+
+**There is no offset angle.** A floating slot is the line through two ordinary joints of the
+carrier link:
+
+```
+PrisJoint (floating) = { carrier: Link, slotJointA: Joint, slotJointB: Joint }
+PrisJoint (grounded) = { ground: true, angle_rad: world angle }   ← unchanged
+```
+
+Why no offset is needed: every mechanism in scope has its slot collinear with two of the carrier's
+joints — Whitworth (pivot → far pin), Geneva (centre → rim), oscillating cylinder (pivot → piston
+pin), hydraulic cylinder (pin → pin), Oldham (one joint pair per slot). The offset only existed
+because an earlier draft measured the slot against a link's *global* axis, which is derived from
+`joints[0]`/`joints[1]` ([`link.ts:275-276`](../src/app/model/link.ts)) and therefore unstable
+across edits and URL round-trips. Two named joints remove the offset **and** the instability.
+
+What this buys:
+
+- **Multiple slots per link.** Each `PrisJoint` names its own joint pair, so a link with many
+  joints can host many slots.
+- **Both solver primitives get simpler.** Forward: the line is through two known points — no
+  `tan`, no derived link angle. Inverse (§2.5a): with A known and B unknown, B lies on ray A→P at
+  distance |AB|; the α term disappears entirely.
+- **The reference-angle risk is gone**, and with it the "convert the number to preserve the
+  geometry" dance on every carrier change.
+
+What it costs: a slot that is not collinear with any two of the carrier's joints — laterally
+offset, or angled across a plate. Recoverable by adding joints to define it; those joints are
+legitimately part of the link's geometry.
+
+**Store the carrier anyway.** Two joints can be shared by several links at a ternary joint, so the
+carrier is what disambiguates and what everything validates against.
+
+**Asymmetry to keep straight:** the two slot-defining joints **are** ordinary members of
+`carrier.joints` and do shape the link. The `PrisJoint` is still **not** a member (§2.3), because
+it slides.
+
+### 2.4a "Grounded" and "floating with no carrier" must not be confusable
+
+If an absent carrier token simply meant "grounded", a broken or half-edited floating slider would
+decode as a *working grounded* one — silently changing the mechanism instead of failing. The two
+states are distinguished by making the second one **impossible**:
+
+1. A `PrisJoint` is either grounded (`angle_rad`, no carrier) or floating (carrier + two slot
+   joints, all resolving). There is no third state, and the model never persists one.
+2. The UI cannot produce one. A floating slot is born from the drop-on-link gesture, which supplies
+   the carrier and the joint pair. Un-grounding an existing slider requires choosing them in the
+   same action.
+3. Lifecycle rules (§2.8a) reground or remove a slider whose carrier — or either slot joint — is
+   deleted or absorbed, so an orphan never survives an edit.
+4. Decode validates: carrier resolves, both slot joints resolve, both belong to the carrier, and
+   they are distinct. A partial or inconsistent set is a **decode error surfaced to the user**, not
+   a silent downgrade to grounded.
+
+With those in place, "no tokens" unambiguously means a pre-feature URL, i.e. grounded.
+
+### 2.5 No "Slot on" dropdown
+
+The carrier is chosen at creation by dropping the joint onto a specific link, and the slot is
+drawn as a hole in that link. The panel shows **`Slot on: Link 3` read-only**. Changing a carrier
+is delete-and-recreate.
+
+### 2.6 Slot length is an output, never an input
+
+Compute it from the solved travel range plus padding. Nobody may type it.
+
+Stroke limits are out of v1. For a *driven* slider a limit is structurally identical to a rocker
+toggle and would reuse `findFullMovementPos`'s reversal path — cheap. For a *passive* slider it is
+an inequality constraint in a solver that has none, plus a new "mechanism jams" state to animate,
+graph, and explain. Keeping slot length = computed travel means the drawing can never contradict
+the solver.
+
+### 2.7 The cylinder is a skin, not a state
+
+A piston is **Slide / floating / driven**. Draw the cylinder skin when carrier and rider each carry
+exactly one other joint, on opposite sides of the block, collinear with the slot — that is the
+two-pin strut case and nothing else produces it. (Under §2.4 the slot is always collinear with two
+of the carrier's joints, so the old "offset is 0°" clause is subsumed.) Provide a manual override;
+auto-switching a glyph is startling the first time.
+
+The override makes the skin **tri-state** (`auto` / `cylinder` / `slotted`), which is state, not
+just rendering. Decision: it is a **view preference, not mechanism state** — it does not serialize
+into the URL and does not enter the undo stack. A shared link always opens in `auto`. If that turns
+out to be wrong, it becomes a fourth joint flag, not an ad-hoc side channel.
+
+Selecting any member of the assembly (barrel, rod, or the Slide joint) overlays the slot axis and
+stroke ghosts **additively** — same size, same position, nothing moves. The revealed block is
+draggable. Rule is "collapsed skins expand on selection", so future skins inherit it.
+
+### 2.8 Visual grammar
+
+Five composable primitives, not twelve hand-drawn glyphs: hatch, block, channel, marker, arrow.
+
+**Link colours are randomly generated per link and carry no meaning.** Nothing in the grammar may
+depend on which colour a link has. Carrier and rider are distinguished *structurally*: the slot is
+a hole in the carrier, the block sits in the hole, the rider attaches at the marker.
+
+- circle marker = rotation allowed · `+` marker = welded/rigid
+- hatching = the other body is ground; a link body in its place = the other body is a moving link
+- **Slot**: block is a fixed dark neutral — it is its own body (`SliderBlock`) and belongs to no
+  link, so it must not borrow a link colour
+- **Slide**: block is a **darkened derivative of the rider's colour** — same hue, forced low
+  lightness. That preserves "same colour family ⇒ same body" without depending on *which* colour
+  the rider got, and it guarantees the block is dark enough for the next rule.
+- arrow = the driven freedom; curved for rotation, straight for translation; **always white**.
+  This is why both block treatments are forced dark: a white arrow on a randomly-coloured light
+  block would be invisible.
+- the selection ring stays purely interaction state (`getJointCSSClass`,
+  [`mechanism.service.ts:1353-1373`](../src/app/services/mechanism.service.ts)) — never overloaded
+  with joint type
+
+Rendering rules that follow: the break in a grounded slot's rail must track the rod's actual
+direction; hatching never rotates, carrier bars always do.
+
+### 2.9 An actuator is an ordered record, not a boolean
+
+An input prescribes a *relative* freedom between **two bodies**. `input: boolean` on a joint cannot
+name them. It survives today only because a grounded crank has an obvious answer, and the solvers
+guess: `kinematic-solver` reaches for the input joint's first link
+([`kinematic-solver.ts:141-160`](../src/app/model/mechanism/kinematic-solver.ts)) and `force-solver`
+for the first incident real body ([`force-solver.ts:269-280`](../src/app/model/mechanism/force-solver.ts)).
+Both are **already wrong** for a grounded input joint carrying more than one link. A driven floating
+pin makes that latent bug unavoidable.
+
+Model an actuator as an ordered record:
+
+```
+{ joint, referenceBody, drivenBody, kind: 'angle' | 'length', initialPhase }
+```
+
+**v1 restriction:** a driven joint must have **exactly two incident bodies**. The panel refuses
+Driven otherwise and says why. That keeps the record derivable rather than hand-authored — but the
+ordering must be canonical and must survive a URL round-trip, since `joint.links` order *is* the
+serialization order. Assert that in Phase 0's template test.
+
+Reportedly MotionGen's engine represents an actuator with three ordered joints rather than a joint
+flag, for the same reason — noted from review, not verified against the paper text.
+
+### 2.10 The slot assembly, and where each flag lives
+
+The 2×2 of §2.1 is a property of an **assembly**, not of one serialized joint. A single
+user-visible "slot joint" is three objects:
+
+```
+carrier ──── P   (PrisJoint: isPrismatic; carrier + slotJointA/B, or ground + angle_rad)
+              │
+         SliderBlock   (zero-length Link — NOT a RealLink)
+              │
+             R   (RevJoint: isWelded)  ──── rider
+```
+
+- `isPrismatic` lives on the **PrisJoint**; `isWelded` lives on the **RevJoint**. They are separate
+  records in the URL. The 2×2 is *derived from the pair*, and nothing in the model enforces that
+  pairing today.
+- `SliderBlock extends Link`, not `RealLink` — and `weldJointTopology` filters
+  `link instanceof RealLink` ([`mechanism.service.ts:1418`](../src/app/services/mechanism.service.ts)).
+  A block therefore **cannot** enter a compound through the generic weld path. See Phase 3.
+
+Invariants to assert on every rebuild:
+
+1. A `PrisJoint` has exactly one `SliderBlock` in `links`; that block has exactly two joints — the
+   `PrisJoint` and one `RevJoint`.
+2. The two are coincident at every timestep.
+3. A `PrisJoint` is **exactly one of**: grounded (`ground`, `angle_rad`, no carrier) or floating
+   (carrier + `slotJointA` + `slotJointB`, all resolving). Never neither, never both (§2.4a).
+4. When floating: both slot joints exist, are members of `carrier.joints`, have distinct ids, and
+   are **not coincident in space** — two coincident joints leave the slot line undefined, which a
+   Phase 1.2 snap that stops short of merging could produce.
+5. `PrisJoint.carrier` is never a link the paired `RevJoint` belongs to — no link sliding on itself.
+6. The `PrisJoint` is **not** a member of `carrier.joints`; the two slot joints **are** (§2.4).
+7. Weld state at the `RevJoint` and presence of the `PrisJoint` are independent; all four
+   combinations are legal and round-trip.
+
+---
+
+## 3. Phases
+
+Each phase is a PR. Gates are hard — do not start the next phase with a red gate.
+
+### Phase 0 — Groundwork (no user-visible change)
+
+| # | Task | Files |
+| --- | --- | --- |
+| 0.1 | Rename `Piston` → `SliderBlock` | [`link.ts:753`](../src/app/model/link.ts) + ~30 `instanceof` sites |
+| 0.2 | Template URL regression test | `template-linkages.ts`, new spec |
+| 0.3 | Rewrite `circleLineIntersection` in parametric form | [`utils.ts:1178`](../src/app/model/utils.ts), [`position-solver.ts:521-658`](../src/app/model/mechanism/position-solver.ts) |
+
+**0.1 first**, before anything else — `Piston` currently means "slider block" and we are about to
+add a feature users call a piston that is a different thing.
+
+**0.2** locks the compatibility surface before anything moves. Decode all five entries in
+`TEMPLATE_LINKAGES`, assert topology and solved positions. `Slider_Crank` is the one that matters:
+its payload encodes joints `C` and `D` at identical coordinates with link `YPCD` between them —
+the coincident RevJoint/PrisJoint pair. `TEMPLATE_LINKAGES` is already imported by
+`analysis-graph`, `analysis-panel`, and `force-solver.fixture` specs, so the hook exists.
+
+**0.3** replaces `y = mx + n` with point + unit vector. A *fixed* slot only hits `m → ∞` if the
+user types 90°; a slot on a rotating carrier crosses vertical twice per revolution. This deletes
+the `Number.MAX_VALUE` clamp ([`position-solver.ts:645-647`](../src/app/model/mechanism/position-solver.ts))
+and the separate NaN branch ([`:543-571`](../src/app/model/mechanism/position-solver.ts)).
+
+> **Gate 0:** all existing specs green; `Slider_Crank` template decodes and solves bit-identically
+> to `main`; new slider-crank cases at 89.9° and exactly 90° match closed form.
+
+### Phase 1 — Drag foundation
+
+Independent of joint types, and a prerequisite for Phase 4's slot drags. This is where the drag
+logic currently living only in the author's head gets written down.
+
+| # | Task | Notes |
+| --- | --- | --- |
+| 1.1 | Extract the drag state machine out of `new-grid.component.ts` | `jointStates`/`linkStates` are scattered across ~12 sites ([`new-grid.component.ts`](../src/app/component/new-grid/new-grid.component.ts)) |
+| 1.2 | Joint-onto-joint drag to snap/merge | new — no snap logic exists today |
+| 1.3 | Whole-link drag | `linkStates.dragging` and `.resizing` are declared ([`utils.ts:30-35`](../src/app/model/utils.ts)) but **never used**; only `creating`/`waiting` appear |
+| 1.4 | Save-on-release discipline | one `updateMechanism(true)` per gesture, not per pointer-move — undo is a stack of URL strings |
+
+`dragJoint` is currently unconstrained free-drag
+([`grid-utils.service.ts:120-128`](../src/app/services/grid-utils.service.ts)) and already keeps
+the PrisJoint glued to the RevJoint ([`:132-137`](../src/app/services/grid-utils.service.ts)).
+Phase 4 inverts that: the block becomes the constrained thing and the pin follows.
+
+**Drop-target arbitration.** 1.2 and Phase 4.3 both add drop targets. Joint snap must win when a
+joint and a link body are both in range, with a visible indicator of which you're about to get.
+
+> **Gate 1:** dragging a joint onto another merges them and round-trips through the URL; dragging
+> a link moves all its joints and leaves the mechanism solvable; each gesture is exactly one undo
+> entry.
+
+### Phase 2 — Floating Slot: model and solvers
+
+| # | Task | Files |
+| --- | --- | --- |
+| 2.1 | `PrisJoint`: `carrier` + `slotJointA/B`; allow `ground = false`; grounded keeps `angle_rad`; three URL tokens + validation (§2.4a) | `joint.ts`, `mechanism-builder.ts`, `string-transcoder.ts`, `transcoder-data.ts` |
+| 2.2 | `Ground` toggle stops destroying sliders; carrier reassignment converts the angle | [`mechanism.service.ts:939-976`](../src/app/services/mechanism.service.ts) |
+| 2.3 | DOF: a prismatic ground must clear `groundNotFound` | [`mechanism.ts:274-301`](../src/app/model/mechanism/mechanism.ts) |
+| 2.4 | Fix global single-slider lookups | [`mechanism.service.ts:956`](../src/app/services/mechanism.service.ts), [`force-solver.ts:278`](../src/app/model/mechanism/force-solver.ts) |
+| 2.5 | **Inverse slot primitive**: solve the carrier's pose from a known block point, then place all its joints | new multi-target step kind |
+| 2.6 | Forward slot primitive: recompute the slot line per timestep | [`position-solver.ts:175-176, 218-222`](../src/app/model/mechanism/position-solver.ts) |
+| 2.7 | `detJointOrder`: defer-and-retry, multi-target steps | [`position-solver.ts:135-271`](../src/app/model/mechanism/position-solver.ts) |
+| 2.8 | Carrier lifecycle and topology — see 2.8a | many |
+| 2.9 | Kinematic solver: add the carrier's ω×r term | [`kinematic-solver.ts:186-202, 269-270`](../src/app/model/mechanism/kinematic-solver.ts) |
+| 2.10 | Force solver: rotate the reaction direction, drop the `.ground` guard, add carrier-side incidence | [`force-solver.ts:476-486, 551`](../src/app/model/mechanism/force-solver.ts) |
+| 2.11 | IC solver: prismatic IC is at infinity ⊥ to a direction that now rotates | [`ic-solver.ts:107-112`](../src/app/model/mechanism/ic-solver.ts) |
+
+#### 2.5a The inverse direction is the primary case, not an edge case
+
+An earlier draft of this plan assumed the forward direction — carrier pose known, find the rider's
+pin on the slot — and treated the inverse as rare. **That was wrong.** Work the solve order for the
+classic floating-slot mechanisms:
+
+- **Whitworth / inverted slider-crank / oscillating cylinder.** Crank is driven, so the crank pin
+  (and therefore the block) is located first. The *slotted lever's* pose is the unknown, determined
+  by its ground pivot plus the requirement that its slot passes through the block.
+- **Scotch yoke.** Same shape — crank pin known, yoke position unknown.
+- **Geneva.** Driver pin known, Geneva wheel pose unknown.
+
+All three are the inverse direction. Driving the crank is the natural input, and the slot lives on
+the output — so for floating slots, **inverse is the common case and forward is the rare one**
+(forward needs the carrier fully determined before the rider, e.g. a four-bar with a slotted
+coupler).
+
+The primitive: the slot is the line through `slotJointA` and `slotJointB` (§2.4). If one of them —
+call it `A` — is already known and a point `P` on the slot is known, then `L`'s pose follows from
+`atan2(P − A)`, and every other joint of `L` places by rigid transform. That solves **a set of
+joints at once**, which is why multi-target steps (§2.7a item 1) are a Phase 2 requirement rather
+than future-proofing.
+
+Because the slot is two named joints rather than an anchor plus an offset, there is no α term and
+no derived link angle in either primitive.
+
+The general case — neither slot joint known, or no solved joint on `L` — does not reduce. Those
+hand to the §2.7a strategy, which in v1 reports unsolvable.
+
+**2.7 is the structural one.** `detJointOrder` is a single-pass DFS that emits a
+`circleLineIntersectionPoints` step as soon as it sees a `PrisJoint` neighbour — safe today
+because a grounded slot is known before the walk starts. It now has to choose between the forward
+and inverse primitives based on what is already known, and may reach either before its
+prerequisites. Wrap the walk in repeat-until-no-progress. That also gives a real error path for
+non-dyadic mechanisms instead of today's silent no-motion.
+
+#### 2.7a The "no progress" exit is a seam, not a dead end
+
+MotionGen's current engine (Lyu, Purwar & Liao, *A Unified Real-Time Motion Generation Algorithm
+for Approximate Position Analysis of Planar N-Bar Mechanisms*, J. Mech. Des. 146(6):063302, 2024)
+keeps a fast dyadic decomposition and falls back to an optimisation-based solve when decomposition
+doesn't apply. That is the natural evolution of this loop: **when a pass makes no progress, the
+remaining unsolved joints are a simultaneous system**, not a failure.
+
+We are **not building the fallback in v1.** We are only shaping 2.6 so it can be added later
+without redesigning the ordering:
+
+1. **Steps target a set of joints, not one.** The step record carries a target *set*, and the
+   switch in `determinePositionAnalysis`
+   ([`position-solver.ts:295-334`](../src/app/model/mechanism/position-solver.ts)) gets a case
+   that can write several positions at once. If v1 hardcodes one-joint-per-step, adding a block
+   solver later means changing the step representation — exactly the retrofit we're avoiding.
+2. **`known` holds link poses as well as joint positions**, even though v1 only ever adds joints
+   to it. This is also what a reverse-direction primitive would need (§7.1).
+3. **Write the constraint residual for every closed-form step as a small pure function**, and use
+   it as a v1 test assertion: assert that the closed-form answer satisfies its own constraint to
+   tolerance. The fallback needs a residual library; this way it exists before it's needed and
+   earns its keep as tests in the meantime.
+4. The exit calls a **strategy**. v1 ships exactly one: report unsolvable, naming the joints it
+   could not order.
+
+If the fallback does land, it is Newton–Raphson (or Levenberg–Marquardt for damping near
+singularities) over the unsolved joint coordinates, with equations of the form
+`(xᵢ−xⱼ)² + (yᵢ−yⱼ)² − Lᵢⱼ² = 0` for rigid links and `(P − A) × û = 0` for slots, **seeded from
+the previous timestep**. The seed is what selects the assembly branch — the same job
+`solutionNearestCurrent` and `concentricSolution` already do for the closed-form path
+([`position-solver.ts:421-490`](../src/app/model/mechanism/position-solver.ts)) — so branch
+tracking is inherited rather than reinvented. Non-convergence at a timestep means the mechanism
+cannot assemble there, which is the existing toggle semantic that `findFullMovementPos` already
+answers by reversing.
+
+**Hard constraint if it ever lands:** a numerical solve is approximate, and the regression suite
+verifies against exact MATLAB values. Any fallback must be gated so that dyadically decomposable
+mechanisms still take the closed-form path bit-identically. The fallback is for mechanisms that
+have no answer today — never a replacement for ones that do.
+
+#### 2.8a Carrier lifecycle and topology
+
+Option A (§2.3) stores the carrier outside both `carrier.joints` and `PrisJoint.links`, so every
+consumer that walks those structures is blind to it. Each of the following is a task, not a
+consequence to discover later:
+
+| Consumer | Problem | Fix |
+| --- | --- | --- |
+| `cloneJointAt` / per-timestep copies | copies `input`, `ground`, `angle_rad` only ([`mechanism.ts:116-128`](../src/app/model/mechanism/mechanism.ts)); the carrier pointer would still reference the *editable* link | rebind the carrier to the per-timestep copy by id — the same class of bug the code already documents at [`kinematic-solver.ts:180-185`](../src/app/model/mechanism/kinematic-solver.ts) |
+| `LoopSolver` | traverses `connectedJoints` only ([`loop-solver.ts:5-43`](../src/app/model/mechanism/loop-solver.ts)) | slot relationships must appear in loop enumeration or kinematic loops are wrong |
+| `incidentBodies` | built from `joint.links` + `body.joints` membership ([`force-solver.ts:551-560`](../src/app/model/mechanism/force-solver.ts)) | dropping the `.ground` guard is **not sufficient** — the carrier-side reaction is omitted entirely |
+| link deletion | carrier reference dangles | reground or remove dependent sliders |
+| **slot joint deletion** | either `slotJointA` or `slotJointB` may be deleted or merged away by the Phase 1.2 snap | reground or remove the slider; a slot cannot survive losing a defining joint |
+| weld / compound | carrier may be absorbed into a compound `RealLink` | remap the carrier to the compound and re-check that both slot joints are still members |
+| URL decode | carrier or slot joint ids may be absent, unknown, duplicated, or not members of the carrier | resolve and **validate** per §2.4a — a partial or inconsistent set is a surfaced decode error, never a silent downgrade to grounded |
+
+The appended tokens are syntactically backward-compatible. **Semantic validity is not "by
+construction"** and needs its own tests — see §4.2.
+
+**2.8 and 2.9 will produce plausible-looking wrong numbers rather than errors.** In a teaching
+tool that is the worst failure mode available. Do not defer them past this phase.
+
+> **Gate 2:** inverted slider-crank and Whitworth (both **inverse** direction) and the slotted-coupler
+> four-bar (**forward** direction) match closed form for position, velocity, and acceleration; force
+> and IC cases match; carrier lifecycle regressions pass; `Slider_Crank` template still bit-identical.
+
+### Phase 3 — Slide (pure prismatic)
+
+Slide is an **assembly-level** state (§2.10), and the generic weld path cannot express it: a
+`SliderBlock` is not a `RealLink`, so `weldJointTopology` filters it out
+([`mechanism.service.ts:1418`](../src/app/services/mechanism.service.ts)). Lifting the `canBeWelded`
+exclusion alone therefore does nothing useful — it neither admits the block to a compound nor
+prevents the rider from rotating.
+
+| # | Task |
+| --- | --- |
+| 3.1 | Lift the `PrisJoint` exclusion in `canBeWelded` ([`joint.ts:119-128`](../src/app/model/joint.ts)) |
+| 3.2 | **Assembly-level weld/unweld**: a dedicated path that rigidly binds rider ↔ block, separate from `weldJointTopology`'s compound-`RealLink` logic |
+| 3.3 | DOF: a welded slot assembly contributes one fewer freedom than an unwelded one |
+| 3.4 | `cloneJointAt` / per-timestep copies carry the weld across the assembly, not just the `RevJoint` |
+| 3.5 | Serialization: assert the `isPrismatic`/`isWelded` pair round-trips as an assembly, including all four 2×2 cells |
+| 3.6 | Solvers: a welded rider has no relative rotation at the block |
+| 3.7 | Guard: Weld/Unweld buttons in the panel act on the assembly when a slider is present, on the compound otherwise — never ambiguously |
+
+Slide still needs **no new type bit**: `isPrismatic` + `isWelded` are both already in `JointData`
+([`transcoder-data.ts:19-32`](../src/app/services/transcoding/transcoder-data.ts)). But that is a
+statement about *encoding*, not about behaviour — the assembly invariants of §2.10 are what make the
+pair meaningful, and they must be asserted rather than assumed.
+
+> **Gate 3:** Scotch yoke matches `x = r cos θ`, `ẋ = −rω sin θ`, `ẍ = −rω² cos θ`; all four 2×2
+> cells round-trip; assembly invariants hold after weld, unweld, clone, and carrier deletion.
+
+### Phase 4 — UI
+
+| # | Task |
+| --- | --- |
+| 4.1 | Panel: Slider + Weld toggles; read-only `Slot on: Link 3 (joints B–C)`; the angle field appears **only for grounded** sliders, labelled "from +x axis" |
+| 4.2 | Canvas: the twelve glyphs, composed from the five primitives |
+| 4.3 | Creation gesture: drop a joint onto a link between two of its joints → slot on that link, defined by that pair. **Pair resolution:** unambiguous on a binary link; on a link with *n* joints there are up to *n*(*n*−1)/2 candidate pairs, so pick the segment whose line the drop point is nearest and show which pair is about to be chosen before release |
+| 4.4 | Slot drag: block along the slot sets s₀ — **that is the only slot-specific drag** |
+
+Today the panel **disables Ground whenever Slider is on**
+([`edit-panel.component.ts:215-217`](../src/app/component/edit-panel/edit-panel.component.ts)) and
+`toggleSlider` always produces a grounded slider
+([`mechanism.service.ts:1021, 1038`](../src/app/services/mechanism.service.ts)). Both go away.
+
+Stash the slot angle and carrier on the RevJoint when a slider is removed, so toggling back
+restores them. Today they are destroyed.
+
+**§2.4 deletes work here.** With the slot defined by two of the carrier's joints, there is no
+rotate-the-slot handle and no snapping — you change a floating slot's direction by dragging its
+defining joints, which is ordinary joint dragging from Phase 1. The angle field disappears for
+floating sliders entirely, and with it the "which reference frame is this number in?" labelling
+problem.
+
+**One drag changes one quantity.** Block-drag moves s₀ and nothing else.
+
+> **Gate 4:** every cell of the 2×2 reachable in ≤2 clicks from every other; each control change
+> alters exactly one visual mark; all twelve states round-trip through the URL.
+
+### Phase 5 — Driven prismatic and the cylinder
+
+| # | Task |
+| --- | --- |
+| 5.1 | Driven floating Slide: prescribe s(t) |
+| 5.2 | **Linear speed units and persistence** — `inputSpeed` is documented "Always RPM" ([`settings.service.ts:22-23`](../src/app/services/settings.service.ts)) and every rebuild converts via `× π/30` ([`mechanism.service.ts:144`](../src/app/services/mechanism.service.ts)). A linear input needs its own unit family, its own default, and its own URL setting. |
+| 5.3 | **Sample Δt and cycle termination** — the timeline assumes one-degree crank samples (`STEPS_PER_REVOLUTION = 360`, [`mechanism.ts:305-320`](../src/app/model/mechanism/mechanism.ts)) and prismatic stepping is a hardcoded `0.1` length increment ([`position-solver.ts:372`](../src/app/model/mechanism/position-solver.ts)). A linear input has no revolution to close on; its cycle ends at a reversal, so only the return-to-start tolerance applies. |
+| 5.4 | Velocity scaling and playback period follow from 5.2/5.3 — audit every place that assumes angular input |
+| 5.5 | Direction terminology: CW/CCW → extend/retract, including `isInputCW` ([`settings.service.ts:21`](../src/app/services/settings.service.ts)) and the analysis-panel text |
+| 5.6 | Cylinder skin + detection rule (§2.7) |
+| 5.7 | Reveal-on-select overlay; decide whether it persists during playback |
+| 5.8 | Link panel shows length at t = 0, not a constant, for variable-length links |
+
+**The constraint is the easy part of this phase.** It reduces to `|P₁P₂| = s(t)`, a
+per-timestep entry in `jointDistMap` feeding the existing circle-circle dyad
+([`position-solver.ts:501-518`](../src/app/model/mechanism/position-solver.ts)) — no slot line, no
+ordering problem. The work is 5.2–5.5: the entire timing and units stack currently assumes an
+angular input, and none of it is parameterised.
+
+Decide which entry point is canonical: the joint panel's Driven toggle, or the link panel's
+"driven length". Two ways to reach one piece of state is fine; two sources of truth is not.
+
+> **Gate 5:** cylinder-driven boom matches the law-of-cosines solution; a linear input completes a
+> cycle, reverses correctly, and its speed round-trips through the URL in its own units.
+
+### Phase 6 — Driven floating Pin
+
+Two problems, not one.
+
+**Ordering.** `determineJointOrder` locates the input joint and walks outward from it
+([`position-solver.ts:82-125`](../src/app/model/mechanism/position-solver.ts)), assuming its
+position is known. A floating input joint's position is not. Needs the Phase 2.7 defer-and-retry
+machinery, which is why this comes last.
+
+**Actuator identity.** Driving a floating pin means prescribing the relative angle between two
+moving bodies, which the `input` boolean cannot express (§2.9). This phase is where the ordered
+actuator record actually gets exercised; the v1 two-body restriction must already be enforced by
+the panel before this lands.
+
+> **Gate 6:** a standard four-bar **driven at its coupler–rocker pin** instead of at the crank
+> reproduces the same coupler curve as the crank-driven version, with velocities rescaled by the
+> joint-angle relationship.
+
+An earlier draft proposed a "geared-five-bar-style" gate. That was incoherent: gears are out of
+scope (§1), and an ungeared five-bar is DOF 2, which the engine rejects. The four-bar driven at a
+floating joint is DOF 1, uses no out-of-scope features, and has an exact reference — the same
+mechanism solved the ordinary way.
+
+---
+
+## 4. Test ladder
+
+### 4.1 Mechanism cases
+
+| # | Mechanism | Direction | Isolates | Verification |
+| --- | --- | --- | --- | --- |
+| 1 | Offset slider-crank, slot at 90° and 89.9° | grounded | parametric-line rewrite | closed form |
+| 2 | Inverted slider-crank (oscillating cylinder) | **inverse** | floating Slot | closed form: `s = √(r² + d² − 2rd·cos θ₂)` |
+| 3 | Scotch yoke | **inverse** | floating Slot **+** grounded Slide | closed form: pure sinusoid |
+| 4 | Whitworth quick-return | **inverse** | full-rotation branch | published time ratio |
+| 5 | Four-bar with a slotted coupler driving a grounded lever | **forward** | the forward primitive, which nothing else covers | four-bar closed form, then circle ∩ known line |
+| 6 | Elliptical trammel | grounded ×2 | two grounded slides at once | traces an exact ellipse |
+| 7 | Cylinder-driven boom | driven | driven floating Slide + linear timing | law of cosines |
+| 8 | Four-bar driven at its coupler–rocker pin | — | driven floating Pin, actuator record | same coupler curve as the crank-driven four-bar |
+| 9 | #2 with a load | — | force reaction direction **and** carrier-side incidence | MATLAB free-body; assert reactions are equal and opposite across the slot |
+| 10 | #2 instant centres | — | IC solver | textbook IC locations |
+
+Case 5 exists because 2, 3, and 4 are all the inverse direction (§2.5a) and would leave the forward
+primitive untested.
+
+### 4.2 Model and lifecycle regressions
+
+These are not mechanisms; they are the failure modes that Option A and the slot assembly introduce.
+
+| Regression | Asserts |
+| --- | --- |
+| Carrier and slot-joint URL resolution | valid ids resolve to the right link and joints after decode |
+| Invalid / dangling / duplicated / self-referential ids | surfaced as a decode error; **never** a silent downgrade to grounded (§2.4a) |
+| Slot joints not members of the carrier | rejected at decode |
+| Missing carrier tokens (pre-existing URL) | decodes as grounded, geometry unchanged |
+| Per-timestep cloning | carrier **and both slot joint** references point at the *copies*, not the editable objects |
+| Carrier link deleted | dependent sliders are regrounded or removed; no dangling reference |
+| Either slot joint deleted or merged by snap | same — a slot cannot outlive a defining joint |
+| Carrier link welded into a compound | carrier remaps; both slot joints still members |
+| Two slots on one link | independent joint pairs on the same carrier both solve |
+| All four 2×2 cells | round-trip through the URL and rebuild identically |
+| Driven joint with 3+ incident bodies | refused by the panel with a reason (§2.9) |
+| Assembly invariants (§2.10, items 1–5) | hold after every structural edit |
+
+### 4.3 Method notes
+
+- For 1, 3, 5, 6, and 8 assert against the analytic formula rather than sampled MATLAB output —
+  stronger, and no reference data to drift.
+- Given the known defects in the existing MATLAB data, generate new references by an independent
+  route wherever a closed form exists rather than trusting a single script.
+- Follow the shape of `app.component.spec.ts` / `SixBarVerification.m`: sample position, velocity,
+  and acceleration at N input angles.
+
+---
+
+## 5. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| `angle_rad` reinterpretation silently changes existing shared URLs | Grounded sliders keep reading the old way (carrier = ground, where the definitions coincide). Gate 0 locks this. |
+| The generic weld path silently cannot express Slide | `SliderBlock` is not a `RealLink` and is filtered out ([`mechanism.service.ts:1418`](../src/app/services/mechanism.service.ts)). Phase 3 builds an assembly-level path instead of extending the compound path. |
+| Force and IC solvers ship wrong-but-plausible numbers | Gates 2 and 4 include force and IC cases; no phase completes on motion alone |
+| Carrier pointer survives into the per-timestep copies unrebound | Phase 2.8a; the codebase already documents this exact bug class at [`kinematic-solver.ts:180-185`](../src/app/model/mechanism/kinematic-solver.ts) |
+| ~~Carrier reference angle unstable across edits or URL round-trips~~ | **Eliminated by §2.4** — the slot is two named joints, so nothing is measured against a derived link angle |
+| A floating slot silently degrades to grounded on decode | §2.4a — the intermediate state is made impossible and decode validates rather than defaults |
+| A slot outlives one of its defining joints (deletion, or a Phase 1.2 snap merge) | §2.8a lifecycle rules plus the §4.2 regressions |
+| Actuator body pair is ambiguous at a joint with 3+ links | §2.9 — pre-existing latent bug, made unavoidable by driven floating pins. v1 restricts to two incident bodies. |
+| Phase 5 is scoped as "the constraint" and the timing stack is missed | 5.2–5.5 are the phase; the constraint is the small part |
+| Twelve glyphs get hand-coded in `new-grid` | §2.8 — five composable primitives, or the combinatorics move from the panel into the renderer |
+| Users build multi-cylinder booms and get nothing | §6 |
+
+---
+
+## 6. Known limitation to communicate
+
+An excavator boom is three cylinders — three DOF. Scope is one input and `dof === 1`. The failure
+must say *"this mechanism has N degrees of freedom — remove a driven joint or add a constraint"*,
+not silently fail to animate. This is the single most likely source of user disappointment once
+cylinders exist.
+
+---
+
+## 7. Open questions
+
+1. ~~**Grounded pin riding a moving slot**~~ — **resolved.** This is not an edge case; it is the
+   same inverse direction that Whitworth, the oscillating cylinder, the Scotch yoke, and Geneva all
+   need. §2.5a promotes the inverse primitive into Phase 2 as first-class work. The retry loop
+   itself has **no direction** — it only reorders; what is directional is the step catalogue, which
+   is why "run it both ways" was never a thing that could be switched on. Cases the closed-form
+   inverse primitive cannot reduce still hand to the §2.7a strategy.
+2. **General inverse cases.** The primitive in §2.5a assumes the slot's anchor is a known joint of
+   the carrier. Offset slots, and carriers with no solved joint, do not reduce. Decide whether v1
+   refuses them explicitly in the panel or lets them reach the "unsolvable" strategy.
+3. **Two links riding one block** — drawn as a normal multi-joint link over the block. Confirm the
+   assembly weld semantics of §2.10 give the intended result.
+4. **Reveal-on-select during playback** — keep or suppress (5.7).
+5. **Canonical entry point for driven cylinder length** — joint panel or link panel (§Phase 5).
+6. **Naming.** "Slider" currently means RP to existing users. If the panel keeps two toggles
+   (Slider, Weld) the word survives unchanged — confirm that reads correctly for Slide.

--- a/docs/joint-types-plan.md
+++ b/docs/joint-types-plan.md
@@ -505,6 +505,12 @@ problem.
 | 5.7 | Reveal-on-select overlay; decide whether it persists during playback |
 | 5.8 | Link panel shows length at t = 0, not a constant, for variable-length links |
 
+**`incrementPrisInput` has no test coverage at all today.** Mutation-testing during Phase 0 showed
+that perturbing it changes nothing in any spec: no built-in template drives the slider, so
+([`position-solver.ts:372-381`](../src/app/model/mechanism/position-solver.ts)) is dead code in
+the suite. Anything this phase changes there is unguarded until a driven-prismatic case exists —
+write that case first, not last.
+
 **The constraint is the easy part of this phase.** It reduces to `|P₁P₂| = s(t)`, a
 per-timestep entry in `jointDistMap` feeding the existing circle-circle dyad
 ([`position-solver.ts:501-518`](../src/app/model/mechanism/position-solver.ts)) — no slot line, no

--- a/docs/joint-types-plan.md
+++ b/docs/joint-types-plan.md
@@ -271,13 +271,30 @@ Invariants to assert on every rebuild:
 
 Each phase is a PR. Gates are hard — do not start the next phase with a red gate.
 
-### Phase 0 — Groundwork (no user-visible change)
+### Phase 0 — Groundwork (no user-visible change) — **DONE** (PR #223)
 
-| # | Task | Files |
-| --- | --- | --- |
-| 0.1 | Rename `Piston` → `SliderBlock` | [`link.ts:753`](../src/app/model/link.ts) + ~30 `instanceof` sites |
-| 0.2 | Template URL regression test | `template-linkages.ts`, new spec |
-| 0.3 | Rewrite `circleLineIntersection` in parametric form | [`utils.ts:1178`](../src/app/model/utils.ts), [`position-solver.ts:521-658`](../src/app/model/mechanism/position-solver.ts) |
+| # | Task | Files | Status |
+| --- | --- | --- | --- |
+| 0.1 | Rename `Piston` → `SliderBlock` | [`link.ts`](../src/app/model/link.ts) + 15 files | done |
+| 0.2 | Template URL regression test | [`template-url.spec.ts`](../src/tests/verification/template-url.spec.ts), [`template-baseline.ts`](../src/tests/verification/template-baseline.ts) | done |
+| 0.3 | Rewrite `circleLineIntersection` in parametric form | [`utils.ts`](../src/app/model/utils.ts), [`position-solver.ts`](../src/app/model/mechanism/position-solver.ts), [`slider-guide-angle.spec.ts`](../src/tests/verification/slider-guide-angle.spec.ts) | done |
+
+**0.3 turned out to be a correctness fix, not just a robustness one.** The clamp treated any
+`|m| > 1000` as `Number.MAX_VALUE` and switched to a constant-`x` branch. `tan(89.95°) = 1146`, so a
+guide a twentieth of a degree off vertical was solved as *exactly* vertical — the slider drifted
+0.0044 off its true position with `x` pinned to its starting value for the whole cycle. Any
+mechanism a user built on a steep guide has been quietly wrong.
+
+Guide angles are asserted against the closed form (§4.3), not sampled data: 0°, 30°, 60°, 89.95°,
+exactly 90°, 120°. MATLAB cases covering the same angles exist and pass their full pipeline in
+`KohmeiK/PMKS_Verification#1`; wiring them in as an independent cross-check is follow-up work and
+needs an upstream-provenance decision first, since PMKSWeb currently pins a `PMKS-Web/` commit.
+
+Two things left in place deliberately:
+
+- The circle-line branch index is still chosen once and held, which is not safe through a tangency
+  — the same failure `solutionNearestCurrent` fixes for circle-circle. Commented in place; Phase 2.
+- `incrementPrisInput` still has no coverage (see Phase 5).
 
 **0.1 first**, before anything else — `Piston` currently means "slider block" and we are about to
 add a feature users call a piston that is a different thing.
@@ -293,8 +310,8 @@ user types 90°; a slot on a rotating carrier crosses vertical twice per revolut
 the `Number.MAX_VALUE` clamp ([`position-solver.ts:645-647`](../src/app/model/mechanism/position-solver.ts))
 and the separate NaN branch ([`:543-571`](../src/app/model/mechanism/position-solver.ts)).
 
-> **Gate 0:** all existing specs green; `Slider_Crank` template decodes and solves bit-identically
-> to `main`; new slider-crank cases at 89.9° and exactly 90° match closed form.
+> **Gate 0 — met.** 263 specs green (was 215); `Slider_Crank` template decodes and solves
+> bit-identically; guide-angle cases match closed form at every tested angle; production build clean.
 
 ### Phase 1 — Drag foundation
 

--- a/src/app/component/linkage-table/linkage-table.component.ts
+++ b/src/app/component/linkage-table/linkage-table.component.ts
@@ -7,7 +7,7 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { Force } from '../../model/force';
-import { Piston, Link, RealLink, Shape } from '../../model/link';
+import { SliderBlock, Link, RealLink, Shape } from '../../model/link';
 import { Joint, PrisJoint, RealJoint, RevJoint } from '../../model/joint';
 import { Coord } from '../../model/coord';
 import { roundNumber } from '../../model/utils';
@@ -234,7 +234,7 @@ export class LinkageTableComponent implements OnInit {
     switch (link.constructor) {
       case RealLink:
         return 'R';
-      case Piston:
+      case SliderBlock:
         return 'P';
     }
     return '?';

--- a/src/app/component/toolbar/toolbar.component.ts
+++ b/src/app/component/toolbar/toolbar.component.ts
@@ -11,7 +11,7 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { Joint, PrisJoint, RealJoint, RevJoint } from '../../model/joint';
-import { Bound, Link, Piston, RealLink } from '../../model/link';
+import { Bound, Link, SliderBlock, RealLink } from '../../model/link';
 import { Force } from '../../model/force';
 import { Mechanism } from '../../model/mechanism/mechanism';
 import {
@@ -262,5 +262,4 @@ export class ToolbarComponent implements OnInit, AfterViewInit {
     //Used to change the color of the topbar when not running prod
     return isDevMode();
   }
-
 }

--- a/src/app/model/link.ts
+++ b/src/app/model/link.ts
@@ -6,11 +6,7 @@ import { degToRad, determineSlope, getAngle, getDistance, radToDeg } from './uti
 import hull from 'hull.js';
 import { SettingsService } from '../services/settings.service';
 import { Arc, Line } from './line';
-import {
-  buildCompoundPath,
-  transformRigidCoord,
-  transformRigidPath,
-} from './compound-link-path';
+import { buildCompoundPath, transformRigidCoord, transformRigidPath } from './compound-link-path';
 
 export enum Shape {
   line = 'line',
@@ -203,13 +199,7 @@ export class RealLink extends Link {
   private copyVisualGeometryFrom(source: RealLink): void {
     const [sourceStart, sourceEnd] = source.joints;
     const [targetStart, targetEnd] = this.joints;
-    this._d = transformRigidPath(
-      source.d,
-      sourceStart,
-      sourceEnd,
-      targetStart,
-      targetEnd
-    );
+    this._d = transformRigidPath(source.d, sourceStart, sourceEnd, targetStart, targetEnd);
     this.externalLines = this.transformVisualLines(
       source.externalLines,
       sourceStart,
@@ -278,9 +268,7 @@ export class RealLink extends Link {
   }
 
   getCompoundPathString(): string {
-    const linkSubset = this.subset.filter(
-      (link): link is RealLink => link instanceof RealLink
-    );
+    const linkSubset = this.subset.filter((link): link is RealLink => link instanceof RealLink);
     linkSubset.forEach((link) => link.reComputeDPath());
     const geometry = buildCompoundPath(
       linkSubset.map((link) => link.d),
@@ -750,7 +738,16 @@ export class RealLink extends Link {
   }
 }
 
-export class Piston extends Link {
+/**
+ * The body a slider rides on: a zero-length link joining a PrisJoint to the
+ * coincident RevJoint that the sliding link pins to. It is a real body so it can
+ * carry mass and take reaction forces, but it has no extent of its own.
+ *
+ * Named for the block, not the actuator — a hydraulic piston is a different
+ * concept built from a prismatic joint, and reusing the word for both would make
+ * the codebase ambiguous.
+ */
+export class SliderBlock extends Link {
   constructor(id: string, joints: Joint[], mass?: number) {
     super(id, joints, mass);
   }

--- a/src/app/model/mechanism/force-analysis.spec.ts
+++ b/src/app/model/mechanism/force-analysis.spec.ts
@@ -1,7 +1,7 @@
 import { Coord } from '../coord';
 import { Force } from '../force';
 import { PrisJoint, RevJoint } from '../joint';
-import { Piston, RealLink } from '../link';
+import { SliderBlock, RealLink } from '../link';
 import { ColorService } from '../../services/color.service';
 import { SettingsService } from '../../services/settings.service';
 import { buildMechanism } from '../../../test-utils/verification/fixture';
@@ -78,13 +78,7 @@ function expectOk(frame: ForceAnalysisFrame): void {
 describe('ForceSolver physical model', () => {
   it('balances one open rigid body under gravity and an applied load', () => {
     const model = singleBody('m');
-    const result = ForceSolver.analyzeFrame(
-      model.joints,
-      model.links,
-      'static',
-      true,
-      'm'
-    );
+    const result = ForceSolver.analyzeFrame(model.joints, model.links, 'static', true, 'm');
     expectOk(result);
     expect(result.jointReactions.get('A')![0]).toBeCloseTo(0, 10);
     expect(result.jointReactions.get('A')![1]).toBeCloseTo(29.6133, 4);
@@ -121,22 +115,13 @@ describe('ForceSolver physical model', () => {
       true,
       'm'
     );
-    const weldedResult = ForceSolver.analyzeFrame(
-      welded.joints,
-      welded.links,
-      'static',
-      true,
-      'm'
-    );
+    const weldedResult = ForceSolver.analyzeFrame(welded.joints, welded.links, 'static', true, 'm');
     expectOk(unsplitResult);
     expectOk(weldedResult);
     expect(weldedResult.jointReactions.get('A')).toEqual(
       expect.arrayContaining(unsplitResult.jointReactions.get('A')!)
     );
-    expect(weldedResult.inputEffort!.valueSI).toBeCloseTo(
-      unsplitResult.inputEffort!.valueSI,
-      12
-    );
+    expect(weldedResult.inputEffort!.valueSI).toBeCloseTo(unsplitResult.inputEffort!.valueSI, 12);
   });
 
   it('adds centripetal inertia dynamically and scales it with speed squared', () => {
@@ -150,10 +135,7 @@ describe('ForceSolver physical model', () => {
     expectOk(fast);
     expect(slow.jointReactions.get('A')![0]).toBeCloseTo(-2, 5);
     expect(fast.jointReactions.get('A')![0]).toBeCloseTo(-8, 5);
-    expect(fast.jointReactions.get('A')![0] / slow.jointReactions.get('A')![0]).toBeCloseTo(
-      4,
-      5
-    );
+    expect(fast.jointReactions.get('A')![0] / slow.jointReactions.get('A')![0]).toBeCloseTo(4, 5);
   });
 
   it('makes zero-speed dynamic equilibrium identical to static equilibrium', () => {
@@ -171,10 +153,7 @@ describe('ForceSolver physical model', () => {
       staticFrame.jointReactions.get('A')![1],
       10
     );
-    expect(dynamicFrame.inputEffort!.valueSI).toBeCloseTo(
-      staticFrame.inputEffort!.valueSI,
-      10
-    );
+    expect(dynamicFrame.inputEffort!.valueSI).toBeCloseTo(staticFrame.inputEffort!.valueSI, 10);
   });
 
   it('balances binary and three-body pin reactions by root-link side', () => {
@@ -190,15 +169,7 @@ describe('ForceSolver physical model', () => {
     b.links = [bj];
     c.links = [cj];
     j.links = [aj, bj, cj];
-    const load = new Force(
-      'F1',
-      cj,
-      new Coord(0.5, 1),
-      new Coord(0.5, 0),
-      false,
-      true,
-      10
-    );
+    const load = new Force('F1', cj, new Coord(0.5, 1), new Coord(0.5, 0), false, true, 10);
     cj.forces = [load];
 
     const result = ForceSolver.analyzeFrame([a, b, c, j], [aj, bj, cj], 'static', false, 'm');
@@ -222,7 +193,7 @@ describe('ForceSolver physical model', () => {
     d.angle_rad = 0;
     const ab = new RealLink('AB', [a, b], 1, 1);
     const bc = new RealLink('BC', [b, c], 1, 1);
-    const piston = new Piston('CD', [c, d], 1);
+    const piston = new SliderBlock('CD', [c, d], 1);
     a.links = [ab];
     b.links = [ab, bc];
     c.links = [bc, piston];
@@ -309,9 +280,10 @@ describe('ForceSolver physical model', () => {
       (frame, index) => frame.status === 'ok' && baseResult.frames[index]?.status === 'ok'
     );
     expect(comparableIndex).toBeGreaterThanOrEqual(0);
-    expect(
-      extensionResult.frames[comparableIndex].inputEffort!.valueSI
-    ).not.toBeCloseTo(baseResult.frames[comparableIndex].inputEffort!.valueSI, 6);
+    expect(extensionResult.frames[comparableIndex].inputEffort!.valueSI).not.toBeCloseTo(
+      baseResult.frames[comparableIndex].inputEffort!.valueSI,
+      6
+    );
   });
 });
 

--- a/src/app/model/mechanism/force-solver.ts
+++ b/src/app/model/mechanism/force-solver.ts
@@ -1,16 +1,12 @@
 import { Joint, PrisJoint, RealJoint } from '../joint';
-import { Link, Piston, RealLink } from '../link';
+import { Link, SliderBlock, RealLink } from '../link';
 import { KinematicsSolver } from './kinematic-solver';
 import { siUnitFactors, SiUnitFactors } from '../unit-conversions';
 
 export type ForceAnalysisMode = 'static' | 'dynamic';
 
 export type ForceAnalysisStatus =
-  | 'ok'
-  | 'singular'
-  | 'unsupported-topology'
-  | 'missing-kinematics'
-  | 'invalid-properties';
+  'ok' | 'singular' | 'unsupported-topology' | 'missing-kinematics' | 'invalid-properties';
 
 export type ForceVector = [number, number];
 
@@ -231,7 +227,8 @@ export class ForceSolver {
     kinematics?: FrameKinematics
   ): ForceAnalysisFrame {
     const bodies = links.filter(
-      (link): link is RealLink | Piston => link instanceof RealLink || link instanceof Piston
+      (link): link is RealLink | SliderBlock =>
+        link instanceof RealLink || link instanceof SliderBlock
     );
     const units = this.unitFactors(unit);
     const empty = (
@@ -275,7 +272,7 @@ export class ForceSolver {
     if (inputJoint) {
       const incident = incidentByJoint.get(inputJoint.id) ?? [];
       if (inputJoint instanceof PrisJoint) {
-        inputBody = incident.find((body) => body instanceof Piston);
+        inputBody = incident.find((body) => body instanceof SliderBlock);
         inputKind = inputBody ? 'force' : undefined;
         inputDirection = [Math.cos(inputJoint.angle_rad), Math.sin(inputJoint.angle_rad)];
       } else {
@@ -474,7 +471,7 @@ export class ForceSolver {
       if (incident.length === 0) continue;
 
       if (candidate instanceof PrisJoint && candidate.ground) {
-        const piston = incident.find((body) => body instanceof Piston);
+        const piston = incident.find((body) => body instanceof SliderBlock);
         if (piston) {
           reactions.push({
             joint: candidate,
@@ -527,7 +524,8 @@ export class ForceSolver {
   /** Joint <-> root-body pairing that both analysis panels enumerate rows from. */
   static buildReactionIndex(joints: Joint[], links: Link[]): ForceReactionIndex {
     const bodies = links.filter(
-      (link): link is RealLink | Piston => link instanceof RealLink || link instanceof Piston
+      (link): link is RealLink | SliderBlock =>
+        link instanceof RealLink || link instanceof SliderBlock
     );
     const linksByJoint = new Map<string, string[]>();
     const jointsByLink = new Map<string, string[]>();
@@ -583,8 +581,7 @@ export class ForceSolver {
     kinematics?: FrameKinematics
   ): kinematics is FrameKinematics {
     if (!kinematics) return false;
-    const vectorFinite = (value?: ForceVector): boolean =>
-      !!value && value.every(Number.isFinite);
+    const vectorFinite = (value?: ForceVector): boolean => !!value && value.every(Number.isFinite);
     return bodies.every((body) => {
       if (body instanceof RealLink) {
         return (
@@ -620,7 +617,7 @@ export class ForceSolver {
           link.id,
           Number.isFinite(angular) ? angular! : fallback?.linkAngularAccelerations.get(link.id)!
         );
-      } else if (link instanceof Piston) {
+      } else if (link instanceof SliderBlock) {
         const movingJoint = link.joints.find((joint) => !(joint instanceof PrisJoint));
         const acceleration = movingJoint
           ? KinematicsSolver.jointAccMap.get(movingJoint.id)
@@ -662,7 +659,7 @@ export class ForceSolver {
       const positions = Array.from({ length: frameCount }, (_, index): ForceVector => {
         const body = bodyAt(index);
         if (body instanceof RealLink) return [body.CoM.x, body.CoM.y];
-        if (body instanceof Piston) {
+        if (body instanceof SliderBlock) {
           const moving = body.joints.find((joint) => !(joint instanceof PrisJoint));
           return [moving?.x ?? 0, moving?.y ?? 0];
         }
@@ -697,7 +694,7 @@ export class ForceSolver {
             id,
             this.secondDerivative(angles, times, index)
           );
-        } else if (body instanceof Piston) {
+        } else if (body instanceof SliderBlock) {
           frames[index].pistonAccelerations.set(id, [ax, ay]);
         }
       }
@@ -807,7 +804,10 @@ export class ForceSolver {
         0
       );
       residualNorm = Math.max(residualNorm, Math.abs(calculated - b[row]));
-      matrixNorm = Math.max(matrixNorm, A[row].reduce((sum, value) => sum + Math.abs(value), 0));
+      matrixNorm = Math.max(
+        matrixNorm,
+        A[row].reduce((sum, value) => sum + Math.abs(value), 0)
+      );
       rhsNorm = Math.max(rhsNorm, Math.abs(b[row]));
       solutionNorm = Math.max(solutionNorm, Math.abs(values[row]));
     }

--- a/src/app/model/mechanism/kinematic-solver.ts
+++ b/src/app/model/mechanism/kinematic-solver.ts
@@ -1,5 +1,5 @@
 import { Joint, PrisJoint, RealJoint } from '../joint';
-import { Piston, Link, RealLink } from '../link';
+import { SliderBlock, Link, RealLink } from '../link';
 import { matLinearSystem } from '../utils';
 import { InstantCenter } from '../instant-center';
 
@@ -164,7 +164,7 @@ export class KinematicsSolver {
         this.linkAngVelMap.set(links[this.inputLinkIndex].id, initialAngularVelocity);
         this.linkAngAccMap.set(links[this.inputLinkIndex].id, 0);
         break;
-      case Piston:
+      case SliderBlock:
         if (!this.realJointIndexMap.has(links[this.inputLinkIndex].id)) {
           const inputLink = links[this.inputLinkIndex];
           if (!(inputLink instanceof RealLink)) {
@@ -207,7 +207,7 @@ export class KinematicsSolver {
     }
 
     links.forEach((l) => {
-      if (l instanceof Piston) {
+      if (l instanceof SliderBlock) {
         return;
       }
       const angle = Math.atan2(l.joints[1].y - l.joints[0].y, l.joints[1].x - l.joints[0].x);
@@ -256,7 +256,7 @@ export class KinematicsSolver {
                 this.unknownLinkIndexMap.set(link.id, this.unknownLinkIndexMap.size);
               }
               break;
-            case Piston:
+            case SliderBlock:
               if (!this.realJointIndexMap.has(link.id)) {
                 const connectedJoint = link.joints.find((j) => j instanceof RealJoint)!;
                 // Match by id: the per-timestep joint arrays hold copies, so
@@ -357,7 +357,7 @@ export class KinematicsSolver {
     this.requiredLoops.forEach((loop) => {
       for (let i = 1; i < loop.length - 1; i++) {
         // cannot find velocity of a joint on an imaginary link
-        if (simLinks[this.linkIndexMap.get(loop[i] + loop[i - 1])!] instanceof Piston) {
+        if (simLinks[this.linkIndexMap.get(loop[i] + loop[i - 1])!] instanceof SliderBlock) {
           continue;
         }
         const desiredLink = simLinks[this.linkIndexMap.get(loop[i] + loop[i - 1])!];
@@ -427,7 +427,7 @@ export class KinematicsSolver {
               unknownLinksOrJoints.push(link);
             }
             break;
-          case Piston:
+          case SliderBlock:
             const desiredJoint = simJoints[this.realJointIndexMap.get(link.id)!];
             if (this.unknownLinkIndexMap.has(desiredJoint.id)) {
               unknownLinksOrJoints.push(desiredJoint);
@@ -488,7 +488,7 @@ export class KinematicsSolver {
                     0,
                   ]);
                   break;
-                case Piston:
+                case SliderBlock:
                   const realJoint = simJoints[this.realJointIndexMap.get(link.id)!];
                   // // slider crank x, y
                   // if (!(realJoint instanceof PrisJoint)) {
@@ -513,7 +513,7 @@ export class KinematicsSolver {
                   arr = this.crossProduct(1, [leftXDist, leftYDist, 0]);
                   colIndex = this.unknownLinkIndexMap.get(link.id)!;
                   break;
-                case Piston:
+                case SliderBlock:
                   const realJoint = simJoints[this.realJointIndexMap.get(link.id)!];
                   // if (!(realJoint instanceof PrisJoint)) {
                   //   return;
@@ -552,7 +552,7 @@ export class KinematicsSolver {
                   ]);
                   sol = this.addTwoArrays(transAccel, angularAccel);
                   break;
-                case Piston:
+                case SliderBlock:
                   const realJoint = simJoints[this.realJointIndexMap.get(link.id)!];
                   // if (!(realJoint instanceof PrisJoint)) {
                   //   return;
@@ -586,7 +586,7 @@ export class KinematicsSolver {
                   this.B_matrix_AngAcc[rowIndex + 1][0] += transAccel[1];
                   colIndex = this.unknownLinkIndexMap.get(link.id)!;
                   break;
-                case Piston:
+                case SliderBlock:
                   const realJoint = simJoints[this.realJointIndexMap.get(link.id)!];
                   // if (!(realJoint instanceof PrisJoint)) {
                   //   return;

--- a/src/app/model/mechanism/mechanism.ts
+++ b/src/app/model/mechanism/mechanism.ts
@@ -1,5 +1,5 @@
 import { Joint, PrisJoint, RealJoint, RevJoint } from '../joint';
-import { Link, Piston, RealLink, Shape } from '../link';
+import { Link, SliderBlock, RealLink, Shape } from '../link';
 import { Force } from '../force';
 // import {LoopSolver} from "./loop-solver";
 import { PositionSolver } from './position-solver';
@@ -62,11 +62,11 @@ export class Mechanism {
           this.restoreLinkSubsetState(l.subset, realLink.subset);
           this._links[0].push(realLink);
           break;
-        case Piston:
-          if (!(l instanceof Piston)) {
+        case SliderBlock:
+          if (!(l instanceof SliderBlock)) {
             return;
           }
-          const piston = new Piston(l.id, linkJoints, l.mass);
+          const piston = new SliderBlock(l.id, linkJoints, l.mass);
           piston.name = l.name;
           this._links[0].push(piston);
           break;
@@ -183,8 +183,8 @@ export class Mechanism {
         link.fill = source.fill;
         return [link];
       }
-      if (source instanceof Piston) {
-        const piston = new Piston(source.id, joints, source.mass);
+      if (source instanceof SliderBlock) {
+        const piston = new SliderBlock(source.id, joints, source.mass);
         piston.name = source.name;
         return [piston];
       }
@@ -425,15 +425,15 @@ export class Mechanism {
               this.restoreLinkSubsetState(l.subset, pushLink.subset);
               this._links[currentTimeStamp + 1].push(pushLink);
               break;
-            case Piston:
-              if (!(l instanceof Piston)) {
+            case SliderBlock:
+              if (!(l instanceof SliderBlock)) {
                 return;
               }
               // connectedJointIndices = connectedJointMapIndices.get(l.id)!;
               // connectedJointIndices.forEach((ji: number) => {
               //   connectedJoints.push(this._joints[currentTimeStamp + 1][ji]);
               // });
-              const newLink = new Piston(l.id, connectedJoints, l.mass);
+              const newLink = new SliderBlock(l.id, connectedJoints, l.mass);
               newLink.name = l.name;
               this._links[currentTimeStamp + 1].push(newLink);
               break;
@@ -774,7 +774,7 @@ export class Mechanism {
         });
         forceTitleRow.push(' ');
         this.links[0].forEach((l) => {
-          if (l instanceof Piston) {
+          if (l instanceof SliderBlock) {
             return;
           }
           forceTitleRow.push('Link ' + l.id + ' CoM x ' + posUnit);
@@ -786,7 +786,7 @@ export class Mechanism {
         });
         forceTitleRow.push(' ');
         this.links[0].forEach((l) => {
-          if (l instanceof Piston) {
+          if (l instanceof SliderBlock) {
             return;
           }
           // forceTitleRow.push('Link ' + l.id + ' angPos ' + angAccUnit);
@@ -884,7 +884,7 @@ export class Mechanism {
     });
     kinematicTitleRow.push(' ');
     this.links[0].forEach((l) => {
-      if (l instanceof Piston) {
+      if (l instanceof SliderBlock) {
         return;
       }
       // if (l instanceof ImagLink) {
@@ -899,7 +899,7 @@ export class Mechanism {
     });
     kinematicTitleRow.push(' ');
     this.links[0].forEach((l) => {
-      if (l instanceof Piston) {
+      if (l instanceof SliderBlock) {
         return;
       }
       // if (l instanceof ImagLink) {
@@ -1099,7 +1099,7 @@ export class Mechanism {
           });
           force_row.push(' ');
           this.links[index].forEach((l) => {
-            if (l instanceof Piston) {
+            if (l instanceof SliderBlock) {
               return;
             }
             force_row.push(
@@ -1143,7 +1143,7 @@ export class Mechanism {
           });
           force_row.push(' ');
           this.links[index].forEach((l) => {
-            if (l instanceof Piston) {
+            if (l instanceof SliderBlock) {
               return;
             }
             force_row.push(roundNumber(KinematicsSolver.linkAngPosMap.get(l.id)!, 4).toString());
@@ -1251,7 +1251,7 @@ export class Mechanism {
       });
       row.push(' ');
       this.links[0].forEach((l) => {
-        if (l instanceof Piston) {
+        if (l instanceof SliderBlock) {
           return;
         }
         // if (l instanceof ImagLink) {
@@ -1284,7 +1284,7 @@ export class Mechanism {
       });
       row.push(' ');
       this.links[0].forEach((l) => {
-        if (l instanceof Piston) {
+        if (l instanceof SliderBlock) {
           return;
         }
         // if (l instanceof ImagLink) {

--- a/src/app/model/mechanism/position-solver.ts
+++ b/src/app/model/mechanism/position-solver.ts
@@ -34,8 +34,10 @@ export class PositionSolver {
   private static desiredAnalysisJointMap = new Map<string, string>();
   private static jointDistMap = new Map<string, number>();
   private static initialJointPosMap = new Map<string, [number, number]>();
-  private static m_Map = new Map<string, number>();
-  private static b_Map = new Map<string, number>();
+  /** A point on each sliding joint's slot line. */
+  private static slotPointMap = new Map<string, [number, number]>();
+  /** Unit direction of each sliding joint's slot line. */
+  private static slotDirectionMap = new Map<string, [number, number]>();
   static forcePositionMap = new Map<string, Coord>();
   static forceMagnitudeMap = new Map<string, number>();
 
@@ -53,8 +55,8 @@ export class PositionSolver {
     this.desiredAnalysisJointMap = new Map<string, string>();
     this.jointDistMap = new Map<string, number>();
     this.initialJointPosMap = new Map<string, [number, number]>();
-    this.m_Map = new Map<string, number>();
-    this.b_Map = new Map<string, number>();
+    this.slotPointMap = new Map<string, [number, number]>();
+    this.slotDirectionMap = new Map<string, [number, number]>();
   }
 
   static determineJointOrder(joints: Joint[], links: Link[]) {
@@ -172,8 +174,7 @@ export class PositionSolver {
           cur_joint.id + ',' + prevJoint.id,
           euclideanDistance(cur_joint.x, cur_joint.y, prevJoint.x, prevJoint.y)
         );
-        this.m_Map.set(cur_joint.id, Math.tan(sliderJoint.angle_rad));
-        this.b_Map.set(cur_joint.id, cur_joint.y - this.m_Map.get(cur_joint.id)! * cur_joint.x);
+        this.setSlot(cur_joint.id, cur_joint.x, cur_joint.y, sliderJoint.angle_rad);
         // Like the revolute branch below, the solved slider joint becomes a
         // known joint and its other neighbors still need solve orders --
         // otherwise a tracer point on the slider's link can never resolve.
@@ -215,11 +216,7 @@ export class PositionSolver {
               tracer_joint.id + ',' + tracer_joint.id,
               euclideanDistance(tracer_joint.x, tracer_joint.y, cur_joint.x, cur_joint.y)
             );
-            this.m_Map.set(tracer_joint.id, Math.tan(tracer_joint.angle_rad));
-            this.b_Map.set(
-              tracer_joint.id,
-              tracer_joint.y - this.m_Map.get(tracer_joint.id)! * tracer_joint.x
-            );
+            this.setSlot(tracer_joint.id, tracer_joint.x, tracer_joint.y, tracer_joint.angle_rad);
             return;
           }
           const desired_link = links.find((l) => {
@@ -517,144 +514,57 @@ export class PositionSolver {
     return circleCircleIntersection(x0, y0, r0, x1, y1, r1);
   }
 
-  // https://cscheng.info/2016/06/09/calculate-circle-line-intersection-with-javascript-and-p5js.html
+  /**
+   * Place a joint that rides a slot: it sits where the slot line meets a circle
+   * of the connecting link's length about an already-solved joint.
+   *
+   * Both roots are on the slot and both satisfy the link length, so they are
+   * the linkage's two assembly modes. The branch is chosen once, by whichever
+   * root the joint started nearest, and then held.
+   */
   private static circleLineIntersectionPoints(j1: Joint, j2: Joint, unknownJoint: Joint) {
+    const solutions = this.slotSolutions(j1, unknownJoint);
+    if (!solutions) {
+      return false;
+    }
+
     if (!this.desiredIndexWithinPosAnalysisMap.has(unknownJoint.id)) {
+      const initial = this.initialJointPosMap.get(unknownJoint.id)!;
+      const distanceToInitial = (point: [number, number]) =>
+        Math.hypot(point[0] - initial[0], point[1] - initial[1]);
       this.desiredIndexWithinPosAnalysisMap.set(
         unknownJoint.id,
-        this.determineDesiredIndexCircleLineIntersection(j1, j2, unknownJoint)
+        distanceToInitial(solutions[0]) <= distanceToInitial(solutions[1]) ? 0 : 1
       );
     }
-    const desiredIndex = this.desiredIndexWithinPosAnalysisMap.get(unknownJoint.id);
-    const [a, b, c, d] = this.circleLineIntersectionMethod(j1, j2, unknownJoint);
-    let x,
-      y,
-      r,
-      curr_known_x,
-      curr_unknown_y,
-      curr_unknown_x,
-      a_temp,
-      b_temp,
-      c_temp,
-      curr_known_y,
-      d_temp,
-      y_1,
-      y_2: number;
-    if (isNaN(d) || !isFinite(d)) {
-      r = this.jointDistMap.get(unknownJoint.id + ',' + j1.id)!;
-      curr_known_x = this.jointMapPositions.get(j1.id)![0];
-      // const curr_unknown_x = this.jointMapPositions.get(unknownJoint.id)[0];
-      curr_unknown_x = unknownJoint.x;
-      curr_known_y = this.jointMapPositions.get(j1.id)![1];
-      curr_unknown_y = unknownJoint.y;
-      // const curr_unknown_y = this.jointMapPositions.get(unknownJoint.id)[1];
-      a_temp = 1;
-      b_temp = -2 * curr_known_y;
-      c_temp =
-        Math.pow(curr_known_y, 2) + Math.pow(curr_known_x - curr_unknown_x, 2) - Math.pow(r, 2);
-      d_temp = Math.pow(b_temp, 2) - 4 * a_temp * c_temp;
-      // utilize quadratic formula to solve for both y values
-      if (d_temp < 0) {
-        return false;
-      }
-      y_1 = (-b_temp + Math.sqrt(Math.pow(b_temp, 2) - 4 * a_temp * c_temp)) / (2 * a_temp);
-      y_2 = (-b_temp - Math.sqrt(Math.pow(b_temp, 2) - 4 * a_temp * c_temp)) / (2 * a_temp);
 
-      // y_1 = Math.abs((-b_temp + Math.sqrt(Math.pow(b_temp, 2) - (4 * a_temp * c_temp))) / (2 * a_temp));
-      // y_2 = Math.abs((-b_temp - Math.sqrt(Math.pow(b_temp, 2) - (4 * a_temp * c_temp))) / (2 * a_temp));
-      // determine which y is closer and use this y value
-      if (Math.abs(curr_unknown_y - y_1) <= Math.abs(curr_unknown_y - y_2)) {
-        y = y_1;
-      } else {
-        y = y_2;
-      }
-      x = curr_unknown_x;
-    } else {
-      if (d >= 0) {
-        const sign = desiredIndex === 0 ? 1 : -1;
-        x = (-b + sign * Math.sqrt(Math.pow(b, 2) - 4 * a * c)) / (2 * a);
-        const vertical_line = (90 * Math.PI) / 180;
-        const horizontal_line = (180 * Math.PI) / 180;
-        // TODO: Have map for determining m
-        // const m = Math.tan(unknownJoint.angle);
-        const m = this.m_Map.get(unknownJoint.id)!;
-        // TODO: have map for determining b_intersection
-        const b_intersect = this.b_Map.get(unknownJoint.id)!;
-        // const b_intersect = unknownJoint.yInitial - m * unknownJoint.xInitial;
-        y = m * x + b_intersect;
-      } else {
-        return false;
-      }
-    }
-    // const y = Math.tan(unknownJoint.angle) * unknownJoint.x + unknownJoint.y;
+    // TODO (Phase 2): a held index is not safe through a tangency, where the two
+    // roots merge and trade places -- the same failure solutionNearestCurrent
+    // fixes for the circle-circle case. Preserved as-is here so this rewrite
+    // changes only the line representation.
+    const [x, y] = solutions[this.desiredIndexWithinPosAnalysisMap.get(unknownJoint.id)!];
     this.jointMapPositions.set(unknownJoint.id, [roundNumber(x, 4), roundNumber(y, 4)]);
     this.jointMapPositions.set(j2.id, [roundNumber(x, 4), roundNumber(y, 4)]);
     return true;
   }
 
-  private static determineDesiredIndexCircleLineIntersection(
-    j1: Joint,
-    j2: Joint,
-    unknownJoint: Joint
-  ) {
-    const [a, b, c, _] = this.circleLineIntersectionMethod(j1, j2, unknownJoint);
-    // const x_1 = Math.abs((-b + Math.sqrt(Math.pow(b, 2) - (4 * a * c))) / (2 * a));
-    // const x_2 = Math.abs((-b - Math.sqrt(Math.pow(b, 2) - (4 * a * c))) / (2 * a));
-    const x_1 = (-b + Math.sqrt(Math.pow(b, 2) - 4 * a * c)) / (2 * a);
-    const x_2 = (-b - Math.sqrt(Math.pow(b, 2) - 4 * a * c)) / (2 * a);
-    // TODO: have map for determining m
-    const m = this.m_Map.get(unknownJoint.id)!;
-    // const m = Math.sin(unknownJoint.angle) / Math.cos(unknownJoint.angle);
-    // TODO: have map for determining b_intersect
-    const b_intersect = this.b_Map.get(unknownJoint.id)!;
-    // const b_intersect = unknownJoint.yInitial - m * unknownJoint.xInitial;
-    const y_1 = m * x_1 + b_intersect;
-    const y_2 = m * x_2 + b_intersect;
-    const intersection1Diff = Math.sqrt(
-      Math.pow(x_1 - this.initialJointPosMap.get(unknownJoint.id)![0], 2) +
-        Math.pow(y_1 - this.initialJointPosMap.get(unknownJoint.id)![1], 2)
-    );
-    const intersection2Diff = Math.sqrt(
-      Math.pow(x_2 - this.initialJointPosMap.get(unknownJoint.id)![0], 2) +
-        Math.pow(y_2 - this.initialJointPosMap.get(unknownJoint.id)![1], 2)
-    );
-    return intersection1Diff < intersection2Diff ? 0 : 1;
+  /** Intersections of the joint's slot line with the circle centred on `j1`. */
+  private static slotSolutions(j1: Joint, unknownJoint: Joint): [number, number][] | undefined {
+    const radius = this.jointDistMap.get(unknownJoint.id + ',' + j1.id)!;
+    const [centreX, centreY] = this.jointMapPositions.get(j1.id)!;
+    const [pointX, pointY] = this.slotPointMap.get(unknownJoint.id)!;
+    const [dirX, dirY] = this.slotDirectionMap.get(unknownJoint.id)!;
+    return circleLineIntersection(radius, centreX, centreY, pointX, pointY, dirX, dirY);
   }
 
-  private static circleLineIntersectionMethod(j1: Joint, j2: Joint, unknownJoint: Joint) {
-    // circle: (x - h)^2 + (y - k)^2 = r^2
-    // line: y = m * x + n
-    // r: circle radius
-    // const unknown_joint_x = this.jointMapPositions.get(unknownJoint.id)[0];
-    // const unknown_joint_y = this.jointMapPositions.get(unknownJoint.id)[1];
-    // const j1_x = this.jointMapPositions.get(j1.id)[0];
-    // const j1_y = this.jointMapPositions.get(j1.id)[1];
-    // const r = Math.sqrt(Math.pow(unknown_joint_x - j1_x, 2) + Math.pow(unknown_joint_y - j1_y, 2));
-    const r = this.jointDistMap.get(unknownJoint.id + ',' + j1.id)!;
-    // h: x value of circle centre
-    // const h = j1.x;
-    const h = this.jointMapPositions.get(j1.id)![0];
-    // k: y value of circle centre
-    // const k = j1.y;
-    const k = this.jointMapPositions.get(j1.id)![1];
-    // m: slope
-    // const radToDeg = 180 / Math.PI;
-    // TODO: Have map for determining m
-    let m = this.m_Map.get(unknownJoint.id)!;
-    // let m = Math.tan(unknownJoint.angle);
-    if (m > 1000 || m < -1000) {
-      m = Number.MAX_VALUE;
-    }
-    // const m = (Math.round(unknownJoint.angle * radToDeg) % 90  === 0 && Math.round(unknownJoint.angle * radToDeg) % 180 !== 0) ?
-    //   99999999999 : Math.tan(unknownJoint.angle);
-    // const m = Math.tan(unknownJoint.angle);
-    // n: y-intercept
-    // const n = unknown_joint_y - m * unknown_joint_x;
-    // TODO: Have map for determining n
-    // const n = this.n_Map.get(unknownJoint.id);
-    // const n = unknownJoint.yInitial - m * unknownJoint.xInitial;
-    const n = this.b_Map.get(unknownJoint.id)!;
-    return circleLineIntersection(r, h, k, m, n);
+  /**
+   * Record the slot a joint slides along: a point it passes through and a unit
+   * direction. Stored as a direction rather than a slope so that vertical and
+   * near-vertical guides need no special case.
+   */
+  private static setSlot(jointID: string, throughX: number, throughY: number, angleRad: number) {
+    this.slotPointMap.set(jointID, [throughX, throughY]);
+    this.slotDirectionMap.set(jointID, [Math.cos(angleRad), Math.sin(angleRad)]);
   }
 
   // https://www.mathsisfun.com/algebra/trig-solving-sss-triangles.html

--- a/src/app/model/utils.ts
+++ b/src/app/model/utils.ts
@@ -1175,23 +1175,46 @@ export function circleCircleIntersection(
 }
 
 // https://cscheng.info/2016/06/09/calculate-circle-line-intersection-with-javascript-and-p5js.html
-export function circleLineIntersection(r: number, h: number, k: number, m: number, n: number) {
-  // circle: (x - h)^2 + (y - k)^2 = r^2
-  // line: y = m * x + n
-  // r: circle radius
-  // h: x value of circle centre
-  // k: y value of circle centre
-  // m: slope
-  // n: y-intercept
+/**
+ * Where a circle meets a line, with the line given as a point and a direction
+ * rather than a slope.
+ *
+ * Slope-intercept (`y = m*x + n`) cannot represent a vertical line at all, and
+ * degrades well before it: `m = tan(angle)` grows without bound near vertical,
+ * so a guide a fraction of a degree off vertical produces a slope large enough
+ * to swamp the other terms. The parametric form has no special direction -- a
+ * vertical line is as ordinary as any other.
+ *
+ * `pointX`/`pointY` is any point the line passes through; `dirX`/`dirY` must be
+ * a unit vector, which makes the quadratic's leading coefficient exactly 1.
+ * Returns both intersection points, or `undefined` when the line misses the
+ * circle. A tangent line returns the same point twice.
+ */
+export function circleLineIntersection(
+  r: number,
+  h: number,
+  k: number,
+  pointX: number,
+  pointY: number,
+  dirX: number,
+  dirY: number
+): [number, number][] | undefined {
+  // Substituting `P + t*u` into `(x - h)^2 + (y - k)^2 = r^2` gives
+  // `t^2 + 2(d.u)t + (|d|^2 - r^2) = 0`, where `d = P - centre`.
+  const dx = pointX - h;
+  const dy = pointY - k;
+  const b = 2 * (dx * dirX + dy * dirY);
+  const c = dx * dx + dy * dy - r * r;
 
-  // get a, b, c values
-  const a = 1 + Math.pow(m, 2);
-  const b = -h * 2 + m * (n - k) * 2;
-  const c = Math.pow(h, 2) + Math.pow(n - k, 2) - Math.pow(r, 2);
+  const discriminant = b * b - 4 * c;
+  if (discriminant < 0 || !Number.isFinite(discriminant)) {
+    return undefined;
+  }
 
-  // get discriminant
-  const d = Math.pow(b, 2) - 4 * a * c;
-  return [a, b, c, d];
+  const root = Math.sqrt(discriminant);
+  return [(-b + root) / 2, (-b - root) / 2].map(
+    (t) => [pointX + t * dirX, pointY + t * dirY] as [number, number]
+  );
 }
 
 // https://dirask.com/posts/JavaScript-calculate-intersection-point-of-two-lines-for-given-4-points-VjvnAj

--- a/src/app/services/grid-utils.service.ts
+++ b/src/app/services/grid-utils.service.ts
@@ -12,7 +12,7 @@ import {
   getDistance,
   point_on_line_segment_closest_to_point,
 } from '../model/utils';
-import { Link, Piston, RealLink } from '../model/link';
+import { Link, SliderBlock, RealLink } from '../model/link';
 import { MechanismService } from './mechanism.service';
 import { ToolbarComponent } from '../component/toolbar/toolbar.component';
 import { Mechanism } from '../model/mechanism/mechanism';
@@ -32,7 +32,10 @@ import { ColorService } from './color.service';
   providedIn: 'root',
 })
 export class GridUtilsService {
-  constructor(private synthesisBuilder: SynthesisBuilderService, public svgGrid: SvgGridService) {}
+  constructor(
+    private synthesisBuilder: SynthesisBuilderService,
+    public svgGrid: SvgGridService
+  ) {}
 
   //Return a boolean, is this link a ground link?
   getGround(joint: Joint) {
@@ -106,7 +109,7 @@ export class GridUtilsService {
     switch (link.constructor) {
       case RealLink:
         return 'R';
-      case Piston:
+      case SliderBlock:
         return 'P';
       default:
         return '?';
@@ -129,7 +132,7 @@ export class GridUtilsService {
     switch (selectedJoint.constructor) {
       case RevJoint:
         selectedJoint.links.forEach((l) => {
-          if (l instanceof Piston) {
+          if (l instanceof SliderBlock) {
             //If the joint is a slider, then the joint is the second joint in the link must follow the first joint
             const jointIndex = l.joints.findIndex((jt) => jt.id !== selectedJoint.id);
             l.joints[jointIndex].x = roundNumber(trueCoord.x, 6);

--- a/src/app/services/mechanism.service.spec.ts
+++ b/src/app/services/mechanism.service.spec.ts
@@ -2,7 +2,7 @@ import '../model/joint';
 import { Injector } from '@angular/core';
 import { Coord } from '../model/coord';
 import { Force } from '../model/force';
-import { Piston, RealLink } from '../model/link';
+import { SliderBlock, RealLink } from '../model/link';
 import { PrisJoint, RealJoint, RevJoint } from '../model/joint';
 import { LengthUnit } from '../model/unit-enums';
 import { ActiveObjService } from './active-obj.service';
@@ -169,7 +169,7 @@ describe('MechanismService welded links and force ownership', () => {
   it('preserves piston connectivity when rebuilding after a weld', () => {
     const harness = createChain();
     const slider = new PrisJoint('P', 2, 0, false, true);
-    const piston = new Piston('CP', [harness.joints[2], slider]);
+    const piston = new SliderBlock('CP', [harness.joints[2], slider]);
     harness.joints[2].links.push(piston);
     harness.joints[2].connectedJoints.push(slider);
     slider.links.push(piston);
@@ -210,10 +210,7 @@ describe('MechanismService welded links and force ownership', () => {
 
     expect(harness.joints[1].x).toBeCloseTo(0.01 / 0.0254, 12);
     expect(link.mass).toBeCloseTo(0.002 / 0.45359237, 12);
-    expect(link.massMoI).toBeCloseTo(
-      0.0003 / (0.45359237 * 0.0254 * 0.0254),
-      12
-    );
+    expect(link.massMoI).toBeCloseTo(0.0003 / (0.45359237 * 0.0254 * 0.0254), 12);
     // Force converts N -> lbf as the exact reciprocal of NEWTONS_PER_LBF.
     expect(force.mag).toBeCloseTo(10 / 4.4482216152605, 12);
     expect(harness.saveCount()).toBe(2);

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Injector } from '@angular/core';
 import { Joint, PrisJoint, RealJoint, RevJoint } from '../model/joint';
-import { Link, Piston, RealLink } from '../model/link';
+import { Link, SliderBlock, RealLink } from '../model/link';
 import { Force } from '../model/force';
 import { Mechanism } from '../model/mechanism/mechanism';
 import { ToolbarComponent } from '../component/toolbar/toolbar.component';
@@ -266,7 +266,7 @@ export class MechanismService {
   }
 
   getLinkProp(l: Link, propType: string) {
-    if (l instanceof Piston) {
+    if (l instanceof SliderBlock) {
       return;
     }
     const link = l as RealLink;
@@ -731,7 +731,7 @@ export class MechanismService {
         }
       }
 
-      if (l instanceof Piston) {
+      if (l instanceof SliderBlock) {
         //Special case, remove the other joint on a pistion
         l.joints.forEach((j) => {
           if (j.id !== this.activeObjService.selectedJoint.id) {
@@ -953,7 +953,7 @@ export class MechanismService {
         );
         j.connectedJoints.splice(removeIndex, 1);
       });
-      const piston = this.links.find((l) => l instanceof Piston)!;
+      const piston = this.links.find((l) => l instanceof SliderBlock)!;
       piston.joints.forEach((j) => {
         if (!(j instanceof RealJoint)) {
           return;
@@ -1040,7 +1040,7 @@ export class MechanismService {
         connectedJoints
       );
       this.activeObjService.selectedJoint.connectedJoints.push(prisJoint);
-      const piston = new Piston(this.activeObjService.selectedJoint.id + prisJoint.id, [
+      const piston = new SliderBlock(this.activeObjService.selectedJoint.id + prisJoint.id, [
         this.activeObjService.selectedJoint,
         prisJoint,
       ]);
@@ -1050,7 +1050,9 @@ export class MechanismService {
       this.links.push(piston);
     } else {
       // delete Prismatic Joint
-      const piston = this.activeObjService.selectedJoint.links.find((l) => l instanceof Piston)!;
+      const piston = this.activeObjService.selectedJoint.links.find(
+        (l) => l instanceof SliderBlock
+      )!;
       const pistonIndex = this.links.findIndex((l) => l.id === piston.id);
       const prismaticJointID = piston.joints.find((j) => j instanceof PrisJoint)!.id;
       this.activeObjService.selectedJoint.connectedJoints =

--- a/src/app/services/transcoding/mechanism-builder.ts
+++ b/src/app/services/transcoding/mechanism-builder.ts
@@ -1,10 +1,17 @@
 import { Joint, PrisJoint, RealJoint, RevJoint } from 'src/app/model/joint';
 import { MechanismService } from '../mechanism.service';
-import { Link, Piston, RealLink } from 'src/app/model/link';
+import { Link, SliderBlock, RealLink } from 'src/app/model/link';
 import { Force } from 'src/app/model/force';
 import { Coord } from 'src/app/model/coord';
 import { GenericTranscoder } from './transcoder-interface';
-import { ACTIVE_TYPE, ForceData, JOINT_TYPE, JointData, LINK_TYPE, LinkData } from './transcoder-data';
+import {
+  ACTIVE_TYPE,
+  ForceData,
+  JOINT_TYPE,
+  JointData,
+  LINK_TYPE,
+  LinkData,
+} from './transcoder-data';
 import { SettingsService } from '../settings.service';
 import { AngleUnit, ForceUnit, GlobalUnit, LengthUnit } from 'src/app/model/utils';
 import { BoolSetting, DecimalSetting, EnumSetting, IntSetting } from './stored-settings';
@@ -73,8 +80,8 @@ export class MechanismBuilder {
   // The link starts off with no forces, to be added as forces are created
   private buildLink(linkData: LinkData, joints: Joint[]): Link {
     // For each joint id of the link, find the associated joint object
-    let jointsOnLink: Joint[] = linkData.jointIDs.map(
-      (jointID) => this.getJointByID(joints, jointID)!
+    let jointsOnLink: Joint[] = linkData.jointIDs.map((jointID) =>
+      this.getJointByID(joints, jointID)!
     );
 
     // For each revolute joint on the link, link it to every other joint
@@ -91,7 +98,7 @@ export class MechanismBuilder {
       link = new RealLink(linkData.id, jointsOnLink, linkData.mass, linkData.massMoI, CoM);
       link.fill = linkData.color;
     } else {
-      link = new Piston(linkData.id, jointsOnLink, linkData.mass);
+      link = new SliderBlock(linkData.id, jointsOnLink, linkData.mass);
     }
 
     // for all joints in link, connect to link
@@ -218,7 +225,8 @@ export class MechanismBuilder {
     // set active object
     let activeObjData = this.transcoder.getActiveObj();
     let activeObj: any;
-    if (activeObjData.type === ACTIVE_TYPE.JOINT) activeObj = this.getJointByID(joints, activeObjData.id)!;
+    if (activeObjData.type === ACTIVE_TYPE.JOINT)
+      activeObj = this.getJointByID(joints, activeObjData.id)!;
     else if (activeObjData.type === ACTIVE_TYPE.LINK)
       activeObj = links.find(
         (link) =>
@@ -249,7 +257,9 @@ export class MechanismBuilder {
       const normalizedForce =
         normalizedGlobal === GlobalUnit.ENGLISH ? ForceUnit.LBF : ForceUnit.NEWTON;
       this.settings.lengthUnit.next(decodedLength);
-      this.settings.angleUnit.next(this.transcoder.getEnumSetting(EnumSetting.ANGLE_UNIT, AngleUnit));
+      this.settings.angleUnit.next(
+        this.transcoder.getEnumSetting(EnumSetting.ANGLE_UNIT, AngleUnit)
+      );
       this.settings.forceUnit.next(normalizedForce);
       this.settings.globalUnit.next(normalizedGlobal);
       this.settings.isInputCW.next(this.transcoder.getBoolSetting(BoolSetting.IS_INPUT_CW));
@@ -264,7 +274,6 @@ export class MechanismBuilder {
       this.settings.isShowID.next(this.transcoder.getBoolSetting(BoolSetting.IS_SHOW_ID));
       this.settings.isShowCOM.next(this.transcoder.getBoolSetting(BoolSetting.IS_SHOW_COM));
       SettingsService._objectScale.next(this.transcoder.getDecimalSetting(DecimalSetting.SCALE));
-    
     }
 
     this.mechanism.mechanismTimeStep = this.transcoder.getIntSetting(IntSetting.TIMESTEP);

--- a/src/app/services/url-generation.service.ts
+++ b/src/app/services/url-generation.service.ts
@@ -1,32 +1,42 @@
 import { Injectable } from '@angular/core';
 import { MechanismService } from './mechanism.service';
-import { Link, Piston, RealLink } from '../model/link';
+import { Link, SliderBlock, RealLink } from '../model/link';
 import { LengthUnit, AngleUnit, ForceUnit, GlobalUnit } from '../model/utils';
-import { EnumSetting, BoolSetting, IntSetting, DecimalSetting } from './transcoding/stored-settings';
+import {
+  EnumSetting,
+  BoolSetting,
+  IntSetting,
+  DecimalSetting,
+} from './transcoding/stored-settings';
 import { StringTranscoder } from './transcoding/string-transcoder';
 import { Force } from '../model/force';
 import { Joint, RevJoint, PrisJoint } from '../model/joint';
-import { JointData, JOINT_TYPE, LinkData, LINK_TYPE, ForceData, ActiveObjData, ACTIVE_TYPE } from './transcoding/transcoder-data';
+import {
+  JointData,
+  JOINT_TYPE,
+  LinkData,
+  LINK_TYPE,
+  ForceData,
+  ActiveObjData,
+  ACTIVE_TYPE,
+} from './transcoding/transcoder-data';
 import { SettingsService } from './settings.service';
 import { ActiveObjService } from './active-obj.service';
 
 /*
-  * This service is responsible for generating the URL from the current mechanism.
-  * It is not responsible for decoding the URL.
-*/
+ * This service is responsible for generating the URL from the current mechanism.
+ * It is not responsible for decoding the URL.
+ */
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class UrlGenerationService {
-
-
   constructor(
     private mechanism: MechanismService,
     private settings: SettingsService,
-    private activeObj: ActiveObjService,
+    private activeObj: ActiveObjService
   ) {}
-
 
   _addJointToEncoder(encoder: StringTranscoder, joint: Joint) {
     if (joint instanceof RevJoint) {
@@ -79,7 +89,7 @@ export class UrlGenerationService {
           link.subset.map((subset) => subset.id)
         )
       );
-    } else if (link instanceof Piston) {
+    } else if (link instanceof SliderBlock) {
       encoder.addLink(
         new LinkData(
           isRoot,
@@ -163,11 +173,7 @@ export class UrlGenerationService {
       ForceUnit,
       normalizedGlobal === GlobalUnit.ENGLISH ? ForceUnit.LBF : ForceUnit.NEWTON
     );
-    encoder.addEnumSetting(
-      EnumSetting.GLOBAL_UNIT,
-      GlobalUnit,
-      normalizedGlobal
-    );
+    encoder.addEnumSetting(EnumSetting.GLOBAL_UNIT, GlobalUnit, normalizedGlobal);
     encoder.addBoolSetting(BoolSetting.IS_INPUT_CW, this.settings.isInputCW.getValue());
     //encoder.addBoolSetting(BoolSetting.IS_GRAVITY, this.settings.isGravity.getValue());
     encoder.addIntSetting(IntSetting.INPUT_SPEED, this.settings.inputSpeed.getValue());
@@ -184,7 +190,7 @@ export class UrlGenerationService {
     encoder.addDecimalSetting(DecimalSetting.SCALE, this.settings.objectScale);
 
     encoder.addIntSetting(IntSetting.TIMESTEP, cachedAnimationFrame);
-    
+
     // Keep this legacy bit enabled so existing URL field positions remain compatible.
     encoder.addBoolSetting(BoolSetting.IS_FORCES, true);
 
@@ -227,5 +233,4 @@ export class UrlGenerationService {
     const dataURL = encodeURI(dataURLString);
     return dataURL;
   }
-
 }

--- a/src/app/services/url-processor.service.ts
+++ b/src/app/services/url-processor.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Injector } from '@angular/core';
 import { stringToBoolean, stringToFloat, stringToShape } from '../model/utils';
 import { Joint, PrisJoint, RealJoint, RevJoint } from '../model/joint';
-import { Bound, Link, Piston, RealLink } from '../model/link';
+import { Bound, Link, SliderBlock, RealLink } from '../model/link';
 import { Coord } from '../model/coord';
 import { Force } from '../model/force';
 import { MechanismService } from './mechanism.service';
@@ -23,7 +23,6 @@ export class UrlProcessorService {
     private activeObj: ActiveObjService,
     private snackBar: MatSnackBar
   ) {
-
     // the content part of the url (the part after the ?)
     const url = this.getURLContent();
 
@@ -33,7 +32,6 @@ export class UrlProcessorService {
     // initial save
     // this causes a circular dependency
     // this.mechanismSrv.save();
-
   }
 
   // From the full url string, extract the substring after the '?'. If does not exist, return null
@@ -46,14 +44,17 @@ export class UrlProcessorService {
   }
 
   // Decode the url and update mechanism
-  updateFromURL(url: string | null, resetSvgScale: boolean = true, updateSettings: boolean = true, save: boolean = false) {
-    
-
+  updateFromURL(
+    url: string | null,
+    resetSvgScale: boolean = true,
+    updateSettings: boolean = true,
+    save: boolean = false
+  ) {
     const mechanismSrv = this.injector.get(MechanismService);
 
     // the transcoder is responsible for decoding the url into a mechanism
     const decoder = new StringTranscoder();
-    
+
     // if the url exists, decode it and build the mechanism. Otherwise, skip to updating mechanism directly
     if (url !== null) {
       try {
@@ -97,7 +98,5 @@ export class UrlProcessorService {
         this.svgGrid.scaleToFitLinkage();
       }, 1000);
     }
-    
   }
-
 }

--- a/src/test-utils/verification/fixture.ts
+++ b/src/test-utils/verification/fixture.ts
@@ -3,7 +3,7 @@
 import { Joint, PrisJoint, RevJoint } from '../../app/model/joint';
 import { Coord } from '../../app/model/coord';
 import { Force } from '../../app/model/force';
-import { Link, Piston, RealLink } from '../../app/model/link';
+import { Link, SliderBlock, RealLink } from '../../app/model/link';
 import { Mechanism } from '../../app/model/mechanism/mechanism';
 import { ColorService } from '../../app/services/color.service';
 import { SettingsService } from '../../app/services/settings.service';
@@ -83,14 +83,7 @@ export function buildMechanism(fixture: MechanismFixture): BuiltMechanism {
     const linkJoints = [...spec.joints].map((id) => jointById.get(id)!);
     const com = spec.com ? new Coord(spec.com[0], spec.com[1]) : undefined;
     const subset = spec.subset?.map(buildFixtureLink);
-    const link = new RealLink(
-      spec.joints,
-      linkJoints,
-      spec.mass ?? 1,
-      spec.moi ?? 1,
-      com,
-      subset
-    );
+    const link = new RealLink(spec.joints, linkJoints, spec.mass ?? 1, spec.moi ?? 1, com, subset);
     link.fill = spec.fill ?? ColorService.instance.getNextLinkColor();
     restoreFixtureLinkState(spec, link);
     return link;
@@ -116,7 +109,7 @@ export function buildMechanism(fixture: MechanismFixture): BuiltMechanism {
     prisJoint.angle_rad = fixture.slider.angleRad ?? 0;
     prisJoint.connectedJoints.push(revJoint);
     revJoint.connectedJoints.push(prisJoint);
-    const piston = new Piston(
+    const piston = new SliderBlock(
       revJoint.id + prisJoint.id,
       [revJoint, prisJoint],
       fixture.slider.pistonMass

--- a/src/tests/verification/slider-guide-angle.spec.ts
+++ b/src/tests/verification/slider-guide-angle.spec.ts
@@ -1,0 +1,160 @@
+// joint.ts first: the model modules form an import cycle that only
+// initializes cleanly when entered here (see test-utils/verification/fixture.ts).
+import '../../app/model/joint';
+import { Joint } from '../../app/model/joint';
+import { buildMechanism, MechanismFixture } from '../../test-utils/verification/fixture';
+
+// A slider-crank has an exact closed form for any guide angle, so these cases
+// are asserted against the formula rather than against sampled reference data:
+// stronger, and there is nothing to drift. See docs/joint-types-plan.md §4.3.
+//
+// The guide angle is the point of the exercise. Today's circle-line
+// intersection is written in slope-intercept form (y = m·x + n with
+// m = tan(angle)), which cannot represent a vertical guide and leans on a
+// Number.MAX_VALUE clamp plus a separate NaN branch to survive near-vertical
+// ones. A guide fixed in the world only meets that singularity if a user types
+// 90 degrees; a guide carried on a rotating link would cross it twice per
+// revolution. The parametric rewrite has to make every angle below ordinary.
+
+const CRANK_LENGTH = 1;
+const CRANK_PIVOT: [number, number] = [0, 0];
+/** Where the slider sits at t = 0; the guide is the line through here. */
+const SLIDER_START: [number, number] = [3.2, 0.6];
+
+function sliderCrankOnGuide(angleRad: number): MechanismFixture {
+  const [bx, by] = [CRANK_PIVOT[0] + CRANK_LENGTH, CRANK_PIVOT[1]];
+  return {
+    joints: [
+      { id: 'A', x: CRANK_PIVOT[0], y: CRANK_PIVOT[1], ground: true, input: true },
+      { id: 'B', x: bx, y: by },
+      { id: 'C', x: SLIDER_START[0], y: SLIDER_START[1] },
+    ],
+    links: [{ joints: 'AB' }, { joints: 'BC' }],
+    slider: { at: 'C', prisId: 'D', angleRad },
+    inputAngVel: (10 * Math.PI) / 30,
+  };
+}
+
+function jointAt(joints: Joint[], id: string): Joint {
+  return joints.find((joint) => joint.id === id)!;
+}
+
+/**
+ * Where the slider must be, from the geometry alone.
+ *
+ * The slider rides the line through `SLIDER_START` at `angleRad`, so
+ * `C = G + t·u`. Requiring `|C − B| = couplerLength` gives a quadratic in `t`
+ * whose two roots are the linkage's two assembly modes; the caller picks the
+ * one the mechanism is actually on.
+ */
+function guidePositionsFor(
+  b: { x: number; y: number },
+  angleRad: number,
+  couplerLength: number
+): [number, number][] {
+  const ux = Math.cos(angleRad);
+  const uy = Math.sin(angleRad);
+  const dx = SLIDER_START[0] - b.x;
+  const dy = SLIDER_START[1] - b.y;
+
+  const dDotU = dx * ux + dy * uy;
+  const discriminant = dDotU * dDotU - (dx * dx + dy * dy) + couplerLength * couplerLength;
+  expect(discriminant).toBeGreaterThanOrEqual(0);
+
+  const root = Math.sqrt(discriminant);
+  return [-dDotU + root, -dDotU - root].map(
+    (t) => [SLIDER_START[0] + t * ux, SLIDER_START[1] + t * uy] as [number, number]
+  );
+}
+
+const GUIDES: [string, number][] = [
+  ['horizontal (0 degrees)', 0],
+  ['30 degrees', Math.PI / 6],
+  ['60 degrees', Math.PI / 3],
+  ['0.05 degrees off vertical', ((90 - 0.05) * Math.PI) / 180],
+  ['exactly vertical (90 degrees)', Math.PI / 2],
+  ['past vertical (120 degrees)', (2 * Math.PI) / 3],
+];
+
+describe('slider-crank on an arbitrary guide angle', () => {
+  for (const [label, angleRad] of GUIDES) {
+    describe(label, () => {
+      it('solves, and every solved position is finite', () => {
+        const { mechanism } = buildMechanism(sliderCrankOnGuide(angleRad));
+
+        expect(mechanism.isMechanismValid()).toBe(true);
+        expect(mechanism.dof).toBe(1);
+        expect(mechanism.joints.length).toBeGreaterThan(1);
+
+        mechanism.joints.forEach((joints) =>
+          joints.forEach((joint) => {
+            expect(Number.isFinite(joint.x)).toBe(true);
+            expect(Number.isFinite(joint.y)).toBe(true);
+          })
+        );
+      });
+
+      it('keeps the slider on its guide line', () => {
+        const { mechanism } = buildMechanism(sliderCrankOnGuide(angleRad));
+        const ux = Math.cos(angleRad);
+        const uy = Math.sin(angleRad);
+
+        mechanism.joints.forEach((joints, timestep) => {
+          const c = jointAt(joints, 'C');
+          // Distance from C to the guide line, via the 2D cross product.
+          const offGuide = Math.abs((c.x - SLIDER_START[0]) * uy - (c.y - SLIDER_START[1]) * ux);
+          expect(
+            offGuide,
+            `timestep ${timestep}: slider left the guide by ${offGuide}`
+          ).toBeLessThan(1e-3);
+        });
+      });
+
+      it('holds the coupler length', () => {
+        const { mechanism } = buildMechanism(sliderCrankOnGuide(angleRad));
+        const first = mechanism.joints[0];
+        const expected = Math.hypot(
+          jointAt(first, 'C').x - jointAt(first, 'B').x,
+          jointAt(first, 'C').y - jointAt(first, 'B').y
+        );
+
+        mechanism.joints.forEach((joints, timestep) => {
+          const actual = Math.hypot(
+            jointAt(joints, 'C').x - jointAt(joints, 'B').x,
+            jointAt(joints, 'C').y - jointAt(joints, 'B').y
+          );
+          expect(actual, `timestep ${timestep}`).toBeCloseTo(expected, 3);
+        });
+      });
+
+      it('matches the closed-form slider position at every timestep', () => {
+        const { mechanism } = buildMechanism(sliderCrankOnGuide(angleRad));
+        const first = mechanism.joints[0];
+        const couplerLength = Math.hypot(
+          jointAt(first, 'C').x - jointAt(first, 'B').x,
+          jointAt(first, 'C').y - jointAt(first, 'B').y
+        );
+
+        mechanism.joints.forEach((joints, timestep) => {
+          const b = jointAt(joints, 'B');
+          const c = jointAt(joints, 'C');
+          const roots = guidePositionsFor(b, angleRad, couplerLength);
+          // Both roots are geometrically valid; the solver is only required to
+          // sit on one of them, and to stay on the branch it started on.
+          const nearest = Math.min(...roots.map(([x, y]) => Math.hypot(c.x - x, c.y - y)));
+          expect(nearest, `timestep ${timestep}: C=(${c.x}, ${c.y})`).toBeLessThan(1e-3);
+        });
+      });
+
+      it('keeps the prismatic joint coincident with its revolute', () => {
+        const { mechanism } = buildMechanism(sliderCrankOnGuide(angleRad));
+
+        mechanism.joints.forEach((joints, timestep) => {
+          const c = jointAt(joints, 'C');
+          const d = jointAt(joints, 'D');
+          expect([d.x, d.y], `timestep ${timestep}`).toEqual([c.x, c.y]);
+        });
+      });
+    });
+  }
+});

--- a/src/tests/verification/structural.spec.ts
+++ b/src/tests/verification/structural.spec.ts
@@ -2,7 +2,7 @@
 // initializes cleanly when entered here (see test-utils/verification/fixture.ts).
 import '../../app/model/joint';
 import { PrisJoint, RevJoint } from '../../app/model/joint';
-import { Piston, RealLink } from '../../app/model/link';
+import { SliderBlock, RealLink } from '../../app/model/link';
 import { Link } from '../../app/model/link';
 import { StringTranscoder } from '../../app/services/transcoding/string-transcoder';
 import { ForceSolver } from '../../app/model/mechanism/force-solver';
@@ -114,7 +114,7 @@ describe('mechanism structure', () => {
       const pris = slider.joints[t].find((joint) => joint.id === 'D');
       expect(pris, `t=${t} prismatic joint`).toBeInstanceOf(PrisJoint);
       expect((pris as PrisJoint).angle_rad).toBe(0);
-      expect(slider.links[t].find((link) => link instanceof Piston)?.mass).toBe(1.31788);
+      expect(slider.links[t].find((link) => link instanceof SliderBlock)?.mass).toBe(1.31788);
     }
   });
 
@@ -323,7 +323,7 @@ describe('URL transcoder round-trip', () => {
             []
           )
         );
-      } else if (link instanceof Piston) {
+      } else if (link instanceof SliderBlock) {
         encoder.addLink(
           new LinkData(
             true,

--- a/src/tests/verification/template-baseline.ts
+++ b/src/tests/verification/template-baseline.ts
@@ -1,0 +1,664 @@
+// PMKS+'s own decoded topology and solved joint positions for the five built-in
+// templates, captured on staging before the Phase 0 solver refactor.
+//
+// This is NOT verification data: nothing here is checked against MATLAB or the
+// PMKS fork (that lives in src/test-data/verification/). It is a self-snapshot
+// whose only job is to fail loudly if a refactor changes what an existing
+// shared URL decodes or solves to. The URL codec is a compatibility surface —
+// every link anyone has ever shared depends on these numbers.
+//
+// Regenerate ONLY when a change to the numbers is intended and reviewed.
+
+export interface TemplateJointSnapshot {
+  id: string;
+  type: number;
+  x: number;
+  y: number;
+  isGrounded: boolean;
+  isInput: boolean;
+  isWelded: boolean;
+  angleRadians: number;
+}
+
+export interface TemplateLinkSnapshot {
+  id: string;
+  type: number;
+  jointIDs: string[];
+  subsetLinkIDs: string[];
+}
+
+export interface TemplateBaseline {
+  joints: TemplateJointSnapshot[];
+  links: TemplateLinkSnapshot[];
+  /** Solved timestep count. */
+  steps: number;
+  /** Timestep indices the samples were taken at. */
+  picks: number[];
+  /** Per pick: [jointId, x, y] for every joint, in mechanism order. */
+  samples: [string, number, number][][];
+}
+
+export const TEMPLATE_BASELINES: Record<string, TemplateBaseline> = {
+  '4-Bar': {
+    joints: [
+      {
+        id: 'A',
+        type: 1,
+        x: -3.129,
+        y: -2.014,
+        isGrounded: true,
+        isInput: true,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'B',
+        type: 1,
+        x: -2.622,
+        y: 0.902,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'C',
+        type: 1,
+        x: 3.009,
+        y: 2.08,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'D',
+        type: 1,
+        x: 3.341,
+        y: -1.646,
+        isGrounded: true,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+    ],
+    links: [
+      {
+        id: 'AB',
+        type: 0,
+        jointIDs: ['A', 'B'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'BC',
+        type: 0,
+        jointIDs: ['B', 'C'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'CD',
+        type: 0,
+        jointIDs: ['C', 'D'],
+        subsetLinkIDs: [],
+      },
+    ],
+    steps: 361,
+    picks: [0, 90, 180, 270],
+    samples: [
+      [
+        ['A', -3.129, -2.014],
+        ['B', -2.622, 0.902],
+        ['C', 3.009, 2.08],
+        ['D', 3.341, -1.646],
+      ],
+      [
+        ['A', -3.129, -2.014],
+        ['B', -0.213, -2.5209],
+        ['C', 3.2234, 2.0929],
+        ['D', 3.341, -1.646],
+      ],
+      [
+        ['A', -3.129, -2.014],
+        ['B', -3.6359, -4.93],
+        ['C', -0.1651, -0.342],
+        ['D', 3.341, -1.646],
+      ],
+      [
+        ['A', -3.129, -2.014],
+        ['B', -6.045, -1.5071],
+        ['C', -0.3244, -0.8987],
+        ['D', 3.341, -1.646],
+      ],
+    ],
+  },
+  Watt_I: {
+    joints: [
+      {
+        id: 'A',
+        type: 1,
+        x: -1.707,
+        y: -1.329,
+        isGrounded: true,
+        isInput: true,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'B',
+        type: 1,
+        x: -2.561,
+        y: 0.62,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'C',
+        type: 1,
+        x: 2.397,
+        y: 1.359,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'D',
+        type: 1,
+        x: -1.029,
+        y: 3.555,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'E',
+        type: 1,
+        x: 1.989,
+        y: 8.125,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'F',
+        type: 1,
+        x: 7.19,
+        y: 5.177,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'G',
+        type: 1,
+        x: 7.543,
+        y: -2.62,
+        isGrounded: true,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+    ],
+    links: [
+      {
+        id: 'AB',
+        type: 0,
+        jointIDs: ['A', 'B'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'BCD',
+        type: 0,
+        jointIDs: ['B', 'C', 'D'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'DE',
+        type: 0,
+        jointIDs: ['D', 'E'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'EF',
+        type: 0,
+        jointIDs: ['E', 'F'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'FCG',
+        type: 0,
+        jointIDs: ['F', 'C', 'G'],
+        subsetLinkIDs: [],
+      },
+    ],
+    steps: 361,
+    picks: [0, 90, 180, 270],
+    samples: [
+      [
+        ['A', -1.707, -1.329],
+        ['B', -2.561, 0.62],
+        ['C', 2.397, 1.359],
+        ['D', -1.029, 3.555],
+        ['E', 1.989, 8.125],
+        ['F', 7.19, 5.177],
+        ['G', 7.543, -2.62],
+      ],
+      [
+        ['A', -1.707, -1.329],
+        ['B', 0.2419, -0.4747],
+        ['C', 4.0041, 2.838],
+        ['D', -0.0653, 2.8218],
+        ['E', 4.0311, 6.4568],
+        ['F', 9.7907, 4.8543],
+        ['G', 7.543, -2.62],
+      ],
+      [
+        ['A', -1.707, -1.329],
+        ['B', -0.8527, -3.2779],
+        ['C', 2.0258, 0.826],
+        ['D', -1.9258, -0.1459],
+        ['E', 0.4439, 4.7915],
+        ['F', 6.4142, 5.1029],
+        ['G', 7.543, -2.62],
+      ],
+      [
+        ['A', -1.707, -1.329],
+        ['B', -3.6559, -2.1833],
+        ['C', 1.2287, -1.0569],
+        ['D', -2.3593, 0.863],
+        ['E', -1.591, 6.2854],
+        ['F', 4.0726, 4.371],
+        ['G', 7.543, -2.62],
+      ],
+    ],
+  },
+  Watt_II: {
+    joints: [
+      {
+        id: 'A',
+        type: 1,
+        x: -2.025,
+        y: -2.023,
+        isGrounded: true,
+        isInput: true,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'B',
+        type: 1,
+        x: -3.107,
+        y: -0.522,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'C',
+        type: 1,
+        x: -0.418,
+        y: 1.356,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'D',
+        type: 1,
+        x: 5.531,
+        y: 1.218,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'E',
+        type: 1,
+        x: 3.45,
+        y: -2.882,
+        isGrounded: true,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'F',
+        type: 1,
+        x: 11.046,
+        y: 1.165,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'G',
+        type: 1,
+        x: 11.246,
+        y: -2.295,
+        isGrounded: true,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+    ],
+    links: [
+      {
+        id: 'AB',
+        type: 0,
+        jointIDs: ['A', 'B'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'BC',
+        type: 0,
+        jointIDs: ['B', 'C'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'CDE',
+        type: 0,
+        jointIDs: ['C', 'D', 'E'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'DF',
+        type: 0,
+        jointIDs: ['D', 'F'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'FG',
+        type: 0,
+        jointIDs: ['F', 'G'],
+        subsetLinkIDs: [],
+      },
+    ],
+    steps: 361,
+    picks: [0, 90, 180, 270],
+    samples: [
+      [
+        ['A', -2.025, -2.023],
+        ['B', -3.107, -0.522],
+        ['C', -0.418, 1.356],
+        ['D', 5.531, 1.218],
+        ['E', 3.45, -2.882],
+        ['F', 11.046, 1.165],
+        ['G', 11.246, -2.295],
+      ],
+      [
+        ['A', -2.025, -2.023],
+        ['B', -0.5239, -0.9411],
+        ['C', 0.645, 2.1234],
+        ['D', 6.4074, 0.6386],
+        ['E', 3.45, -2.882],
+        ['F', 11.9026, 1.108],
+        ['G', 11.246, -2.295],
+      ],
+      [
+        ['A', -2.025, -2.023],
+        ['B', -0.9433, -3.5242],
+        ['C', -1.6891, -0.3302],
+        ['D', 3.907, 1.6931],
+        ['E', 3.45, -2.882],
+        ['F', 9.3085, 0.5786],
+        ['G', 11.246, -2.295],
+      ],
+      [
+        ['A', -2.025, -2.023],
+        ['B', -3.5262, -3.1047],
+        ['C', -1.7103, -0.3734],
+        ['D', 3.8686, 1.6968],
+        ['E', 3.45, -2.882],
+        ['F', 9.2627, 0.5472],
+        ['G', 11.246, -2.295],
+      ],
+    ],
+  },
+  Stephenson_III: {
+    joints: [
+      {
+        id: 'A',
+        type: 1,
+        x: -2.201,
+        y: -2.472,
+        isGrounded: true,
+        isInput: true,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'B',
+        type: 1,
+        x: -2.458,
+        y: -0.978,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'C',
+        type: 1,
+        x: 3.02,
+        y: 0.127,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'D',
+        type: 1,
+        x: 3.258,
+        y: -1.921,
+        isGrounded: true,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'E',
+        type: 1,
+        x: -0.195,
+        y: 0.895,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'F',
+        type: 1,
+        x: 0.87,
+        y: 3.181,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'G',
+        type: 1,
+        x: 5.504,
+        y: 1.043,
+        isGrounded: true,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+    ],
+    links: [
+      {
+        id: 'AB',
+        type: 0,
+        jointIDs: ['A', 'B'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'BCE',
+        type: 0,
+        jointIDs: ['B', 'C', 'E'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'CD',
+        type: 0,
+        jointIDs: ['C', 'D'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'EF',
+        type: 0,
+        jointIDs: ['E', 'F'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'FG',
+        type: 0,
+        jointIDs: ['F', 'G'],
+        subsetLinkIDs: [],
+      },
+    ],
+    steps: 361,
+    picks: [0, 90, 180, 270],
+    samples: [
+      [
+        ['A', -2.201, -2.472],
+        ['B', -2.458, -0.978],
+        ['C', 3.02, 0.127],
+        ['D', 3.258, -1.921],
+        ['E', -0.195, 0.895],
+        ['F', 0.87, 3.181],
+        ['G', 5.504, 1.043],
+      ],
+      [
+        ['A', -2.201, -2.472],
+        ['B', -0.707, -2.2149],
+        ['C', 4.5474, -0.3122],
+        ['D', 3.258, -1.921],
+        ['E', 1.2542, -0.0279],
+        ['F', 0.5853, 2.4037],
+        ['G', 5.504, 1.043],
+      ],
+      [
+        ['A', -2.201, -2.472],
+        ['B', -1.9439, -3.966],
+        ['C', 2.1618, -0.1748],
+        ['D', 3.258, -1.921],
+        ['E', -0.984, -1.1897],
+        ['F', 0.4021, 0.9171],
+        ['G', 5.504, 1.043],
+      ],
+      [
+        ['A', -2.201, -2.472],
+        ['B', -3.695, -2.7291],
+        ['C', 1.5418, -0.7784],
+        ['D', 3.258, -1.921],
+        ['E', -1.7539, -0.5243],
+        ['F', 0.4076, 0.7749],
+        ['G', 5.504, 1.043],
+      ],
+    ],
+  },
+  Slider_Crank: {
+    joints: [
+      {
+        id: 'A',
+        type: 1,
+        x: -3.082,
+        y: -0.038,
+        isGrounded: true,
+        isInput: true,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'B',
+        type: 1,
+        x: -2.231,
+        y: 2.388,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'C',
+        type: 1,
+        x: 2.863,
+        y: 1.151,
+        isGrounded: false,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+      {
+        id: 'D',
+        type: 0,
+        x: 2.863,
+        y: 1.151,
+        isGrounded: true,
+        isInput: false,
+        isWelded: false,
+        angleRadians: 0,
+      },
+    ],
+    links: [
+      {
+        id: 'AB',
+        type: 0,
+        jointIDs: ['A', 'B'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'BC',
+        type: 0,
+        jointIDs: ['B', 'C'],
+        subsetLinkIDs: [],
+      },
+      {
+        id: 'CD',
+        type: 1,
+        jointIDs: ['C', 'D'],
+        subsetLinkIDs: [],
+      },
+    ],
+    steps: 361,
+    picks: [0, 90, 180, 270],
+    samples: [
+      [
+        ['A', -3.082, -0.038],
+        ['B', -2.231, 2.388],
+        ['C', 2.863, 1.151],
+        ['D', 2.863, 1.151],
+      ],
+      [
+        ['A', -3.082, -0.038],
+        ['B', -0.6559, -0.8888],
+        ['C', 4.173, 1.151],
+        ['D', 4.173, 1.151],
+      ],
+      [
+        ['A', -3.082, -0.038],
+        ['B', -3.9328, -2.4641],
+        ['C', -0.1367, 1.151],
+        ['D', -0.1367, 1.151],
+      ],
+      [
+        ['A', -3.082, -0.038],
+        ['B', -5.5081, 0.8128],
+        ['C', -0.277, 1.151],
+        ['D', -0.277, 1.151],
+      ],
+    ],
+  },
+};

--- a/src/tests/verification/template-url.spec.ts
+++ b/src/tests/verification/template-url.spec.ts
@@ -1,0 +1,138 @@
+// joint.ts first: the model modules form an import cycle that only
+// initializes cleanly when entered here (see test-utils/verification/fixture.ts).
+import '../../app/model/joint';
+import { PrisJoint, RealJoint, RevJoint } from '../../app/model/joint';
+import { SliderBlock, RealLink } from '../../app/model/link';
+import {
+  BUILT_IN_TEMPLATE_IDS,
+  TEMPLATE_LINKAGES,
+} from '../../app/component/MODALS/templates/template-linkages';
+import { StringTranscoder } from '../../app/services/transcoding/string-transcoder';
+import { JOINT_TYPE, LINK_TYPE } from '../../app/services/transcoding/transcoder-data';
+import { buildMechanismFixture } from '../fixtures/mechanism-fixtures';
+import { TEMPLATE_BASELINES } from './template-baseline';
+
+// The URL codec is a compatibility surface: every mechanism anyone has ever
+// shared is a string in this format. These tests pin what the five built-in
+// templates decode to and what they solve to, so a solver or codec refactor
+// cannot quietly change either. See docs/joint-types-plan.md, Phase 0.
+
+function decode(payload: string): StringTranscoder {
+  const transcoder = new StringTranscoder();
+  transcoder.decodeURL(payload);
+  return transcoder;
+}
+
+describe('built-in template URLs', () => {
+  for (const templateID of BUILT_IN_TEMPLATE_IDS) {
+    const baseline = TEMPLATE_BASELINES[templateID];
+
+    describe(templateID, () => {
+      it('decodes to the pinned topology', () => {
+        const transcoder = decode(TEMPLATE_LINKAGES[templateID]);
+
+        expect(
+          transcoder.getJoints().map((joint) => ({
+            id: joint.id,
+            type: joint.type,
+            x: joint.x,
+            y: joint.y,
+            isGrounded: joint.isGrounded,
+            isInput: joint.isInput,
+            isWelded: joint.isWelded,
+            angleRadians: joint.angleRadians,
+          }))
+        ).toEqual(baseline.joints);
+
+        expect(
+          transcoder.getLinks().map((link) => ({
+            id: link.id,
+            type: link.type,
+            jointIDs: link.jointIDs,
+            subsetLinkIDs: link.subsetLinkIDs,
+          }))
+        ).toEqual(baseline.links);
+      });
+
+      it('survives a decode/encode/decode round trip unchanged', () => {
+        const first = decode(TEMPLATE_LINKAGES[templateID]);
+        const second = decode(first.encodeURL());
+
+        expect(second.getJoints()).toEqual(first.getJoints());
+        expect(second.getLinks()).toEqual(first.getLinks());
+        expect(second.getForces()).toEqual(first.getForces());
+      });
+
+      it('solves to the pinned positions', () => {
+        const { mechanism } = buildMechanismFixture(TEMPLATE_LINKAGES[templateID]);
+
+        expect(mechanism.isMechanismValid()).toBe(true);
+        expect(mechanism.dof).toBe(1);
+        // The sample count fixes the t=0 pose: a mechanism that closes its
+        // cycle in a different number of steps has moved its own zero.
+        expect(mechanism.joints.length).toBe(baseline.steps);
+
+        baseline.picks.forEach((timestep, index) => {
+          const solved = mechanism.joints[timestep].map(
+            (joint) => [joint.id, joint.x, joint.y] as [string, number, number]
+          );
+          expect(solved).toEqual(baseline.samples[index]);
+        });
+      });
+    });
+  }
+});
+
+// The slider-crank is the template that exercises the prismatic path, so its
+// structure gets asserted explicitly rather than only through the snapshot.
+describe('Slider_Crank prismatic structure', () => {
+  it('pairs a grounded prismatic joint with a coincident revolute via a slider block', () => {
+    const transcoder = decode(TEMPLATE_LINKAGES['Slider_Crank']);
+    const jointC = transcoder.getJoints().find((joint) => joint.id === 'C')!;
+    const jointD = transcoder.getJoints().find((joint) => joint.id === 'D')!;
+    const linkCD = transcoder.getLinks().find((link) => link.id === 'CD')!;
+
+    expect(jointC.type).toBe(JOINT_TYPE.REVOLUTE);
+    expect(jointD.type).toBe(JOINT_TYPE.PRISMATIC);
+    expect(jointD.isGrounded).toBe(true);
+    expect([jointD.x, jointD.y]).toEqual([jointC.x, jointC.y]);
+
+    expect(linkCD.type).toBe(LINK_TYPE.PISTON);
+    expect(linkCD.jointIDs).toEqual(['C', 'D']);
+  });
+
+  it('builds a SliderBlock whose two joints stay coincident at every timestep', () => {
+    const { mechanism } = buildMechanismFixture(TEMPLATE_LINKAGES['Slider_Crank']);
+
+    const block = mechanism.links[0].find((link) => link instanceof SliderBlock);
+    expect(block).toBeInstanceOf(SliderBlock);
+    expect(block!.joints).toHaveLength(2);
+    expect(block!.joints.some((joint) => joint instanceof PrisJoint)).toBe(true);
+    expect(block!.joints.some((joint) => joint instanceof RevJoint)).toBe(true);
+    expect(mechanism.links[0].some((link) => link instanceof RealLink)).toBe(true);
+
+    for (let timestep = 0; timestep < mechanism.joints.length; timestep++) {
+      const joints = mechanism.joints[timestep];
+      const jointC = joints.find((joint) => joint.id === 'C')!;
+      const jointD = joints.find((joint) => joint.id === 'D')!;
+      expect([jointD.x, jointD.y]).toEqual([jointC.x, jointC.y]);
+    }
+  });
+
+  it('keeps the slider on its guide line for the whole cycle', () => {
+    const { mechanism } = buildMechanismFixture(TEMPLATE_LINKAGES['Slider_Crank']);
+
+    // The template's guide is horizontal, so the slider's y is the invariant
+    // the circle-line intersection has to preserve. This is the assertion the
+    // parametric-line rewrite must not move.
+    const guideY = mechanism.joints[0].find((joint) => joint.id === 'C')!.y;
+    const prismatic = mechanism.joints[0].find(
+      (joint) => joint instanceof PrisJoint
+    ) as unknown as RealJoint;
+    expect((prismatic as unknown as PrisJoint).angle_rad).toBe(0);
+
+    for (let timestep = 0; timestep < mechanism.joints.length; timestep++) {
+      expect(mechanism.joints[timestep].find((joint) => joint.id === 'C')!.y).toBe(guideY);
+    }
+  });
+});


### PR DESCRIPTION
Phase 0 of [docs/joint-types-plan.md](docs/joint-types-plan.md) — no user-visible change. Establishes a green baseline before any joint-type work moves geometry.

### 1. Rename `Piston` → `SliderBlock`

`Piston` named the zero-length body between a prismatic joint and the link that slides on it. Upcoming work adds hydraulic cylinders, which users call pistons and which are a different thing built *from* a prismatic joint. Freeing the word now avoids two meanings in one codebase. Pure rename.

### 2. Pin what the built-in template URLs decode and solve to

The URL codec is a compatibility surface — every mechanism anyone has shared is a string in this format — and nothing asserted what the five built-in templates decode to. Adds snapshots of decoded topology, a decode/encode/decode round trip, solved timestep count, and solved joint positions at four timesteps, plus explicit structural assertions for `Slider_Crank` (joint `D` is a grounded prismatic coincident with revolute `C`, link `CD` is the slider block, the two stay coincident every timestep, and the slider never leaves its guide).

The baseline is PMKS+'s own output, not MATLAB data, so it lives beside the spec rather than in `src/test-data/verification/`.

### 3. Solve slider guides parametrically instead of by slope

**This fixes a silent correctness bug.** `circleLineIntersection` took the guide as `y = m*x + n` with `m = tan(angle)`, which cannot represent a vertical guide. The code worked around that by clamping any `|m| > 1000` to `Number.MAX_VALUE` and solving for a constant `x` instead.

`tan(89.95°)` is 1146 — so **a guide a twentieth of a degree off vertical was solved as exactly vertical**, drifting 0.0044 off the true slider position with `x` pinned to its starting value for the whole cycle.

Taking the guide as a point plus a unit direction removes the special direction entirely. The clamp, the NaN branch, and the slope/intercept maps all go away: **net 67 lines deleted**.

### Gate 0

- [x] All existing specs green — 263 passing (was 215)
- [x] `Slider_Crank` template decodes and solves bit-identically — baseline spec passes unchanged
- [x] Guide-angle cases match closed form — 0°, 30°, 60°, 89.95°, exactly 90°, 120°
- [x] Production build clean

Guide angles are asserted against the analytic formula rather than sampled reference data, per §4.3 of the plan: stronger, and no reference data to drift.

### Notes

- Mutation testing confirmed the suite detects a change in the circle-line path at the solver's own 4-decimal resolution, and also surfaced that **`incrementPrisInput` is exercised by no test at all** — no template drives the slider. Recorded in the plan as a Phase 5 prerequisite.
- MATLAB cases for these guide angles exist and pass their full pipeline in [KohmeiK/PMKS_Verification#1](https://github.com/KohmeiK/PMKS_Verification/pull/1). Wiring them in as an independent cross-check is follow-up work, not needed for this gate.
- A latent issue is left in place and commented: the circle-line branch index is chosen once and held, which is not safe through a tangency. Phase 2 territory; this PR changes only the line representation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)