### PR TITLE
Put the number in the header, and the graph behind it

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { DualInputComponent } from './component/BLOCKS/dual-input/dual-input.com
 import { ReactiveFormsModule } from '@angular/forms';
 import { AnalysisPanelComponent } from './component/analysis-panel/analysis-panel.component';
 import { AnalysisGraphComponent } from './component/analysis-graph/analysis-graph.component';
+import { AnalysisGraphSectionComponent } from './component/analysis-graph-section/analysis-graph-section.component';
 import { AnalysisApexChartComponent } from './component/analysis-graph/analysis-apex-chart.component';
 import { RightPanelComponent } from './component/right-panel/right-panel.component';
 import { SettingsPanelComponent } from './component/settings-panel/settings-panel.component';
@@ -76,6 +77,7 @@ import { BottombarComponent } from './component/bottombar/bottombar.component';
     DualInputComponent,
     AnalysisPanelComponent,
     AnalysisGraphComponent,
+    AnalysisGraphSectionComponent,
     AnalysisApexChartComponent,
     RightPanelComponent,
     SettingsPanelComponent,

--- a/src/app/component/analysis-graph-section/analysis-graph-section.component.html
+++ b/src/app/component/analysis-graph-section/analysis-graph-section.component.html
@@ -1,5 +1,18 @@
-<div class="graphSection" [class.open]="expanded">
-  <button class="graphHeader" type="button" (click)="toggle()" [attr.aria-expanded]="expanded">
+<!-- Closed, the whole card opens it: the values are as much an invitation to
+     look closer as the title is, and a reader aiming at either was hitting a
+     strip only the title lived in. -->
+<div
+  class="graphSection"
+  [class.open]="expanded"
+  [class.closed]="!expanded"
+  (click)="expanded ? null : toggle()"
+>
+  <button
+    class="graphHeader"
+    type="button"
+    (click)="toggle(); $event.stopPropagation()"
+    [attr.aria-expanded]="expanded"
+  >
     <span class="graphTitle">{{ label }}</span>
     <mat-icon class="graphChevron">{{ expanded ? 'expand_less' : 'expand_more' }}</mat-icon>
   </button>

--- a/src/app/component/analysis-graph-section/analysis-graph-section.component.html
+++ b/src/app/component/analysis-graph-section/analysis-graph-section.component.html
@@ -1,0 +1,56 @@
+<div class="graphSection" [class.open]="expanded">
+  <button class="graphHeader" type="button" (click)="toggle()" [attr.aria-expanded]="expanded">
+    <span class="graphTitle">{{ label }}</span>
+    <mat-icon class="graphChevron">{{ expanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+  </button>
+
+  <!-- One row, two jobs: what each series reads at the pose on screen, and --
+       once the graph is open -- which of them the graph is drawing. Closed it
+       is a read-out; open it is the legend. Two rows saying the same names in
+       different orders was what the checkboxes and the values came to. -->
+  @if (preview.length) {
+    <div class="graphPreview" [class.interactive]="expanded">
+      @for (series of preview; track series.name) {
+        @if (expanded && preview.length > 1) {
+          <button
+            type="button"
+            class="previewSeries"
+            [class.off]="!isShown(series.key)"
+            [attr.aria-pressed]="isShown(series.key)"
+            (click)="toggleSeries(series.key)"
+          >
+            <span class="previewRule" [style.background]="series.color"></span>
+            {{ series.name }}: {{ series.text }}
+          </button>
+        } @else {
+          <span class="previewSeries">
+            <span class="previewRule" [style.background]="series.color"></span>
+            @if (series.name) {
+              {{ series.name }}:
+            }
+            {{ series.text }}
+          </span>
+        }
+      }
+    </div>
+  }
+
+  @if (help) {
+    <mat-icon class="graphHelp" [matTooltip]="help" [matTooltipShowDelay]="600" aria-hidden="true"
+      >help_outline</mat-icon
+    >
+  }
+
+  @if (expanded) {
+    <div class="graphBody">
+      <app-analysis-graph
+        #graph
+        [analysis]="analysis"
+        [analysisType]="analysisType"
+        [mechProp]="mechProp"
+        [mechPart]="mechPart"
+        [reactionLinkId]="reactionLinkId"
+      ></app-analysis-graph>
+    </div>
+  }
+</div>

--- a/src/app/component/analysis-graph-section/analysis-graph-section.component.html
+++ b/src/app/component/analysis-graph-section/analysis-graph-section.component.html
@@ -14,6 +14,11 @@
     [attr.aria-expanded]="expanded"
   >
     <span class="graphTitle">{{ label }}</span>
+    @if (help) {
+      <mat-icon class="graphHelp" [matTooltip]="help" [matTooltipShowDelay]="600" aria-hidden="true"
+        >help_outline</mat-icon
+      >
+    }
     <mat-icon class="graphChevron">{{ expanded ? 'expand_less' : 'expand_more' }}</mat-icon>
   </button>
 
@@ -48,14 +53,8 @@
     </div>
   }
 
-  @if (help) {
-    <mat-icon class="graphHelp" [matTooltip]="help" [matTooltipShowDelay]="600" aria-hidden="true"
-      >help_outline</mat-icon
-    >
-  }
-
-  @if (expanded) {
-    <div class="graphBody">
+  <div class="graphBody" [@openClose]="expanded ? 'open' : 'closed'">
+    @if (expanded) {
       <app-analysis-graph
         #graph
         [analysis]="analysis"
@@ -64,6 +63,6 @@
         [mechPart]="mechPart"
         [reactionLinkId]="reactionLinkId"
       ></app-analysis-graph>
-    </div>
-  }
+    }
+  </div>
 </div>

--- a/src/app/component/analysis-graph-section/analysis-graph-section.component.scss
+++ b/src/app/component/analysis-graph-section/analysis-graph-section.component.scss
@@ -12,7 +12,10 @@
     border: 1px solid #eceef5;
     border-radius: var(--border-radius);
     background: var(--card-surface);
-    margin-bottom: 8px;
+    // On the panel's own text gutter, so the card's edges line up with the
+    // paragraph above it rather than running the full width of the panel.
+    margin: 0 15px 8px;
+    overflow: hidden;
 
     &.closed {
       cursor: pointer;
@@ -27,6 +30,7 @@
   // it was 9px over and 3px under, which read as the title sitting high in its
   // own highlight.
   .graphHeader {
+    position: relative;
     display: flex;
     align-items: center;
     gap: 8px;
@@ -114,11 +118,10 @@
   }
 
   // Over the header's right end, before the chevron: a question about the
-  // quantity, not a control of the card.
+  // quantity, not a control of the card. Centred on the title's line, with the
+  // chevron -- the three of them used to sit at three heights.
   .graphHelp {
-    position: absolute;
-    top: 12px;
-    right: 38px;
+    flex: 0 0 auto;
     width: 17px;
     height: 17px;
     font-size: 17px;
@@ -132,5 +135,6 @@
   // margin.
   .graphBody {
     padding: 0 12px 8px;
+    overflow: hidden;
   }
 }

--- a/src/app/component/analysis-graph-section/analysis-graph-section.component.scss
+++ b/src/app/component/analysis-graph-section/analysis-graph-section.component.scss
@@ -1,0 +1,121 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@mixin css($theme) {
+  $color-config: mat.m2-get-color-config($theme);
+  $primary-palette: map.get($color-config, 'primary');
+
+  // A card per quantity, as the mock has it: name and value on the left, a
+  // chevron on the right, and the graph underneath once it is opened.
+  .graphSection {
+    position: relative;
+    border: 1px solid #eceef5;
+    border-radius: var(--border-radius);
+    background: var(--card-surface);
+    margin-bottom: 8px;
+  }
+
+  .graphHeader {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 9px 12px 3px;
+    border: none;
+    background: transparent;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    border-radius: var(--border-radius);
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.02);
+    }
+  }
+
+  .graphTitle {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 14px;
+    font-weight: 500;
+    color: #2c2c2c;
+  }
+
+  .graphPreview {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 2px 12px;
+    padding: 0 12px 9px;
+    font-size: 12px;
+    color: rgba(0, 0, 0, 0.6);
+  }
+
+  .previewSeries {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
+    border: none;
+    background: transparent;
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+    padding: 0;
+  }
+
+  // Open, each entry is the switch for its own line.
+  .graphPreview.interactive .previewSeries {
+    cursor: pointer;
+    padding: 1px 4px;
+    margin: -1px -4px;
+    border-radius: 4px;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.04);
+    }
+
+    // Off, not gone: the reader has to be able to find it again.
+    &.off {
+      color: rgba(0, 0, 0, 0.3);
+
+      .previewRule {
+        opacity: 0.3;
+      }
+    }
+  }
+
+  .previewRule {
+    width: 14px;
+    height: 2.5px;
+    border-radius: 2px;
+    flex: 0 0 auto;
+  }
+
+  .graphChevron {
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
+    font-size: 20px;
+    line-height: 20px;
+    color: mat.m2-get-color-from-palette($primary-palette, 500);
+  }
+
+  // Over the header's right end, before the chevron: a question about the
+  // quantity, not a control of the card.
+  .graphHelp {
+    position: absolute;
+    top: 11px;
+    right: 38px;
+    width: 17px;
+    height: 17px;
+    font-size: 17px;
+    line-height: 17px;
+    color: rgba(0, 0, 0, 0.3);
+    pointer-events: auto;
+  }
+
+  .graphBody {
+    padding: 0 6px 6px;
+  }
+}

--- a/src/app/component/analysis-graph-section/analysis-graph-section.component.scss
+++ b/src/app/component/analysis-graph-section/analysis-graph-section.component.scss
@@ -108,24 +108,33 @@
     flex: 0 0 auto;
   }
 
-  .graphChevron {
+  .graphHeader .graphChevron {
     flex: 0 0 auto;
-    width: 20px;
-    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
     font-size: 20px;
-    line-height: 20px;
+    line-height: 1;
     color: mat.m2-get-color-from-palette($primary-palette, 500);
   }
 
   // Over the header's right end, before the chevron: a question about the
   // quantity, not a control of the card. Centred on the title's line, with the
   // chevron -- the three of them used to sit at three heights.
-  .graphHelp {
+  // Material gives mat-icon a 24px box whatever the glyph inside it is, so a
+  // 17px glyph with a 17px line-height sat at the top of it. Centre the glyph
+  // in the box the box actually is.
+  .graphHeader .graphHelp {
     flex: 0 0 auto;
-    width: 17px;
-    height: 17px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
     font-size: 17px;
-    line-height: 17px;
+    line-height: 1;
     color: rgba(0, 0, 0, 0.3);
     pointer-events: auto;
   }

--- a/src/app/component/analysis-graph-section/analysis-graph-section.component.scss
+++ b/src/app/component/analysis-graph-section/analysis-graph-section.component.scss
@@ -13,22 +13,34 @@
     border-radius: var(--border-radius);
     background: var(--card-surface);
     margin-bottom: 8px;
+
+    &.closed {
+      cursor: pointer;
+
+      &:hover {
+        background: rgba(0, 0, 0, 0.02);
+      }
+    }
   }
 
+  // The title and its chevron, in a band with the same air above and below --
+  // it was 9px over and 3px under, which read as the title sitting high in its
+  // own highlight.
   .graphHeader {
     display: flex;
     align-items: center;
     gap: 8px;
     width: 100%;
-    padding: 9px 12px 3px;
+    min-height: 38px;
+    padding: 6px 12px;
     border: none;
     background: transparent;
     font-family: inherit;
     text-align: left;
     cursor: pointer;
-    border-radius: var(--border-radius);
+    border-radius: var(--border-radius) var(--border-radius) 0 0;
 
-    &:hover {
+    .graphSection.open &:hover {
       background: rgba(0, 0, 0, 0.02);
     }
   }
@@ -46,7 +58,7 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 2px 12px;
-    padding: 0 12px 9px;
+    padding: 0 12px 8px;
     font-size: 12px;
     color: rgba(0, 0, 0, 0.6);
   }
@@ -105,7 +117,7 @@
   // quantity, not a control of the card.
   .graphHelp {
     position: absolute;
-    top: 11px;
+    top: 12px;
     right: 38px;
     width: 17px;
     height: 17px;
@@ -115,7 +127,10 @@
     pointer-events: auto;
   }
 
+  // The same gutter the title and the values sit on, so the plot's frame lines
+  // up with the text above it rather than running wider than the card's own
+  // margin.
   .graphBody {
-    padding: 0 6px 6px;
+    padding: 0 12px 8px;
   }
 }

--- a/src/app/component/analysis-graph-section/analysis-graph-section.component.ts
+++ b/src/app/component/analysis-graph-section/analysis-graph-section.component.ts
@@ -6,6 +6,7 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
+import { animate, AUTO_STYLE, state, style, transition, trigger } from '@angular/animations';
 import { AnalysisGraphComponent } from '../analysis-graph/analysis-graph.component';
 import { MechanismService } from '../../services/mechanism.service';
 import { SettingsService } from '../../services/settings.service';
@@ -32,6 +33,15 @@ export interface SeriesPreview {
  */
 @Component({
   selector: 'app-analysis-graph-section',
+  // The same open and close every other section in the app uses.
+  animations: [
+    trigger('openClose', [
+      state('open', style({ visibility: AUTO_STYLE, height: AUTO_STYLE, opacity: '1' })),
+      state('closed', style({ opacity: '0', height: '0px', padding: '0px' })),
+      transition(':enter', []),
+      transition('* => *', [animate('0.15s ease-in-out')]),
+    ]),
+  ],
   templateUrl: './analysis-graph-section.component.html',
   styleUrls: ['./analysis-graph-section.component.scss'],
   changeDetection: ChangeDetectionStrategy.Eager,

--- a/src/app/component/analysis-graph-section/analysis-graph-section.component.ts
+++ b/src/app/component/analysis-graph-section/analysis-graph-section.component.ts
@@ -1,0 +1,159 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { AnalysisGraphComponent } from '../analysis-graph/analysis-graph.component';
+import { MechanismService } from '../../services/mechanism.service';
+import { SettingsService } from '../../services/settings.service';
+import { AnalysisSampleService } from '../../services/analysis-sample.service';
+import { AngleUnit, LengthUnit } from '../../model/unit-enums';
+import { ANALYSIS_SERIES_COLORS } from '../../model/analysis-series';
+import { roundNumber } from '../../model/utils';
+
+/** One value of one series, as the collapsed header shows it. */
+export interface SeriesPreview {
+  key: 'x' | 'y' | 'z';
+  name: string;
+  color: string;
+  text: string;
+}
+
+/**
+ * One analysable quantity: its name, its value right now, and its graph.
+ *
+ * The value is the point of the header. A reader looking for "where is joint B"
+ * had to open a graph to find out, and the ten graphs a joint and a link offer
+ * between them are ten things to open. The number is there before the graph is,
+ * and the graph is what you open when the number is not enough.
+ */
+@Component({
+  selector: 'app-analysis-graph-section',
+  templateUrl: './analysis-graph-section.component.html',
+  styleUrls: ['./analysis-graph-section.component.scss'],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  standalone: false,
+})
+export class AnalysisGraphSectionComponent {
+  @Input() label = '';
+  @Input() help = '';
+  @Input() analysis = '';
+  @Input() analysisType = '';
+  @Input() mechProp = '';
+  @Input() mechPart = '';
+  @Input() reactionLinkId = '';
+  @Input() expanded = false;
+  @Output() expandedChange = new EventEmitter<boolean>();
+  @ViewChild('graph') graph?: AnalysisGraphComponent;
+
+  constructor(
+    private mechanismService: MechanismService,
+    private settings: SettingsService,
+    private samples: AnalysisSampleService
+  ) {}
+
+  /**
+   * What this quantity reads at the pose on screen.
+   *
+   * One sample, not the cycle: the header is answering "what is it now", and
+   * solving every sample of every collapsed graph to answer that would cost
+   * more than the graphs themselves.
+   */
+  get preview(): SeriesPreview[] {
+    const mechanism = this.mechanismFor();
+    if (!mechanism) return [];
+    const step = Math.min(this.mechanismService.mechanismTimeStep, mechanism.joints.length - 1);
+    const values = this.samples.sampleAt(
+      mechanism,
+      Math.max(step, 0),
+      this.analysis,
+      this.analysisType,
+      this.mechProp,
+      this.mechPart,
+      this.reactionLinkId
+    );
+    if (values.length === 0) return [];
+
+    const names = this.seriesNames(values.length);
+    const keys: ('x' | 'y' | 'z')[] = ['x', 'y', 'z'];
+    const unit = this.unitFor();
+    return values.map((value, index) => ({
+      key: keys[index],
+      name: names[index],
+      color: this.colorFor(names[index]),
+      text: Number.isFinite(value) ? `${roundNumber(value, 2).toFixed(2)} ${unit}`.trim() : '—',
+    }));
+  }
+
+  /** Whether the open graph is drawing this series. Closed, everything reads. */
+  isShown(key: 'x' | 'y' | 'z'): boolean {
+    return !this.graph || this.graph.isSeriesShown(key);
+  }
+
+  toggleSeries(key: 'x' | 'y' | 'z'): void {
+    this.graph?.toggleSeries(key);
+  }
+
+  toggle(): void {
+    this.expanded = !this.expanded;
+    this.expandedChange.emit(this.expanded);
+  }
+
+  private mechanismFor() {
+    const part =
+      this.mechanismService.joints.find((joint) => joint.id === this.mechPart) ??
+      this.mechanismService.links.find((link) => link.id === this.mechPart);
+    return part ? this.mechanismService.mechanismContaining(part) : undefined;
+  }
+
+  /**
+   * The names the graph plots these under.
+   *
+   * A third series is the magnitude of the first two everywhere except force
+   * analysis, where it is a component in its own right.
+   */
+  private seriesNames(count: number): string[] {
+    if (count === 1) return [''];
+    if (count === 2) return ['X', 'Y'];
+    return this.analysis === 'force' ? ['X', 'Y', 'Z'] : ['X', 'Y', 'Mag'];
+  }
+
+  private colorFor(name: string): string {
+    if (name === 'Y') return ANALYSIS_SERIES_COLORS.Y;
+    if (name === 'Z' || name === 'Mag') return ANALYSIS_SERIES_COLORS.Z;
+    return ANALYSIS_SERIES_COLORS.X;
+  }
+
+  /** Spelled the way the graph's own axis spells it. */
+  private unitFor(): string {
+    const length = this.unitStr(this.settings.lengthUnit.value);
+    const angle = this.unitStr(this.settings.angleUnit.value);
+    if (this.mechProp.includes('Angular')) {
+      if (this.mechProp.includes('Acc')) return `${angle}/s²`;
+      if (this.mechProp.includes('Vel')) return `${angle}/s`;
+      return angle;
+    }
+    if (this.analysis === 'force') return 'N';
+    if (this.mechProp.includes('Acc')) return `${length}/s²`;
+    if (this.mechProp.includes('Vel')) return `${length}/s`;
+    return length;
+  }
+
+  private unitStr(unit: LengthUnit | AngleUnit): string {
+    switch (unit) {
+      case AngleUnit.RADIAN:
+        return 'rad';
+      case AngleUnit.DEGREE:
+        return 'deg';
+      case LengthUnit.INCH:
+        return 'in';
+      case LengthUnit.METER:
+        return 'm';
+      default:
+        return 'cm';
+    }
+  }
+}

--- a/src/app/component/analysis-graph/analysis-apex-chart.component.ts
+++ b/src/app/component/analysis-graph/analysis-apex-chart.component.ts
@@ -84,13 +84,43 @@ export class AnalysisApexChartComponent implements OnChanges, AfterViewInit, OnD
   ngAfterViewInit(): void {
     this.viewInitialized = true;
     this.scheduleUpdate();
+    this.watchWidth();
   }
 
   ngOnDestroy(): void {
     this.destroyed = true;
     this.updateGeneration++;
+    this.widthWatch?.disconnect();
     this.chartInstance?.destroy();
     this.chartInstance = undefined;
+  }
+
+  private widthWatch?: ResizeObserver;
+  private renderedWidth = 0;
+
+  /**
+   * Re-lay the chart out when its container's width changes under it.
+   *
+   * Apex measures the host once, at construction, and keeps that width. A chart
+   * built while the panel was still settling -- which is every chart on the
+   * first render of a panel -- stayed at the width it was built for, so the
+   * label at the far end of the axis sat past the card's edge and was clipped.
+   * Toggling the card rebuilt the chart and it came back right, which is what
+   * made this look like a rendering bug rather than a measuring one.
+   */
+  private watchWidth(): void {
+    const host = this.chartHost?.nativeElement;
+    if (!host || typeof ResizeObserver === 'undefined') return;
+    this.renderedWidth = host.clientWidth;
+    this.widthWatch = new ResizeObserver(() => {
+      const width = host.clientWidth;
+      if (!width || width === this.renderedWidth || this.destroyed) return;
+      this.renderedWidth = width;
+      this.zone.runOutsideAngular(() => {
+        this.chartInstance?.updateOptions({ chart: { width } }, false, false);
+      });
+    });
+    this.widthWatch.observe(host);
   }
 
   updateOptions(

--- a/src/app/component/analysis-graph/analysis-graph.component.html
+++ b/src/app/component/analysis-graph/analysis-graph.component.html
@@ -1,24 +1,17 @@
 @if (analysisDiagnostic) {
   <div class="analysis-diagnostic" role="status">{{ analysisDiagnostic }}</div>
 } @else {
-  <div
-    [@showHide]="noDataSelected ? 'graphHidden' : 'graphShown'"
-    [class.compact-single-series]="compactSingleSeries"
-    id="graphNoSeries"
-    role="status"
-  >
-    Please select at least one data series.
-  </div>
-  <div
-    [@showHide]="loading ? 'graphHidden' : 'graphShown'"
-    [class.compact-single-series]="compactSingleSeries"
-    id="graphDragging"
-    role="status"
-  >
-    Graph unavailable while dragging.
-  </div>
+  <!-- In place of the chart rather than over it: these used to be fixed-height
+       overlays pinned 100px down the card, which on a short graph covered the
+       card below and on a tall one floated in the middle of nothing. -->
+  @if (noDataSelected || loading) {
+    <div class="graphPlaceholder" role="status">
+      {{ noDataSelected ? 'No series shown. Pick one above.' : 'Graph paused while dragging.' }}
+    </div>
+  }
   <app-analysis-apex-chart
     #chart
+    [class.hidden]="noDataSelected || loading"
     role="img"
     [attr.aria-label]="graphSummary"
     [class.compact-single-series]="compactSingleSeries"

--- a/src/app/component/analysis-graph/analysis-graph.component.html
+++ b/src/app/component/analysis-graph/analysis-graph.component.html
@@ -1,55 +1,6 @@
 @if (analysisDiagnostic) {
   <div class="analysis-diagnostic" role="status">{{ analysisDiagnostic }}</div>
 } @else {
-  @if (numberOfSeries === 3) {
-    <div
-      id="graph-checkbox-list-three"
-      [formGroup]="seriesCheckboxForm"
-      role="group"
-      [attr.aria-label]="'Series shown in ' + graphLabel"
-    >
-      <mat-checkbox class="series-z" formControlName="z" (change)="applySeriesVisibility()"
-        >Magnitude</mat-checkbox
-      >
-      <mat-checkbox
-        class="series-x"
-        formControlName="x"
-        color="primary"
-        (change)="applySeriesVisibility()"
-        >X</mat-checkbox
-      >
-      <mat-checkbox
-        class="series-y"
-        formControlName="y"
-        color="warn"
-        (change)="applySeriesVisibility()"
-        >Y</mat-checkbox
-      >
-    </div>
-  }
-  @if (numberOfSeries === 2) {
-    <div
-      id="graph-checkbox-list-two"
-      [formGroup]="seriesCheckboxForm"
-      role="group"
-      [attr.aria-label]="'Series shown in ' + graphLabel"
-    >
-      <mat-checkbox
-        class="series-x"
-        formControlName="x"
-        color="primary"
-        (change)="applySeriesVisibility()"
-        >X</mat-checkbox
-      >
-      <mat-checkbox
-        class="series-y"
-        formControlName="y"
-        color="warn"
-        (change)="applySeriesVisibility()"
-        >Y</mat-checkbox
-      >
-    </div>
-  }
   <div
     [@showHide]="noDataSelected ? 'graphHidden' : 'graphShown'"
     [class.compact-single-series]="compactSingleSeries"
@@ -86,14 +37,4 @@
   >
   </app-analysis-apex-chart>
 
-  <button
-    id="csvDownload"
-    (click)="downloadCSV()"
-    mat-stroked-button
-    color="primary"
-    [attr.aria-label]="'Download ' + graphLabel + ' data as CSV'"
-  >
-    <mat-icon>download</mat-icon>
-    Download Data (CSV)
-  </button>
 }

--- a/src/app/component/analysis-graph/analysis-graph.component.scss
+++ b/src/app/component/analysis-graph/analysis-graph.component.scss
@@ -38,13 +38,26 @@
     display: block;
   }
 
+  // The chart draws itself 250px tall; a host shorter than that does not make
+  // a shorter chart, it cuts the bottom off one -- which is where the time
+  // axis's label lives.
   app-analysis-apex-chart > div:not(.chart-render-error) {
     min-height: 0 !important;
-    height: 250px !important;
+    height: auto !important;
   }
 
-  app-analysis-apex-chart.compact-single-series > div:not(.chart-render-error) {
-    height: 210px !important;
+  // Nothing below the plot but the axis it belongs to.
+  .apexcharts-canvas {
+    margin-bottom: -6px;
+  }
+
+  // A container Apex leaves in the DOM with a border on it whether or not there
+  // is anything to say. Empty, it reads as a stray box floating over the plot,
+  // and half of one while the card is opening.
+  .apexcharts-tooltip:not(.apexcharts-active),
+  .apexcharts-xaxistooltip:not(.apexcharts-active),
+  .apexcharts-yaxistooltip:not(.apexcharts-active) {
+    display: none !important;
   }
 
   .chart-render-error {

--- a/src/app/component/analysis-graph/analysis-graph.component.scss
+++ b/src/app/component/analysis-graph/analysis-graph.component.scss
@@ -11,36 +11,40 @@
   $background: map.get($theme, background);
   $foreground: map.get($theme, foreground);
 
-  #graphNoSeries,
-  #graphDragging {
-    background-color: rgb(255, 255, 255);
-    position: absolute;
-    top: 100px;
-    left: 0;
-    width: 100%;
-    height: 240px;
-    z-index: 100;
+  // Stands where the chart would, so nothing has to guess its height.
+  .graphPlaceholder {
     display: flex;
+    align-items: center;
     justify-content: center;
-    align-items: start;
-    color: black;
+    min-height: 160px;
+    margin: 4px 0 8px;
+    border: 1px dashed #dfe1ea;
     border-radius: var(--border-radius);
-    pointer-events: none;
-    padding-top: 80px;
-
-    &.compact-single-series {
-      top: 60px;
-    }
+    background: #fafbfd;
+    color: rgba(0, 0, 0, 0.5);
+    font-size: 13px;
+    text-align: center;
+    padding: 0 16px;
   }
 
-  app-analysis-apex-chart.compact-single-series {
+  app-analysis-apex-chart.hidden {
+    display: none;
+  }
+
+  // A single-series graph is shorter, not lifted: the -40px here closed the gap
+  // the old checkbox row left behind, and with that row gone it pulled the plot
+  // up over the values above it.
+  app-analysis-apex-chart {
     display: block;
-    margin-top: -40px;
   }
 
   app-analysis-apex-chart > div:not(.chart-render-error) {
     min-height: 0 !important;
-    height: 225px !important;
+    height: 250px !important;
+  }
+
+  app-analysis-apex-chart.compact-single-series > div:not(.chart-render-error) {
+    height: 210px !important;
   }
 
   .chart-render-error {
@@ -52,7 +56,6 @@
     text-align: center;
     color: mat.m2-get-color-from-palette($primary-palette, 900);
   }
-
 
   .analysis-diagnostic {
     margin: 16px 4px 12px;

--- a/src/app/component/analysis-graph/analysis-graph.component.scss
+++ b/src/app/component/analysis-graph/analysis-graph.component.scss
@@ -11,81 +11,6 @@
   $background: map.get($theme, background);
   $foreground: map.get($theme, foreground);
 
-  #graph-checkbox-list-three {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    padding-left: 4px;
-    padding-right: 10px;
-    margin-top: -10px;
-    margin-bottom: -25px;
-  }
-
-  #graph-checkbox-list-two {
-    display: flex;
-    flex-direction: row;
-    justify-content: start;
-    align-items: center;
-    gap: 20px;
-    padding-left: 4px;
-    padding-right: 10px;
-    margin-top: -10px;
-    margin-bottom: -25px;
-  }
-
-  #graph-checkbox-list-three,
-  #graph-checkbox-list-two {
-    // The negative bottom margin above pulls the chart up into this row, so the
-    // chart's SVG paints over the labels and swallows clicks meant for them.
-    // Lifting the row restores the label as a hit target for its checkbox.
-    position: relative;
-    z-index: 1;
-
-    .mdc-form-field {
-      align-items: center;
-    }
-
-    .mdc-label {
-      line-height: 20px;
-    }
-
-    .series-x {
-      --mat-checkbox-selected-focus-icon-color: #313aa7;
-      --mat-checkbox-selected-hover-icon-color: #313aa7;
-      --mat-checkbox-selected-icon-color: #313aa7;
-      --mat-checkbox-selected-pressed-icon-color: #313aa7;
-      --mat-checkbox-selected-focus-state-layer-color: #313aa7;
-      --mat-checkbox-selected-hover-state-layer-color: #313aa7;
-      --mat-checkbox-selected-pressed-state-layer-color: #313aa7;
-    }
-
-    .series-y {
-      --mat-checkbox-selected-focus-icon-color: #ea2b29;
-      --mat-checkbox-selected-hover-icon-color: #ea2b29;
-      --mat-checkbox-selected-icon-color: #ea2b29;
-      --mat-checkbox-selected-pressed-icon-color: #ea2b29;
-      --mat-checkbox-selected-focus-state-layer-color: #ea2b29;
-      --mat-checkbox-selected-hover-state-layer-color: #ea2b29;
-      --mat-checkbox-selected-pressed-state-layer-color: #ea2b29;
-    }
-
-    .series-z {
-      --mat-checkbox-selected-focus-icon-color: #fdb50e;
-      --mat-checkbox-selected-hover-icon-color: #fdb50e;
-      --mat-checkbox-selected-icon-color: #fdb50e;
-      --mat-checkbox-selected-pressed-icon-color: #fdb50e;
-      --mat-checkbox-selected-focus-state-layer-color: #fdb50e;
-      --mat-checkbox-selected-hover-state-layer-color: #fdb50e;
-      --mat-checkbox-selected-pressed-state-layer-color: #fdb50e;
-    }
-  }
-
-  #shift-up {
-    margin-top: -100px;
-    background-color: red;
-  }
-
   #graphNoSeries,
   #graphDragging {
     background-color: rgb(255, 255, 255);
@@ -128,29 +53,6 @@
     color: mat.m2-get-color-from-palette($primary-palette, 900);
   }
 
-  #csvDownload {
-    width: 100%;
-    border-color: mat.m2-get-color-from-palette($primary-palette, 500) !important;
-    margin-top: 6px;
-    margin-bottom: 10px;
-
-    .mdc-button__label {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 8px;
-      line-height: 20px;
-      white-space: nowrap;
-    }
-
-    .mat-icon {
-      margin: 0;
-      height: 20px;
-      width: 20px;
-      font-size: 20px;
-      line-height: 20px;
-    }
-  }
 
   .analysis-diagnostic {
     margin: 16px 4px 12px;

--- a/src/app/component/analysis-graph/analysis-graph.component.spec.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.spec.ts
@@ -16,6 +16,7 @@ import { KinematicsSolver } from '../../model/mechanism/kinematic-solver';
 import { ForceUnit, LengthUnit } from '../../model/unit-enums';
 import { NumberUnitParserService } from '../../services/number-unit-parser.service';
 import { ActiveObjService } from '../../services/active-obj.service';
+import { AnalysisSampleService } from '../../services/analysis-sample.service';
 import { MechanismService } from '../../services/mechanism.service';
 import { SettingsService } from '../../services/settings.service';
 import { BUILT_IN_TEMPLATE_IDS, TEMPLATE_LINKAGES } from '../MODALS/templates/template-linkages';
@@ -82,7 +83,8 @@ function createComponent(fixture: MechanismFixture): AnalysisGraphComponent {
     fixture.service,
     fixture.settings,
     new NumberUnitParserService(),
-    fixture.active
+    fixture.active,
+    new AnalysisSampleService(fixture.settings)
   );
 }
 
@@ -442,7 +444,7 @@ describe('AnalysisGraphComponent lifecycle', () => {
 describe('AnalysisGraphComponent rendered controls', () => {
   afterEach(() => TestBed.resetTestingModule());
 
-  it('updates the rendered chart series when its Material checkboxes are clicked', async () => {
+  it('updates the rendered chart series when a series is switched off and on', async () => {
     const fixtureData = buildMechanismFixture(TEMPLATE_LINKAGES['4-Bar']);
     await TestBed.configureTestingModule({
       declarations: [AnalysisGraphComponent, ApexChartStubComponent],
@@ -472,26 +474,28 @@ describe('AnalysisGraphComponent rendered controls', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    const loader = TestbedHarnessEnvironment.loader(fixture);
-    const xCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'X' }));
-    const yCheckbox = await loader.getHarness(MatCheckboxHarness.with({ label: 'Y' }));
-    expect(await xCheckbox.isChecked()).toBe(true);
-    expect(await yCheckbox.isChecked()).toBe(true);
+    // The switches live on the panel header that owns this graph now -- one row
+    // that reads the values out and turns the lines on and off -- so this drives
+    // the API that row calls rather than a checkbox that no longer exists.
+    const graph = fixture.componentInstance;
+    expect(graph.isSeriesShown('x')).toBe(true);
+    expect(graph.isSeriesShown('y')).toBe(true);
 
-    await xCheckbox.uncheck();
+    graph.toggleSeries('x');
     fixture.detectChanges();
-    expect(fixture.componentInstance.displayedSeries.map((series) => series.name)).toEqual(['Y']);
+    expect(graph.isSeriesShown('x')).toBe(false);
+    expect(graph.displayedSeries.map((series) => series.name)).toEqual(['Y']);
 
-    await yCheckbox.uncheck();
+    graph.toggleSeries('y');
     fixture.detectChanges();
-    expect(fixture.componentInstance.displayedSeries).toHaveLength(0);
-    expect(fixture.componentInstance.noDataSelected).toBe(true);
+    expect(graph.displayedSeries).toHaveLength(0);
+    expect(graph.noDataSelected).toBe(true);
     expect(fixture.nativeElement.textContent).toContain('Please select at least one data series.');
 
-    await xCheckbox.check();
+    graph.toggleSeries('x');
     fixture.detectChanges();
-    expect(fixture.componentInstance.displayedSeries.map((series) => series.name)).toEqual(['X']);
-    expect(fixture.componentInstance.noDataSelected).toBe(false);
+    expect(graph.displayedSeries.map((series) => series.name)).toEqual(['X']);
+    expect(graph.noDataSelected).toBe(false);
 
     const chartStub = fixture.debugElement.query(By.directive(ApexChartStubComponent))
       .componentInstance as ApexChartStubComponent;

--- a/src/app/component/analysis-graph/analysis-graph.component.spec.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.spec.ts
@@ -490,7 +490,7 @@ describe('AnalysisGraphComponent rendered controls', () => {
     fixture.detectChanges();
     expect(graph.displayedSeries).toHaveLength(0);
     expect(graph.noDataSelected).toBe(true);
-    expect(fixture.nativeElement.textContent).toContain('Please select at least one data series.');
+    expect(fixture.nativeElement.textContent).toContain('No series shown. Pick one above.');
 
     graph.toggleSeries('x');
     fixture.detectChanges();

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -23,17 +23,18 @@ import {
   ApexYAxis,
 } from 'apexcharts';
 import { KinematicsSolver } from 'src/app/model/mechanism/kinematic-solver';
+import { ANALYSIS_SERIES_COLORS } from 'src/app/model/analysis-series';
+export { ANALYSIS_SERIES_COLORS };
 import { ForceAnalysisMode } from 'src/app/model/mechanism/force-solver';
 import { Mechanism } from 'src/app/model/mechanism/mechanism';
-import { AngleUnit, ForceUnit, LengthUnit, roundNumber } from '../../model/utils';
-import { LBF_IN_PER_NEWTON_METER, LBF_PER_NEWTON } from '../../model/unit-conversions';
-import { MODEL_SCALE } from '../../model/render-scale';
+import { AngleUnit, ForceUnit, LengthUnit } from '../../model/utils';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { FormBuilder } from '@angular/forms';
 import { MechanismService } from '../../services/mechanism.service';
 import { SettingsService } from '../../services/settings.service';
 import { NumberUnitParserService } from '../../services/number-unit-parser.service';
 import { ActiveObjService } from '../../services/active-obj.service';
+import { AnalysisSampleService } from '../../services/analysis-sample.service';
 import { skip, Subscription } from 'rxjs';
 import { AnalysisApexChartComponent } from './analysis-apex-chart.component';
 
@@ -54,12 +55,6 @@ export type ChartOptions = {
   toolbar: any;
   legend: ApexLegend;
 };
-
-export const ANALYSIS_SERIES_COLORS = {
-  X: '#313aa7',
-  Y: '#ea2b29',
-  Z: '#fdb50e',
-} as const;
 
 /**
  * Time axis labels: a typical cycle runs 0-3 s, where "3.000" is noise. Cap at
@@ -273,7 +268,8 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
     private mechanismService: MechanismService,
     public settingsService: SettingsService,
     private nup: NumberUnitParserService,
-    private activeSrv: ActiveObjService
+    private activeSrv: ActiveObjService,
+    private samples: AnalysisSampleService
   ) {}
 
   seriesCheckboxForm = this.fb.group(
@@ -364,6 +360,38 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
       this.applySeriesVisibility();
       this.updateYAxis();
     }, 1);
+  }
+
+  /**
+   * Which series this graph has, in the order it plots them.
+   *
+   * Two means X and Y; three means either X, Y and a magnitude, or the three
+   * components of a force -- `seriesLabel` is what knows the difference.
+   */
+  get seriesKeys(): ('x' | 'y' | 'z')[] {
+    if (this.numberOfSeries === 3) return ['z', 'x', 'y'];
+    if (this.numberOfSeries === 2) return ['x', 'y'];
+    return [];
+  }
+
+  seriesLabel(key: 'x' | 'y' | 'z'): string {
+    if (key !== 'z') return key.toUpperCase();
+    // The third series is the magnitude of the other two, except in force
+    // analysis, where it is a component of its own.
+    return this.analysis === 'force' ? 'Z' : 'Magnitude';
+  }
+
+  isSeriesShown(key: 'x' | 'y' | 'z'): boolean {
+    return !!this.seriesCheckboxForm.value[key];
+  }
+
+  /** The legend is the switch. Showing none of them is allowed; the graph says so. */
+  toggleSeries(key: 'x' | 'y' | 'z'): void {
+    this.seriesCheckboxForm.patchValue({ [key]: !this.isSeriesShown(key) });
+  }
+
+  colorForSeriesKey(key: 'x' | 'y' | 'z'): string {
+    return this.colorForSeries(this.seriesLabel(key) === 'Magnitude' ? 'Z' : key.toUpperCase());
   }
 
   applySeriesVisibility(): void {
@@ -852,70 +880,30 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
     const datum_X: number[] = [];
     const datum_Y: number[] = [];
     const datum_Z: number[] = [];
-    let x = 0;
-    let y = 0;
-    let z = 0;
     const categories: string[] = [];
     const mechanism = this.mechanismFor(mechPart);
     // A loose joint, or a chain that never reaches ground, is in no mechanism
     // and so has nothing solved to plot.
     if (!mechanism) return [[datum_X, datum_Y, datum_Z], categories];
+
+    const series = [datum_X, datum_Y, datum_Z];
+    /** One solved sample, spread across the series in the order plotted. */
+    const collect = (index: number): void => {
+      this.samples
+        .sampleAt(mechanism, index, analysis, analysisType, mechProp, mechPart, this.reactionLinkId)
+        .forEach((value, position) => series[position].push(value));
+    };
+
     if (analysis === 'force') {
       const mode: ForceAnalysisMode = analysisType === 'dynamic' ? 'dynamic' : 'static';
       const result = mechanism.getForceAnalysis(mode);
-      const forceConversion =
-        this.settingsService.forceUnit.value === ForceUnit.LBF ? LBF_PER_NEWTON : 1;
-      const torqueConversion =
-        this.settingsService.forceUnit.value === ForceUnit.LBF ? LBF_IN_PER_NEWTON_METER : 1;
-
-      for (const frame of result.frames) {
+      result.frames.forEach((frame, index) => {
         categories.push(frame.timeSeconds.toString());
-        if (frame.status !== 'ok') {
-          datum_X.push(Number.NaN);
-          if (mechProp === 'Joint Forces') {
-            datum_Y.push(Number.NaN);
-            datum_Z.push(Number.NaN);
-          }
-          continue;
-        }
+        collect(index);
+      });
 
-        if (mechProp === 'Input Torque' || mechProp === 'Input Effort') {
-          // A torque's moment arms are internal model lengths (MODEL_SCALE
-          // times the user's unit), so the solved value divides back down for
-          // display. An input *force* has no length in it and is invariant.
-          datum_X.push(
-            frame.inputEffort
-              ? roundNumber(
-                  (frame.inputEffort.valueSI *
-                    (frame.inputEffort.kind === 'force' ? forceConversion : torqueConversion)) /
-                    (frame.inputEffort.kind === 'force' ? 1 : MODEL_SCALE),
-                  3
-                )
-              : Number.NaN
-          );
-          continue;
-        }
-
-        const byLink = frame.jointReactionsByLink.get(mechPart);
-        const reaction = this.reactionLinkId
-          ? byLink?.get(this.reactionLinkId)
-          : frame.jointReactions.get(mechPart);
-        if (!reaction) {
-          datum_X.push(Number.NaN);
-          datum_Y.push(Number.NaN);
-          datum_Z.push(Number.NaN);
-          continue;
-        }
-        x = reaction[0] * forceConversion;
-        y = reaction[1] * forceConversion;
-        z = Math.hypot(x, y);
-        datum_X.push(roundNumber(x, 3));
-        datum_Y.push(roundNumber(y, 3));
-        datum_Z.push(roundNumber(z, 3));
-      }
-
-      const hasFiniteData = [datum_X, datum_Y, datum_Z].some((series) =>
-        series.some(Number.isFinite)
+      const hasFiniteData = [datum_X, datum_Y, datum_Z].some((values) =>
+        values.some(Number.isFinite)
       );
       this.analysisDiagnostic = hasFiniteData
         ? null
@@ -926,121 +914,13 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
       return [[datum_X, datum_Y, datum_Z], categories];
     }
 
+    // The solver keeps its answers in statics, and starts each graph from a
+    // clean set of them rather than from the last mechanism graphed.
     KinematicsSolver.resetVariables();
     KinematicsSolver.requiredLoops = mechanism.requiredLoops;
     mechanism.joints.forEach((_, index) => {
       categories.push(mechanism.timeNum[index]?.toString() ?? index.toString());
-      const vector = (value: [number, number] | undefined): [number, number] =>
-        value ?? [Number.NaN, Number.NaN];
-      switch (mechProp) {
-        // Positions, velocities and accelerations are linear in length, so
-        // each internal model value divides by MODEL_SCALE for display in the
-        // user's unit. Angular series carry no length and pass through.
-        case 'Linear Joint Pos':
-          const jt = mechanism.joints[index].find((j) => j.id === mechPart);
-          x = (jt?.x ?? Number.NaN) / MODEL_SCALE;
-          y = (jt?.y ?? Number.NaN) / MODEL_SCALE;
-          datum_X.push(roundNumber(x, 3));
-          datum_Y.push(roundNumber(y, 3));
-          break;
-        case 'Linear Joint Vel':
-          KinematicsSolver.determineKinematics(
-            mechanism.joints[index],
-            mechanism.links[index],
-            mechanism.inputAngularVelocities[index]
-          );
-          [x, y] = vector(KinematicsSolver.jointVelMap.get(mechPart));
-          x /= MODEL_SCALE;
-          y /= MODEL_SCALE;
-          z = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
-          datum_X.push(roundNumber(x, 3));
-          datum_Y.push(roundNumber(y, 3));
-          datum_Z.push(roundNumber(z, 3));
-          break;
-        case 'Linear Joint Acc':
-          KinematicsSolver.determineKinematics(
-            mechanism.joints[index],
-            mechanism.links[index],
-            mechanism.inputAngularVelocities[index]
-          );
-          [x, y] = vector(KinematicsSolver.jointAccMap.get(mechPart));
-          x /= MODEL_SCALE;
-          y /= MODEL_SCALE;
-          z = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
-          datum_X.push(roundNumber(x, 3));
-          datum_Y.push(roundNumber(y, 3));
-          datum_Z.push(roundNumber(z, 3));
-          break;
-        case "Linear Link's CoM Pos":
-          KinematicsSolver.determineKinematics(
-            mechanism.joints[index],
-            mechanism.links[index],
-            mechanism.inputAngularVelocities[index]
-          );
-          [x, y] = vector(KinematicsSolver.linkCoMMap.get(mechPart));
-          x /= MODEL_SCALE;
-          y /= MODEL_SCALE;
-          datum_X.push(roundNumber(x, 3));
-          datum_Y.push(roundNumber(y, 3));
-          break;
-        case "Linear Link's CoM Vel":
-          KinematicsSolver.determineKinematics(
-            mechanism.joints[index],
-            mechanism.links[index],
-            mechanism.inputAngularVelocities[index]
-          );
-          [x, y] = vector(KinematicsSolver.linkVelMap.get(mechPart));
-          x /= MODEL_SCALE;
-          y /= MODEL_SCALE;
-          z = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
-          datum_X.push(roundNumber(x, 3));
-          datum_Y.push(roundNumber(y, 3));
-          datum_Z.push(roundNumber(z, 3));
-          break;
-        case "Linear Link's CoM Acc":
-          KinematicsSolver.determineKinematics(
-            mechanism.joints[index],
-            mechanism.links[index],
-            mechanism.inputAngularVelocities[index]
-          );
-          [x, y] = vector(KinematicsSolver.linkAccMap.get(mechPart));
-          x /= MODEL_SCALE;
-          y /= MODEL_SCALE;
-          z = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
-          datum_X.push(roundNumber(x, 3));
-          datum_Y.push(roundNumber(y, 3));
-          datum_Z.push(roundNumber(z, 3));
-          break;
-        case 'Angular Link Pos':
-          KinematicsSolver.determineKinematics(
-            mechanism.joints[index],
-            mechanism.links[index],
-            mechanism.inputAngularVelocities[index]
-          );
-          x = KinematicsSolver.linkAngPosMap.get(mechPart) ?? Number.NaN;
-          datum_X.push(roundNumber(x, 3));
-          break;
-        case 'Angular Link Vel':
-          KinematicsSolver.determineKinematics(
-            mechanism.joints[index],
-            mechanism.links[index],
-            mechanism.inputAngularVelocities[index]
-          );
-          x = KinematicsSolver.linkAngVelMap.get(mechPart) ?? Number.NaN;
-          datum_X.push(roundNumber(x, 3));
-          break;
-        case 'Angular Link Acc':
-          KinematicsSolver.determineKinematics(
-            mechanism.joints[index],
-            mechanism.links[index],
-            mechanism.inputAngularVelocities[index]
-          );
-          x = KinematicsSolver.linkAngAccMap.get(mechPart) ?? Number.NaN;
-          datum_X.push(roundNumber(x, 3));
-          break;
-        case 'ic':
-          break;
-      }
+      collect(index);
     });
     return [[datum_X, datum_Y, datum_Z], categories];
   }

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -157,7 +157,7 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
       show: true,
       padding: {
         top: -14,
-        bottom: 0,
+        bottom: -8,
       },
       xaxis: {
         lines: {
@@ -199,9 +199,11 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
       tickAmount: 1,
       title: {
         text: 'Time (seconds)',
-        // Up beside the two ends rather than on a line of its own below them.
-        offsetY: -18,
-        offsetX: 0,
+        // Up beside the two ends rather than on a line of its own below them,
+        // and centred between them: Apex centres it on the whole canvas, which
+        // the y axis's own labels make eight pixels wider on the left.
+        offsetY: -20,
+        offsetX: -8,
       },
       tooltip: {
         enabled: false,

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -145,7 +145,7 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
       show: true,
       padding: {
         top: 0,
-        bottom: 12,
+        bottom: 0,
       },
       xaxis: {
         lines: {
@@ -160,8 +160,10 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
     },
     xaxis: {
       type: 'numeric',
-      position: 'top',
-      offsetY: 15,
+      // Under the plot, where a time axis reads. It sat on top because the
+      // legend used to want the room below it, and the legend has gone.
+      position: 'bottom',
+      offsetY: 0,
       // floating: true,
       // categories: categories,
       labels: {
@@ -179,8 +181,8 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
       tickAmount: 1,
       title: {
         text: 'Time (seconds)',
-        // small nudge to sit on the same baseline as the tick labels
-        offsetY: 6,
+        // On the same baseline as the tick labels either side of it.
+        offsetY: -4,
         offsetX: 0,
       },
       tooltip: {

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -66,6 +66,18 @@ export function formatTimeLabel(value: number): string {
   return Number(rounded.toFixed(3)).toString();
 }
 
+/**
+ * The two ends of the time axis, to one decimal.
+ *
+ * They read beside the y axis, which is also one decimal, and "0" against
+ * "6.0" looks like two different kinds of number.
+ */
+export function formatAxisEnd(value: number): string {
+  const rounded = Number(value);
+  if (!Number.isFinite(rounded)) return '';
+  return rounded.toFixed(1);
+}
+
 @Component({
   selector: 'app-analysis-graph',
   templateUrl: './analysis-graph.component.html',
@@ -144,7 +156,7 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
       position: 'back',
       show: true,
       padding: {
-        top: 0,
+        top: -14,
         bottom: 0,
       },
       xaxis: {
@@ -173,16 +185,22 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
         // the space actually free at the two ends of this axis.
         trim: false,
         hideOverlappingLabels: false,
-        offsetY: 0,
+        // Clear of the plot's own frame, which they used to sit against.
+        offsetY: 4,
+        style: {
+          fontSize: '12px',
+          fontWeight: 400,
+          colors: ['#373d3f', '#373d3f'],
+        },
         formatter: function (val) {
-          return formatTimeLabel(Number(val));
+          return formatAxisEnd(Number(val));
         },
       },
       tickAmount: 1,
       title: {
         text: 'Time (seconds)',
-        // On the same baseline as the tick labels either side of it.
-        offsetY: -4,
+        // Up beside the two ends rather than on a line of its own below them.
+        offsetY: -18,
         offsetX: 0,
       },
       tooltip: {

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -210,6 +210,15 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
     yaxis: {
       showForNullSeries: false,
       forceNiceScale: true,
+      // The same size and weight as the time axis. Apex defaults the two axes
+      // to 11px and the x axis was set to 12px on its own, so the two ends of
+      // one plot were lettered differently.
+      labels: {
+        style: {
+          fontSize: '12px',
+          fontWeight: 400,
+        },
+      },
       min: function (min) {
         return Math.floor(min);
       },
@@ -218,6 +227,9 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
       },
       title: {
         text: 'setLater',
+        style: {
+          fontSize: '12px',
+        },
       },
       // tickAmount: 1,
       decimalsInFloat: 1,

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -467,10 +467,16 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
         {
           x: timeSeconds,
           borderColor: '#000000',
+          // Under the line rather than over it. Above, it was pushed past the
+          // top of the plot and clipped by the card, which left a white box
+          // with half a label in it hanging over the chart.
           label: {
-            text: 'T= ' + formatTimeLabel(timeSeconds),
+            // One decimal, like the two ends of the axis it sits on: "T= 1"
+            // beside "0.0" and "3.0" is the same number written two ways.
+            text: 'T= ' + formatAxisEnd(timeSeconds),
             orientation: 'horizontal',
-            offsetY: -20,
+            position: 'bottom',
+            offsetY: 4,
           },
         },
         false

--- a/src/app/component/analysis-panel/analysis-panel.component.html
+++ b/src/app/component/analysis-panel/analysis-panel.component.html
@@ -142,14 +142,16 @@
         ></app-analysis-graph-section>
       }
       @if (showForce) {
-        <radio-block
-          tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
-          option1="Static (Equilibrium)"
-          option2="In-motion (Dynamic)"
-          [formGroup]="this.forceAnalysisFormGroup"
-          _formControl="mode"
-          >Force Analysis Type
-        </radio-block>
+        <div class="forceModeRow">
+          <radio-block
+            tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
+            option1="Static (Equilibrium)"
+            option2="In-motion (Dynamic)"
+            [formGroup]="this.forceAnalysisFormGroup"
+            _formControl="mode"
+            >Force Analysis Type
+          </radio-block>
+        </div>
         @if (jointForceRows().length === 0) {
           <div class="analysis-message" role="status">
             Joint {{ this.activeSrv.selectedJoint.name }} is internal to one welded body and has no
@@ -233,9 +235,13 @@
           [expanded]="graphExpanded['LAngAcc']"
           (expandedChange)="graphExpanded['LAngAcc'] = $event"
         ></app-analysis-graph-section>
-        <subtitle-block style="margin-top: 20px"
-          >Center of Mass (COM) of {{ selectedBodyLabel }}</subtitle-block
+        <div
+          class="graphGroupHeading"
+          (mouseenter)="highlightCoM(true)"
+          (mouseleave)="highlightCoM(false)"
         >
+          Centre of mass
+        </div>
         <app-analysis-graph-section
           label="Position of {{ selectedBodyLabel }}'s COM"
           help="Where this link’s centre of mass is"
@@ -268,14 +274,16 @@
         ></app-analysis-graph-section>
       }
       @if (showForce) {
-        <radio-block
-          tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
-          option1="Static (Equilibrium)"
-          option2="In-motion (Dynamic)"
-          [formGroup]="this.forceAnalysisFormGroup"
-          _formControl="mode"
-          >Force Analysis Type
-        </radio-block>
+        <div class="forceModeRow">
+          <radio-block
+            tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
+            option1="Static (Equilibrium)"
+            option2="In-motion (Dynamic)"
+            [formGroup]="this.forceAnalysisFormGroup"
+            _formControl="mode"
+            >Force Analysis Type
+          </radio-block>
+        </div>
         @if (linkForceRows().length === 0) {
           <div class="analysis-message" role="status">
             {{ selectedBodyLabel }} has no external joint that carries an independent pin reaction.

--- a/src/app/component/analysis-panel/analysis-panel.component.html
+++ b/src/app/component/analysis-panel/analysis-panel.component.html
@@ -106,181 +106,81 @@
   <!-- Joint Kinematics-->
   @if (validMechanisms() && this.activeSrv.objType == 'Joint') {
     <panel-section id="analysis-panel">
-      <title-block
-        description="{{ inputSummary }} {{ inputEditHint }}"
-      >
-        Analysis for Joint
-        {{ this.activeSrv.selectedJoint.name }}
+      <title-block description="{{ inputSummary }} {{ inputEditHint }}">
+        {{ modeLabel }} for Joint {{ this.activeSrv.selectedJoint.name }}
       </title-block>
       @if (showKinematic) {
-        <collapsible-subseciton
-          titleLabel="Kinematic Analysis"
-          [expanded]="graphExpanded['JKineAna']"
-          (opened)="graphExpanded['JKineAna'] = true"
-          (closed)="graphExpanded['JKineAna'] = false"
-        >
-          <mat-expansion-panel
-            [expanded]="graphExpanded['JPos']"
-            (opened)="graphExpanded['JPos'] = true"
-            (closed)="graphExpanded['JPos'] = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Position of Joint {{ this.activeSrv.selectedJoint.name }}
-              </mat-panel-title>
-              <mat-panel-description>
-                <mat-icon
-                  matTooltip="Where this joint is, through the cycle"
-                  [matTooltipShowDelay]="1000"
-                  id="graph-help"
-                  >help_outline
-                </mat-icon>
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            @if (graphExpanded['JPos']) {
-              <app-analysis-graph
-                analysis="kinematic"
-                analysisType="loop"
-                mechProp="Linear Joint Pos"
-                mechPart="{{ this.activeSrv.selectedJoint.id }}"
-              ></app-analysis-graph>
-            }
-          </mat-expansion-panel>
-          <mat-expansion-panel
-            [expanded]="graphExpanded['JVel']"
-            (opened)="graphExpanded['JVel'] = true"
-            (closed)="graphExpanded['JVel'] = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Velocity of Joint {{ this.activeSrv.selectedJoint.name }}
-              </mat-panel-title>
-              <mat-panel-description>
-                <mat-icon
-                  matTooltip="How fast this joint moves, and which way"
-                  [matTooltipShowDelay]="1000"
-                  id="graph-help"
-                  >help_outline
-                </mat-icon>
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            @if (graphExpanded['JVel']) {
-              <app-analysis-graph
-                analysis="kinematic"
-                analysisType="loop"
-                mechProp="Linear Joint Vel"
-                mechPart="{{ this.activeSrv.selectedJoint.id }}"
-              ></app-analysis-graph>
-            }
-          </mat-expansion-panel>
-          <mat-expansion-panel
-            [expanded]="graphExpanded['JAcc']"
-            (opened)="graphExpanded['JAcc'] = true"
-            (closed)="graphExpanded['JAcc'] = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Acceleration of Joint {{ this.activeSrv.selectedJoint.name }}
-              </mat-panel-title>
-              <mat-panel-description>
-                <mat-icon
-                  matTooltip="How this joint’s velocity changes"
-                  [matTooltipShowDelay]="1000"
-                  id="graph-help"
-                  >help_outline
-                </mat-icon>
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            @if (graphExpanded['JAcc']) {
-              <app-analysis-graph
-                analysis="kinematic"
-                analysisType="loop"
-                mechProp="Linear Joint Acc"
-                mechPart="{{ this.activeSrv.selectedJoint.id }}"
-              ></app-analysis-graph>
-            }
-          </mat-expansion-panel>
-        </collapsible-subseciton>
+        <app-analysis-graph-section
+          label="Position of Joint {{ this.activeSrv.selectedJoint.name }}"
+          help="Where this joint is, through the cycle"
+          analysis="kinematic"
+          analysisType="loop"
+          mechProp="Linear Joint Pos"
+          mechPart="{{ this.activeSrv.selectedJoint.id }}"
+          [expanded]="graphExpanded['JPos']"
+          (expandedChange)="graphExpanded['JPos'] = $event"
+        ></app-analysis-graph-section>
+        <app-analysis-graph-section
+          label="Velocity of Joint {{ this.activeSrv.selectedJoint.name }}"
+          help="How fast this joint moves, and which way"
+          analysis="kinematic"
+          analysisType="loop"
+          mechProp="Linear Joint Vel"
+          mechPart="{{ this.activeSrv.selectedJoint.id }}"
+          [expanded]="graphExpanded['JVel']"
+          (expandedChange)="graphExpanded['JVel'] = $event"
+        ></app-analysis-graph-section>
+        <app-analysis-graph-section
+          label="Acceleration of Joint {{ this.activeSrv.selectedJoint.name }}"
+          help="How this joint’s velocity changes"
+          analysis="kinematic"
+          analysisType="loop"
+          mechProp="Linear Joint Acc"
+          mechPart="{{ this.activeSrv.selectedJoint.id }}"
+          [expanded]="graphExpanded['JAcc']"
+          (expandedChange)="graphExpanded['JAcc'] = $event"
+        ></app-analysis-graph-section>
       }
       @if (showForce) {
-        <collapsible-subseciton
-          titleLabel="Force Analysis"
-          [expanded]="graphExpanded['JForceAna']"
-          (opened)="graphExpanded['JForceAna'] = true"
-          (closed)="graphExpanded['JForceAna'] = false"
-        >
-          <radio-block
-            tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
-            option1="Static (Equilibrium)"
-            option2="In-motion (Dynamic)"
-            [formGroup]="this.forceAnalysisFormGroup"
-            _formControl="mode"
-            >Force Analysis Type
-          </radio-block>
-          @if (jointForceRows().length === 0) {
-            <div class="analysis-message" role="status">
-              Joint {{ this.activeSrv.selectedJoint.name }} is internal to one welded body and has
-              no independent pin reaction. Select an external or grounded joint to graph a reaction.
-            </div>
-          }
-          @for (row of jointForceRows(); track row.linkId) {
-            <mat-expansion-panel
-              [expanded]="graphExpanded['JForce_' + row.linkId]"
-              (opened)="graphExpanded['JForce_' + row.linkId] = true"
-              (closed)="graphExpanded['JForce_' + row.linkId] = false"
-            >
-              <mat-expansion-panel-header>
-                <mat-panel-title> Force on Link {{ row.linkName }} </mat-panel-title>
-                <mat-panel-description>
-                  <mat-icon
-                    matTooltip="The reaction that link carries at this joint"
-                    [matTooltipShowDelay]="1000"
-                    id="graph-help"
-                    >help_outline
-                  </mat-icon>
-                </mat-panel-description>
-              </mat-expansion-panel-header>
-              @if (graphExpanded['JForce_' + row.linkId]) {
-                <app-analysis-graph
-                  analysis="force"
-                  [analysisType]="forceAnalysisMode()"
-                  mechProp="Joint Forces"
-                  mechPart="{{ row.jointId }}"
-                  [reactionLinkId]="row.linkId"
-                ></app-analysis-graph>
-              }
-            </mat-expansion-panel>
-          }
-          @if (this.activeSrv.selectedJoint.input) {
-            <mat-expansion-panel
-              [expanded]="graphExpanded['JInputForce']"
-              (opened)="graphExpanded['JInputForce'] = true"
-              (closed)="graphExpanded['JInputForce'] = false"
-            >
-              <mat-expansion-panel-header>
-                <mat-panel-title>
-                  Input {{ inputEffortLabel() }} at Joint {{ this.activeSrv.selectedJoint.name }}
-                </mat-panel-title>
-                <mat-panel-description>
-                  <mat-icon
-                    matTooltip="The effort the input has to supply to drive the mechanism"
-                    [matTooltipShowDelay]="1000"
-                    id="graph-help"
-                    >help_outline
-                  </mat-icon>
-                </mat-panel-description>
-              </mat-expansion-panel-header>
-              @if (graphExpanded['JInputForce']) {
-                <app-analysis-graph
-                  analysis="force"
-                  [analysisType]="forceAnalysisMode()"
-                  mechProp="Input Effort"
-                  mechPart="{{ this.activeSrv.selectedJoint.id }}"
-                ></app-analysis-graph>
-              }
-            </mat-expansion-panel>
-          }
-        </collapsible-subseciton>
+        <radio-block
+          tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
+          option1="Static (Equilibrium)"
+          option2="In-motion (Dynamic)"
+          [formGroup]="this.forceAnalysisFormGroup"
+          _formControl="mode"
+          >Force Analysis Type
+        </radio-block>
+        @if (jointForceRows().length === 0) {
+          <div class="analysis-message" role="status">
+            Joint {{ this.activeSrv.selectedJoint.name }} is internal to one welded body and has no
+            independent pin reaction. Select an external or grounded joint to graph a reaction.
+          </div>
+        }
+        @for (row of jointForceRows(); track row.linkId) {
+          <app-analysis-graph-section
+            label="Force on Link {{ row.linkName }}"
+            help="The reaction that link carries at this joint"
+            analysis="force"
+            [analysisType]="forceAnalysisMode()"
+            mechProp="Joint Forces"
+            mechPart="{{ row.jointId }}"
+            [reactionLinkId]="row.linkId"
+            [expanded]="graphExpanded['JForce_' + row.linkId]"
+            (expandedChange)="graphExpanded['JForce_' + row.linkId] = $event"
+          ></app-analysis-graph-section>
+        }
+        @if (this.activeSrv.selectedJoint.input) {
+          <app-analysis-graph-section
+            label="Input {{ inputEffortLabel() }} at Joint {{ this.activeSrv.selectedJoint.name }}"
+            help="The effort the input has to supply to drive the mechanism"
+            analysis="force"
+            [analysisType]="forceAnalysisMode()"
+            mechProp="Input Effort"
+            mechPart="{{ this.activeSrv.selectedJoint.id }}"
+            [expanded]="graphExpanded['JInputForce']"
+            (expandedChange)="graphExpanded['JInputForce'] = $event"
+          ></app-analysis-graph-section>
+        }
       }
     </panel-section>
   }
@@ -288,10 +188,8 @@
   <!-- Link Kinematics-->
   @if (validMechanisms() && this.activeSrv.objType == 'Link') {
     <panel-section id="analysis-panel">
-      <title-block
-        description="{{ inputSummary }} {{ inputEditHint }}"
-      >
-        Analysis for {{ selectedBodyLabel }}
+      <title-block description="{{ inputSummary }} {{ inputEditHint }}">
+        {{ modeLabel }} for {{ selectedBodyLabel }}
       </title-block>
       <!-- <subtitle-block>Kinematics</subtitle-block> -->
       <!--
@@ -305,229 +203,97 @@
               //Param 4: mechPart: If Joint 'a','b','c'... If Link 'ab','bc','cd'...
               -->
       @if (showKinematic) {
-        <collapsible-subseciton
-          titleLabel="Kinematic Analysis"
-          [expanded]="graphExpanded['LKineAna']"
-          (opened)="graphExpanded['LKineAna'] = true"
-          (closed)="graphExpanded['LKineAna'] = false"
+        <app-analysis-graph-section
+          label="Angle of {{ selectedBodyLabel }}"
+          help="The angle of this link above the horizontal"
+          analysis="kinematic"
+          analysisType="loop"
+          mechProp="Angular Link Pos"
+          mechPart="{{ this.activeSrv.selectedLink.id }}"
+          [expanded]="graphExpanded['LAng']"
+          (expandedChange)="graphExpanded['LAng'] = $event"
+        ></app-analysis-graph-section>
+        <app-analysis-graph-section
+          label="Angular Velocity of {{ selectedBodyLabel }}"
+          help="How fast this link turns, and which way"
+          analysis="kinematic"
+          analysisType="loop"
+          mechProp="Angular Link Vel"
+          mechPart="{{ this.activeSrv.selectedLink.id }}"
+          [expanded]="graphExpanded['LAngVel']"
+          (expandedChange)="graphExpanded['LAngVel'] = $event"
+        ></app-analysis-graph-section>
+        <app-analysis-graph-section
+          label="Angular Acceleration of {{ selectedBodyLabel }}"
+          help="How this link’s turning rate changes"
+          analysis="kinematic"
+          analysisType="loop"
+          mechProp="Angular Link Acc"
+          mechPart="{{ this.activeSrv.selectedLink.id }}"
+          [expanded]="graphExpanded['LAngAcc']"
+          (expandedChange)="graphExpanded['LAngAcc'] = $event"
+        ></app-analysis-graph-section>
+        <subtitle-block style="margin-top: 20px"
+          >Center of Mass (COM) of {{ selectedBodyLabel }}</subtitle-block
         >
-          <mat-expansion-panel
-            [expanded]="graphExpanded['LAng']"
-            (opened)="graphExpanded['LAng'] = true"
-            (closed)="graphExpanded['LAng'] = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Angle of {{ selectedBodyLabel }}
-              </mat-panel-title>
-              <mat-panel-description>
-                <mat-icon
-                  matTooltip="The angle of this link above the horizontal"
-                  [matTooltipShowDelay]="1000"
-                  id="graph-help"
-                  >help_outline
-                </mat-icon>
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            @if (graphExpanded['LAng']) {
-              <app-analysis-graph
-                analysis="kinematic"
-                analysisType="loop"
-                mechProp="Angular Link Pos"
-                mechPart="{{ this.activeSrv.selectedLink.id }}"
-              ></app-analysis-graph>
-            }
-          </mat-expansion-panel>
-          <mat-expansion-panel
-            [expanded]="graphExpanded['LAngVel']"
-            (opened)="graphExpanded['LAngVel'] = true"
-            (closed)="graphExpanded['LAngVel'] = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Angular Velocity of {{ selectedBodyLabel }}
-              </mat-panel-title>
-              <mat-panel-description>
-                <mat-icon
-                  matTooltip="How fast this link turns, and which way"
-                  [matTooltipShowDelay]="1000"
-                  id="graph-help"
-                  >help_outline
-                </mat-icon>
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            @if (graphExpanded['LAngVel']) {
-              <app-analysis-graph
-                analysis="kinematic"
-                analysisType="loop"
-                mechProp="Angular Link Vel"
-                mechPart="{{ this.activeSrv.selectedLink.id }}"
-              ></app-analysis-graph>
-            }
-          </mat-expansion-panel>
-          <mat-expansion-panel
-            [expanded]="graphExpanded['LAngAcc']"
-            (opened)="graphExpanded['LAngAcc'] = true"
-            (closed)="graphExpanded['LAngAcc'] = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Angular Acceleration of {{ selectedBodyLabel }}
-              </mat-panel-title>
-              <mat-panel-description>
-                <mat-icon
-                  matTooltip="How this link’s turning rate changes"
-                  [matTooltipShowDelay]="1000"
-                  id="graph-help"
-                  >help_outline
-                </mat-icon>
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            @if (graphExpanded['LAngAcc']) {
-              <app-analysis-graph
-                analysis="kinematic"
-                analysisType="loop"
-                mechProp="Angular Link Acc"
-                mechPart="{{ this.activeSrv.selectedLink.id }}"
-              ></app-analysis-graph>
-            }
-          </mat-expansion-panel>
-          <subtitle-block style="margin-top: 20px"
-            >Center of Mass (COM) of {{ selectedBodyLabel }}</subtitle-block
-          >
-          <mat-expansion-panel
-            [expanded]="graphExpanded['LPos']"
-            (opened)="graphExpanded['LPos'] = true"
-            (closed)="graphExpanded['LPos'] = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Position of {{ selectedBodyLabel }}'s COM
-              </mat-panel-title>
-              <mat-panel-description>
-                <mat-icon
-                  matTooltip="Where this link’s centre of mass is"
-                  [matTooltipShowDelay]="1000"
-                  id="graph-help"
-                  >help_outline
-                </mat-icon>
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            @if (graphExpanded['LPos']) {
-              <app-analysis-graph
-                analysis="kinematic"
-                analysisType="loop"
-                mechProp="Linear Link's CoM Pos"
-                mechPart="{{ this.activeSrv.selectedLink.id }}"
-              ></app-analysis-graph>
-            }
-          </mat-expansion-panel>
-          <mat-expansion-panel
-            [expanded]="graphExpanded['LVel']"
-            (opened)="graphExpanded['LVel'] = true"
-            (closed)="graphExpanded['LVel'] = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Velocity of {{ selectedBodyLabel }}'s COM
-              </mat-panel-title>
-              <mat-panel-description>
-                <mat-icon
-                  matTooltip="How fast this link’s centre of mass moves"
-                  [matTooltipShowDelay]="1000"
-                  id="graph-help"
-                  >help_outline
-                </mat-icon>
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            @if (graphExpanded['LVel']) {
-              <app-analysis-graph
-                analysis="kinematic"
-                analysisType="loop"
-                mechProp="Linear Link's CoM Vel"
-                mechPart="{{ this.activeSrv.selectedLink.id }}"
-              ></app-analysis-graph>
-            }
-          </mat-expansion-panel>
-          <mat-expansion-panel
-            [expanded]="graphExpanded['LAcc']"
-            (opened)="graphExpanded['LAcc'] = true"
-            (closed)="graphExpanded['LAcc'] = false"
-          >
-            <mat-expansion-panel-header>
-              <mat-panel-title>
-                Acceleration of {{ selectedBodyLabel }}'s COM
-              </mat-panel-title>
-              <mat-panel-description>
-                <mat-icon
-                  matTooltip="How this link’s centre of mass changes speed"
-                  [matTooltipShowDelay]="1000"
-                  id="graph-help"
-                  >help_outline
-                </mat-icon>
-              </mat-panel-description>
-            </mat-expansion-panel-header>
-            @if (graphExpanded['LAcc']) {
-              <app-analysis-graph
-                analysis="kinematic"
-                analysisType="loop"
-                mechProp="Linear Link's CoM Acc"
-                mechPart="{{ this.activeSrv.selectedLink.id }}"
-              ></app-analysis-graph>
-            }
-          </mat-expansion-panel>
-        </collapsible-subseciton>
+        <app-analysis-graph-section
+          label="Position of {{ selectedBodyLabel }}'s COM"
+          help="Where this link’s centre of mass is"
+          analysis="kinematic"
+          analysisType="loop"
+          mechProp="Linear Link's CoM Pos"
+          mechPart="{{ this.activeSrv.selectedLink.id }}"
+          [expanded]="graphExpanded['LPos']"
+          (expandedChange)="graphExpanded['LPos'] = $event"
+        ></app-analysis-graph-section>
+        <app-analysis-graph-section
+          label="Velocity of {{ selectedBodyLabel }}'s COM"
+          help="How fast this link’s centre of mass moves"
+          analysis="kinematic"
+          analysisType="loop"
+          mechProp="Linear Link's CoM Vel"
+          mechPart="{{ this.activeSrv.selectedLink.id }}"
+          [expanded]="graphExpanded['LVel']"
+          (expandedChange)="graphExpanded['LVel'] = $event"
+        ></app-analysis-graph-section>
+        <app-analysis-graph-section
+          label="Acceleration of {{ selectedBodyLabel }}'s COM"
+          help="How this link’s centre of mass changes speed"
+          analysis="kinematic"
+          analysisType="loop"
+          mechProp="Linear Link's CoM Acc"
+          mechPart="{{ this.activeSrv.selectedLink.id }}"
+          [expanded]="graphExpanded['LAcc']"
+          (expandedChange)="graphExpanded['LAcc'] = $event"
+        ></app-analysis-graph-section>
       }
       @if (showForce) {
-        <collapsible-subseciton
-          titleLabel="Force Analysis"
-          [expanded]="graphExpanded['LForceAna']"
-          (opened)="graphExpanded['LForceAna'] = true"
-          (closed)="graphExpanded['LForceAna'] = false"
-        >
-          <radio-block
-            tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
-            option1="Static (Equilibrium)"
-            option2="In-motion (Dynamic)"
-            [formGroup]="this.forceAnalysisFormGroup"
-            _formControl="mode"
-            >Force Analysis Type
-          </radio-block>
-          @if (linkForceRows().length === 0) {
-            <div class="analysis-message" role="status">
-              {{ selectedBodyLabel }} has no external joint that carries an
-              independent pin reaction.
-            </div>
-          }
-          @for (row of linkForceRows(); track row.jointId) {
-            <mat-expansion-panel
-              [expanded]="graphExpanded['LForce_' + row.jointId]"
-              (opened)="graphExpanded['LForce_' + row.jointId] = true"
-              (closed)="graphExpanded['LForce_' + row.jointId] = false"
-            >
-              <mat-expansion-panel-header>
-                <mat-panel-title> Force at Joint {{ row.jointName }} </mat-panel-title>
-                <mat-panel-description>
-                  <mat-icon
-                    matTooltip="The reaction this link carries at that joint"
-                    [matTooltipShowDelay]="1000"
-                    id="graph-help"
-                    >help_outline
-                  </mat-icon>
-                </mat-panel-description>
-              </mat-expansion-panel-header>
-              @if (graphExpanded['LForce_' + row.jointId]) {
-                <app-analysis-graph
-                  analysis="force"
-                  [analysisType]="forceAnalysisMode()"
-                  mechProp="Joint Forces"
-                  mechPart="{{ row.jointId }}"
-                  [reactionLinkId]="row.linkId"
-                ></app-analysis-graph>
-              }
-            </mat-expansion-panel>
-          }
-        </collapsible-subseciton>
+        <radio-block
+          tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
+          option1="Static (Equilibrium)"
+          option2="In-motion (Dynamic)"
+          [formGroup]="this.forceAnalysisFormGroup"
+          _formControl="mode"
+          >Force Analysis Type
+        </radio-block>
+        @if (linkForceRows().length === 0) {
+          <div class="analysis-message" role="status">
+            {{ selectedBodyLabel }} has no external joint that carries an independent pin reaction.
+          </div>
+        }
+        @for (row of linkForceRows(); track row.jointId) {
+          <app-analysis-graph-section
+            label="Force at Joint {{ row.jointName }}"
+            help="The reaction this link carries at that joint"
+            analysis="force"
+            [analysisType]="forceAnalysisMode()"
+            mechProp="Joint Forces"
+            mechPart="{{ row.jointId }}"
+            [reactionLinkId]="row.linkId"
+            [expanded]="graphExpanded['LForce_' + row.jointId]"
+            (expandedChange)="graphExpanded['LForce_' + row.jointId] = $event"
+          ></app-analysis-graph-section>
+        }
       }
     </panel-section>
   }
@@ -536,7 +302,7 @@
   @if (validMechanisms() && this.activeSrv.objType == 'Force') {
     <panel-section id="analysis-panel">
       <title-block description="There are no analysis graphs for forces.">
-        Analysis for Force {{ this.activeSrv.selectedForce.name }}
+        {{ modeLabel }} for Force {{ this.activeSrv.selectedForce.name }}
       </title-block>
     </panel-section>
   }

--- a/src/app/component/analysis-panel/analysis-panel.component.scss
+++ b/src/app/component/analysis-panel/analysis-panel.component.scss
@@ -69,8 +69,8 @@
 #analysisWrapper .graphGroupHeading {
   // On the cards' own gutter, and weighted to carry the group under it rather
   // than to be the quietest thing on the page.
-  margin: 16px 15px 10px;
-  padding-top: 14px;
+  margin: 16px 0 10px;
+  padding: 14px 15px 0;
   border-top: 1px solid #eceef5;
   font-size: 15px;
   font-weight: 500;
@@ -82,7 +82,7 @@
 // the centre-of-mass heading is set off from its graphs. It used to sit flush
 // against the first reaction card, so the two read as one control.
 #analysisWrapper .forceModeRow {
-  margin: 0 15px 12px;
-  padding-bottom: 12px;
+  margin: 0 0 12px;
+  padding: 0 15px 12px;
   border-bottom: 1px solid #eceef5;
 }

--- a/src/app/component/analysis-panel/analysis-panel.component.scss
+++ b/src/app/component/analysis-panel/analysis-panel.component.scss
@@ -67,14 +67,14 @@
 // down 20px, which read as a stray line of text between two cards rather than
 // as a heading for the ones below it.
 #analysisWrapper .graphGroupHeading {
-  margin: 14px 0 8px;
-  padding-top: 12px;
+  // On the cards' own gutter, and weighted to carry the group under it rather
+  // than to be the quietest thing on the page.
+  margin: 16px 15px 10px;
+  padding-top: 14px;
   border-top: 1px solid #eceef5;
-  font-size: 12px;
+  font-size: 15px;
   font-weight: 500;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(0, 0, 0, 0.5);
+  color: #2c2c2c;
   cursor: default;
 }
 
@@ -82,7 +82,7 @@
 // the centre-of-mass heading is set off from its graphs. It used to sit flush
 // against the first reaction card, so the two read as one control.
 #analysisWrapper .forceModeRow {
-  margin-bottom: 12px;
+  margin: 0 15px 12px;
   padding-bottom: 12px;
   border-bottom: 1px solid #eceef5;
 }

--- a/src/app/component/analysis-panel/analysis-panel.component.scss
+++ b/src/app/component/analysis-panel/analysis-panel.component.scss
@@ -62,3 +62,27 @@
   background: #f4f5fb;
   line-height: 1.4;
 }
+
+// Names the group of graphs under it. It used to be a subtitle-block nudged
+// down 20px, which read as a stray line of text between two cards rather than
+// as a heading for the ones below it.
+#analysisWrapper .graphGroupHeading {
+  margin: 14px 0 8px;
+  padding-top: 12px;
+  border-top: 1px solid #eceef5;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.5);
+  cursor: default;
+}
+
+// The mode the reactions below are computed for, set off from them the same way
+// the centre-of-mass heading is set off from its graphs. It used to sit flush
+// against the first reaction card, so the two read as one control.
+#analysisWrapper .forceModeRow {
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #eceef5;
+}

--- a/src/app/component/analysis-panel/analysis-panel.component.spec.ts
+++ b/src/app/component/analysis-panel/analysis-panel.component.spec.ts
@@ -43,6 +43,20 @@ async function createPanel(payload: string, selectedId: string, mode: TabID = Ta
   return { fixture, fixtureData };
 }
 
+/**
+ * What the panel calls each of its graphs, read off the section it renders.
+ *
+ * From the property rather than the attribute: an interpolated binding sets the
+ * property, and this spec stubs the section component, so the attribute holds
+ * only the static half of the string.
+ */
+function sectionLabels(fixture: ComponentFixture<AnalysisPanelComponent>): string[] {
+  return [...fixture.nativeElement.querySelectorAll('app-analysis-graph-section')].map(
+    (section: Element) =>
+      ((section as unknown as { label?: string }).label ?? section.getAttribute('label') ?? '').trim()
+  );
+}
+
 describe('AnalysisPanelComponent welded mechanism regression', () => {
   beforeEach(() => vi.spyOn(console, 'log').mockImplementation(() => undefined));
   afterEach(() => {
@@ -66,10 +80,9 @@ describe('AnalysisPanelComponent welded mechanism regression', () => {
     }
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.textContent).toContain('Analysis for Joint A');
-    expect(fixture.nativeElement.textContent).toContain('Force Analysis');
+    expect(fixture.nativeElement.textContent).toContain('Force Analysis for Joint A');
     expect(fixture.nativeElement.textContent).not.toContain('Kinematic Analysis');
-    expect(fixture.nativeElement.querySelectorAll('app-analysis-graph').length).toBe(
+    expect(fixture.nativeElement.querySelectorAll('app-analysis-graph-section').length).toBe(
       rows.length + 1
     );
 
@@ -110,9 +123,7 @@ describe('AnalysisPanelComponent welded mechanism regression', () => {
     expect(rows.every((row) => row.jointId === 'B')).toBe(true);
     expect(fixture.nativeElement.querySelector('.reaction-link-selector')).toBeNull();
 
-    const titles = [...fixture.nativeElement.querySelectorAll('mat-panel-title')].map(
-      (title: Element) => title.textContent!.trim()
-    );
+    const titles = sectionLabels(fixture);
     for (const row of rows) {
       expect(titles).toContain(`Force on Link ${row.linkName}`);
     }
@@ -123,16 +134,15 @@ describe('AnalysisPanelComponent welded mechanism regression', () => {
     const { fixture } = await createPanel(TEMPLATE_LINKAGES['4-Bar'], 'BC', TabID.FORCE);
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.textContent).toContain('Analysis for Link BC');
-    expect(fixture.nativeElement.textContent).not.toContain('Kinematic Analysis for Link');
+    // The panel names the analysis it is showing, which is the heading the
+    // accordion inside it used to carry.
+    expect(fixture.nativeElement.textContent).toContain('Force Analysis for Link BC');
 
     const rows = fixture.componentInstance.linkForceRows();
     expect(rows.map((row) => row.jointId)).toEqual(['B', 'C']);
     expect(rows.every((row) => row.linkId === 'BC')).toBe(true);
 
-    const titles = [...fixture.nativeElement.querySelectorAll('mat-panel-title')].map(
-      (title: Element) => title.textContent!.trim()
-    );
+    const titles = sectionLabels(fixture);
     expect(titles).toContain('Force at Joint B');
     expect(titles).toContain('Force at Joint C');
     fixture.destroy();
@@ -161,8 +171,9 @@ describe('AnalysisPanelComponent welded mechanism regression', () => {
     });
     fixture.detectChanges();
 
-    const graphs = [...fixture.nativeElement.querySelectorAll('app-analysis-graph')];
-    const properties = graphs.map((graph: Element) => graph.getAttribute('mechprop'));
+    const properties = [
+      ...fixture.nativeElement.querySelectorAll('app-analysis-graph-section'),
+    ].map((section: Element) => section.getAttribute('mechprop'));
     expect(properties).toEqual(
       expect.arrayContaining(['Linear Joint Pos', 'Linear Joint Vel', 'Linear Joint Acc'])
     );
@@ -184,8 +195,10 @@ describe('AnalysisPanelComponent welded mechanism regression', () => {
     });
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelectorAll('app-analysis-graph')).toHaveLength(6);
-    expect(fixture.nativeElement.querySelector('mat-panel-title mat-panel-title')).toBeNull();
+    expect(fixture.nativeElement.querySelectorAll('app-analysis-graph-section')).toHaveLength(6);
+    // One heading each, and no accordion wrapping the six of them.
+    expect(sectionLabels(fixture)).toHaveLength(6);
+    expect(fixture.nativeElement.querySelector('collapsible-subseciton')).toBeNull();
     fixture.destroy();
   });
 
@@ -230,11 +243,12 @@ describe('AnalysisPanelComponent with a cylinder selected', () => {
 
     expect(fixture.nativeElement.textContent).toContain('Analysis for Cylinder');
     expect(fixture.nativeElement.textContent).not.toContain('Analysis for Link GN');
-    // And so does everything under the heading. A panel that calls the body a
+    // And so does every graph under the heading. A panel that calls the body a
     // cylinder at the top and a link in every row below has only moved the
     // disagreement down the page.
-    expect(fixture.nativeElement.textContent).not.toContain('of Link GN');
-    expect(fixture.nativeElement.textContent).toContain('Angle of Cylinder');
+    const labels = sectionLabels(fixture);
+    expect(labels.some((label) => label.includes('Link GN'))).toBe(false);
+    expect(labels).toContain('Angle of Cylinder GC');
     fixture.destroy();
   });
 

--- a/src/app/component/analysis-panel/analysis-panel.component.ts
+++ b/src/app/component/analysis-panel/analysis-panel.component.ts
@@ -67,10 +67,6 @@ export class AnalysisPanelComponent {
 
   //A dictionary for wether each graph is expanded or not
   graphExpanded: { [key: string]: boolean } = {
-    LKineAna: true,
-    LForceAna: true,
-    JKineAna: true,
-    JForceAna: true,
     LAng: false,
     LAngVel: false,
     LAngAcc: false,
@@ -306,6 +302,18 @@ export class AnalysisPanelComponent {
    * it -- the canvas outlines the whole ram while the panel headed itself
    * "Analysis for Link GN".
    */
+  /**
+   * Which analysis this panel is showing.
+   *
+   * It used to be an accordion inside the panel headed "Kinematic Analysis" --
+   * a heading that only ever said what mode the reader had already chosen, and
+   * one more thing to open before reaching a graph. The panel's own title says
+   * it now.
+   */
+  get modeLabel(): string {
+    return this.tabs.getCurrentTab() === TabID.FORCE ? 'Force Analysis' : 'Kinematic Analysis';
+  }
+
   get selectedBodyLabel(): string {
     const sealed = this.selectedCylinder;
     if (!sealed) return `Link ${this.activeSrv.selectedLink.name}`;

--- a/src/app/component/analysis-panel/analysis-panel.component.ts
+++ b/src/app/component/analysis-panel/analysis-panel.component.ts
@@ -310,6 +310,11 @@ export class AnalysisPanelComponent {
    * one more thing to open before reaching a graph. The panel's own title says
    * it now.
    */
+  /** Point at the thing on the grid these numbers describe, while asked to. */
+  highlightCoM(on: boolean): void {
+    this.settingsService.previewCoMLinkId = on ? (this.activeSrv.selectedLink?.id ?? null) : null;
+  }
+
   get modeLabel(): string {
     return this.tabs.getCurrentTab() === TabID.FORCE ? 'Force Analysis' : 'Kinematic Analysis';
   }

--- a/src/app/component/new-grid/new-grid.component.html
+++ b/src/app/component/new-grid/new-grid.component.html
@@ -1133,39 +1133,41 @@
       </svg>
     }
   </g>
-  @if (settings.isShowCOM.value) {
+  @if (settings.isShowCOM.value || settings.previewCoMLinkId) {
     <g id="comTagHolder" style="transform: scaleY(-1); pointer-events: none">
       @for (link of mechanismSrv.getLinks(); track link) {
-        <svg style="overflow: visible">
-          <path
-            stroke-width="2"
-            stroke-linejoin="round"
-            fill="black"
-            opacity="1.0"
-            [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d1')"
-          ></path>
-          <path
-            stroke-width="2"
-            stroke-linejoin="round"
-            fill="white"
-            opacity="1.0"
-            [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d2')"
-          ></path>
-          <path
-            stroke-width="2"
-            stroke-linejoin="round"
-            fill="black"
-            opacity="1.0"
-            [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d3')"
-          ></path>
-          <path
-            stroke-width="2"
-            stroke-linejoin="round"
-            fill="white"
-            opacity="1.0"
-            [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d4')"
-          ></path>
-        </svg>
+        @if (settings.isShowCOM.value || settings.previewCoMLinkId === link.id) {
+          <svg style="overflow: visible">
+            <path
+              stroke-width="2"
+              stroke-linejoin="round"
+              fill="black"
+              opacity="1.0"
+              [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d1')"
+            ></path>
+            <path
+              stroke-width="2"
+              stroke-linejoin="round"
+              fill="white"
+              opacity="1.0"
+              [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d2')"
+            ></path>
+            <path
+              stroke-width="2"
+              stroke-linejoin="round"
+              fill="black"
+              opacity="1.0"
+              [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d3')"
+            ></path>
+            <path
+              stroke-width="2"
+              stroke-linejoin="round"
+              fill="white"
+              opacity="1.0"
+              [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d4')"
+            ></path>
+          </svg>
+        }
       }
     </g>
   }

--- a/src/app/model/analysis-series.ts
+++ b/src/app/model/analysis-series.ts
@@ -1,0 +1,12 @@
+/**
+ * The colour of each analysis series, in one place.
+ *
+ * A graph, its legend and the collapsed header that previews its values all
+ * have to agree about which colour means X, so the answer lives beside the
+ * model rather than inside whichever component happened to need it first.
+ */
+export const ANALYSIS_SERIES_COLORS = {
+  X: '#313aa7',
+  Y: '#ea2b29',
+  Z: '#fdb50e',
+} as const;

--- a/src/app/services/analysis-sample.service.spec.ts
+++ b/src/app/services/analysis-sample.service.spec.ts
@@ -1,0 +1,155 @@
+import { RealJoint } from '../model/joint';
+import { MODEL_SCALE } from '../model/render-scale';
+import { TEMPLATE_LINKAGES } from '../component/MODALS/templates/template-linkages';
+import { buildMechanismFixture, MechanismFixture } from '../../tests/fixtures/mechanism-fixtures';
+import { AnalysisSampleService } from './analysis-sample.service';
+
+/**
+ * The numbers here are the ones the graphs plotted before this arithmetic moved
+ * out of the graph component, so they pin the extraction. Where a value can be
+ * derived from the mechanism instead of copied from it — a crank pin's speed is
+ * ωr, its acceleration ω²r toward the pivot, a link's angle an arctangent of its
+ * own two ends — it is checked both ways, because a literal alone only says the
+ * code still does what it did.
+ */
+describe('AnalysisSampleService', () => {
+  let fixture: MechanismFixture;
+  let service: AnalysisSampleService;
+
+  const sample = (index: number, prop: string, part: string, reactionLinkId?: string) =>
+    service.sampleAt(
+      fixture.mechanism,
+      index,
+      'kinematic',
+      'loop',
+      prop,
+      part,
+      reactionLinkId ?? ''
+    );
+
+  const force = (index: number, mode: string, prop: string, part: string, link = '') =>
+    service.sampleAt(fixture.mechanism, index, 'force', mode, prop, part, link);
+
+  describe('a four-bar driven at its crank', () => {
+    beforeEach(() => {
+      fixture = buildMechanismFixture(TEMPLATE_LINKAGES['4-Bar']);
+      service = new AnalysisSampleService(fixture.settings);
+    });
+
+    /** The crank A→B at the pose given, in internal model units. */
+    const crank = (index: number): [number, number] => {
+      const at = (id: string) => fixture.mechanism.joints[index].find((joint) => joint.id === id)!;
+      return [at('B').x - at('A').x, at('B').y - at('A').y];
+    };
+
+    it('plots a joint position as its solved coordinates in the user unit', () => {
+      expect(sample(0, 'Linear Joint Pos', 'B')).toEqual([-2.622, 0.902]);
+      expect(sample(45, 'Linear Joint Pos', 'B')).toEqual([-0.709, -0.311]);
+
+      // The same numbers the drawing is built from, divided back down.
+      const joint = fixture.mechanism.joints[45].find((candidate) => candidate.id === 'B')!;
+      expect(sample(45, 'Linear Joint Pos', 'B')).toEqual([
+        Number((joint.x / MODEL_SCALE).toFixed(3)),
+        Number((joint.y / MODEL_SCALE).toFixed(3)),
+      ]);
+    });
+
+    it('leaves a grounded joint standing still', () => {
+      const grounded = fixture.mechanism.joints[0].find(
+        (joint): joint is RealJoint => joint instanceof RealJoint && joint.ground
+      )!;
+      expect(sample(0, 'Linear Joint Pos', grounded.id)).toEqual([-3.129, -2.014]);
+      expect(sample(0, 'Linear Joint Vel', grounded.id)).toEqual([0, 0, 0]);
+      expect(sample(0, 'Linear Joint Acc', grounded.id)).toEqual([0, 0, 0]);
+    });
+
+    it('plots the crank pin speed as ωr, across the crank rather than along it', () => {
+      const velocity = sample(0, 'Linear Joint Vel', 'B');
+      expect(velocity).toEqual([6.107, -1.062, 6.199]);
+
+      const omega = Math.abs(fixture.mechanism.inputAngularVelocities[0]);
+      const [dx, dy] = crank(0);
+      const radius = Math.hypot(dx, dy) / MODEL_SCALE;
+      expect(velocity[2]).toBeCloseTo(omega * radius, 3);
+      // A pin on a rigid crank moves perpendicular to it.
+      const along = (velocity[0] * dx + velocity[1] * dy) / (velocity[2] * Math.hypot(dx, dy));
+      expect(Math.abs(along)).toBeLessThan(1e-3);
+    });
+
+    it('plots the crank pin acceleration as ω²r pointing at the pivot', () => {
+      const acceleration = sample(0, 'Linear Joint Acc', 'B');
+      expect(acceleration).toEqual([-2.224, -12.791, 12.983]);
+
+      const omega = Math.abs(fixture.mechanism.inputAngularVelocities[0]);
+      const [dx, dy] = crank(0);
+      const length = Math.hypot(dx, dy);
+      const radius = length / MODEL_SCALE;
+      expect(acceleration[2]).toBeCloseTo(omega * omega * radius, 3);
+      // Centripetal: back down the crank, towards the ground pivot.
+      expect(acceleration[0]).toBeCloseTo((-dx / length) * acceleration[2], 2);
+      expect(acceleration[1]).toBeCloseTo((-dy / length) * acceleration[2], 2);
+    });
+
+    it('plots a link angle in degrees, and turns it one degree per sample', () => {
+      expect(sample(0, 'Angular Link Pos', 'AB')).toEqual([80.137]);
+      expect(sample(1, 'Angular Link Pos', 'AB')).toEqual([79.137]);
+      expect(sample(45, 'Angular Link Pos', 'AB')).toEqual([35.137]);
+
+      const [dx, dy] = crank(45);
+      expect(sample(45, 'Angular Link Pos', 'AB')[0]).toBeCloseTo(
+        (Math.atan2(dy, dx) * 180) / Math.PI,
+        3
+      );
+      // 360 samples of one revolution, driven clockwise.
+      expect(sample(0, 'Angular Link Vel', 'AB')).toEqual([-2.094]);
+    });
+
+    it('plots a coupler by its centre of mass and its own angle', () => {
+      expect(sample(0, "Linear Link's CoM Pos", 'BC')).toEqual([0.194, 1.491]);
+      expect(sample(0, 'Angular Link Pos', 'BC')).toEqual([11.816]);
+      expect(sample(45, 'Angular Link Pos', 'BC')).toEqual([22.288]);
+    });
+
+    it('reports a joint reaction as x, y and the magnitude of the two', () => {
+      const reaction = force(0, 'static', 'Joint Forces', 'A');
+      expect(reaction).toEqual([0.001, 0.015, 0.015]);
+      expect(reaction[2]).toBeCloseTo(Math.hypot(reaction[0], reaction[1]), 3);
+      expect(force(0, 'dynamic', 'Joint Forces', 'A')).toEqual([-0.01, -0.01, 0.014]);
+      // One value, not three: an input effort is a single quantity.
+      expect(force(0, 'static', 'Input Effort', 'A')).toHaveLength(1);
+    });
+
+    it('reads a reaction from the link asked for, and gaps where that link is absent', () => {
+      expect(force(0, 'static', 'Joint Forces', 'A', 'AB')).toEqual([0.001, 0.015, 0.015]);
+      // C is nowhere near link AB, so that row of the panel has no number to show.
+      expect(force(0, 'static', 'Joint Forces', 'C', 'AB').every(Number.isNaN)).toBe(true);
+      expect(force(0, 'static', 'Joint Forces', 'C', 'AB')).toHaveLength(3);
+    });
+
+    it('has nothing to say about a graph it does not draw', () => {
+      expect(sample(0, 'ic', 'B')).toEqual([]);
+      expect(sample(0, 'Linear Joint Bogus', 'B')).toEqual([]);
+      expect(sample(9999, 'Linear Joint Pos', 'B')).toEqual([]);
+    });
+  });
+
+  describe('a cylinder-driven boom', () => {
+    beforeEach(() => {
+      fixture = buildMechanismFixture(TEMPLATE_LINKAGES['Cylinder_Boom']);
+      service = new AnalysisSampleService(fixture.settings);
+    });
+
+    it('plots the boom rising, and the piston angle as a gap rather than a number', () => {
+      expect(sample(0, 'Linear Joint Pos', 'C')).toEqual([0, 4]);
+      expect(sample(45, 'Linear Joint Pos', 'C')).toEqual([1.061, 3.857]);
+      expect(sample(0, 'Angular Link Pos', 'OC')).toEqual([90]);
+      expect(sample(45, 'Angular Link Pos', 'OC')).toEqual([74.623]);
+
+      // A sealed cylinder's own body has no solved angle; the graph draws a gap
+      // at that timestep rather than dropping the sample and shifting the rest.
+      const piston = sample(0, 'Angular Link Pos', 'PS');
+      expect(piston).toHaveLength(1);
+      expect(Number.isNaN(piston[0])).toBe(true);
+    });
+  });
+});

--- a/src/app/services/analysis-sample.service.ts
+++ b/src/app/services/analysis-sample.service.ts
@@ -1,0 +1,187 @@
+import { Injectable } from '@angular/core';
+import { ForceAnalysisMode } from '../model/mechanism/force-solver';
+import { KinematicsSolver } from '../model/mechanism/kinematic-solver';
+import { Mechanism } from '../model/mechanism/mechanism';
+import { LBF_IN_PER_NEWTON_METER, LBF_PER_NEWTON } from '../model/unit-conversions';
+import { MODEL_SCALE } from '../model/render-scale';
+import { ForceUnit } from '../model/unit-enums';
+import { roundNumber } from '../model/utils';
+import { SettingsService } from './settings.service';
+
+/**
+ * What a graph plots, one solved sample at a time.
+ *
+ * This used to be a switch inside the graph component's plotting loop, which
+ * meant the only way to ask "what does joint B read right now" was to build the
+ * whole cycle and take one point out of it. A panel header wants exactly one
+ * sample, so the arithmetic lives here and both callers share it — the graph by
+ * walking every index, the header by asking for the pose on screen.
+ */
+@Injectable({ providedIn: 'root' })
+export class AnalysisSampleService {
+  /**
+   * The mechanism the solver's static state was last prepared for.
+   *
+   * KinematicsSolver keeps its answers in statics, including a cached input
+   * joint index, so a sample of a second mechanism taken without a reset would
+   * be solved against the first one's indices. Resetting per sample instead
+   * would throw away the maps this fills 360 times per graph, so it is done
+   * once per mechanism — the same granularity the plotting loop always used.
+   */
+  private preparedFor: Mechanism | undefined;
+
+  constructor(private settingsService: SettingsService) {}
+
+  /**
+   * The values a graph plots, for one solved sample.
+   *
+   * Returned in the order the graph draws them: X, then Y, then the third
+   * series where there is one. An empty array means this service has nothing
+   * to say about that property — an unknown name, an instant-centre graph, or
+   * a sample index the mechanism does not have.
+   */
+  sampleAt(
+    mechanism: Mechanism,
+    index: number,
+    analysis: string,
+    analysisType: string,
+    mechProp: string,
+    mechPart: string,
+    reactionLinkId: string = ''
+  ): number[] {
+    if (analysis === 'force') {
+      return this.forceSample(mechanism, index, analysisType, mechProp, mechPart, reactionLinkId);
+    }
+    return this.kinematicSample(mechanism, index, mechProp, mechPart);
+  }
+
+  private forceSample(
+    mechanism: Mechanism,
+    index: number,
+    analysisType: string,
+    mechProp: string,
+    mechPart: string,
+    reactionLinkId: string
+  ): number[] {
+    const mode: ForceAnalysisMode = analysisType === 'dynamic' ? 'dynamic' : 'static';
+    const frame = mechanism.getForceAnalysis(mode).frames[index];
+    if (!frame) return [];
+
+    const forceConversion =
+      this.settingsService.forceUnit.value === ForceUnit.LBF ? LBF_PER_NEWTON : 1;
+    const torqueConversion =
+      this.settingsService.forceUnit.value === ForceUnit.LBF ? LBF_IN_PER_NEWTON_METER : 1;
+
+    if (frame.status !== 'ok') {
+      return mechProp === 'Joint Forces' ? [Number.NaN, Number.NaN, Number.NaN] : [Number.NaN];
+    }
+
+    if (mechProp === 'Input Torque' || mechProp === 'Input Effort') {
+      // A torque's moment arms are internal model lengths (MODEL_SCALE times
+      // the user's unit), so the solved value divides back down for display. An
+      // input *force* has no length in it and is invariant.
+      if (!frame.inputEffort) return [Number.NaN];
+      const isForce = frame.inputEffort.kind === 'force';
+      return [
+        roundNumber(
+          (frame.inputEffort.valueSI * (isForce ? forceConversion : torqueConversion)) /
+            (isForce ? 1 : MODEL_SCALE),
+          3
+        ),
+      ];
+    }
+
+    const byLink = frame.jointReactionsByLink.get(mechPart);
+    const reaction = reactionLinkId
+      ? byLink?.get(reactionLinkId)
+      : frame.jointReactions.get(mechPart);
+    if (!reaction) return [Number.NaN, Number.NaN, Number.NaN];
+
+    const x = reaction[0] * forceConversion;
+    const y = reaction[1] * forceConversion;
+    return [roundNumber(x, 3), roundNumber(y, 3), roundNumber(Math.hypot(x, y), 3)];
+  }
+
+  private kinematicSample(
+    mechanism: Mechanism,
+    index: number,
+    mechProp: string,
+    mechPart: string
+  ): number[] {
+    const joints = mechanism.joints[index];
+    const links = mechanism.links[index];
+    if (!joints || !links) return [];
+
+    // Positions, velocities and accelerations are linear in length, so each
+    // internal model value divides by MODEL_SCALE for display in the user's
+    // unit. Angular series carry no length and pass through.
+    if (mechProp === 'Linear Joint Pos') {
+      const joint = joints.find((candidate) => candidate.id === mechPart);
+      return [
+        roundNumber((joint?.x ?? Number.NaN) / MODEL_SCALE, 3),
+        roundNumber((joint?.y ?? Number.NaN) / MODEL_SCALE, 3),
+      ];
+    }
+
+    switch (mechProp) {
+      case 'Linear Joint Vel':
+        this.solve(mechanism, index);
+        return this.scaledVector(KinematicsSolver.jointVelMap.get(mechPart), true);
+      case 'Linear Joint Acc':
+        this.solve(mechanism, index);
+        return this.scaledVector(KinematicsSolver.jointAccMap.get(mechPart), true);
+      case "Linear Link's CoM Pos":
+        this.solve(mechanism, index);
+        return this.scaledVector(KinematicsSolver.linkCoMMap.get(mechPart), false);
+      case "Linear Link's CoM Vel":
+        this.solve(mechanism, index);
+        return this.scaledVector(KinematicsSolver.linkVelMap.get(mechPart), true);
+      case "Linear Link's CoM Acc":
+        this.solve(mechanism, index);
+        return this.scaledVector(KinematicsSolver.linkAccMap.get(mechPart), true);
+      case 'Angular Link Pos':
+        this.solve(mechanism, index);
+        return [roundNumber(KinematicsSolver.linkAngPosMap.get(mechPart) ?? Number.NaN, 3)];
+      case 'Angular Link Vel':
+        this.solve(mechanism, index);
+        return [roundNumber(KinematicsSolver.linkAngVelMap.get(mechPart) ?? Number.NaN, 3)];
+      case 'Angular Link Acc':
+        this.solve(mechanism, index);
+        return [roundNumber(KinematicsSolver.linkAngAccMap.get(mechPart) ?? Number.NaN, 3)];
+      default:
+        // 'ic' and anything this service does not know plot nothing.
+        return [];
+    }
+  }
+
+  /** Rates and poses for one sample, left in the solver's static maps. */
+  private solve(mechanism: Mechanism, index: number): void {
+    if (this.preparedFor !== mechanism) {
+      KinematicsSolver.resetVariables();
+      this.preparedFor = mechanism;
+    }
+    KinematicsSolver.requiredLoops = mechanism.requiredLoops;
+    KinematicsSolver.determineKinematics(
+      mechanism.joints[index],
+      mechanism.links[index],
+      mechanism.inputAngularVelocities[index]
+    );
+  }
+
+  /**
+   * A solved vector in display units, with its magnitude where one is plotted.
+   *
+   * A missing entry is two NaNs rather than nothing: the graph draws a gap at
+   * that timestep, and dropping the point would shift every later one.
+   */
+  private scaledVector(value: [number, number] | undefined, withMagnitude: boolean): number[] {
+    const [rawX, rawY] = value ?? [Number.NaN, Number.NaN];
+    const x = rawX / MODEL_SCALE;
+    const y = rawY / MODEL_SCALE;
+    const series = [roundNumber(x, 3), roundNumber(y, 3)];
+    if (withMagnitude) {
+      series.push(roundNumber(Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2)), 3));
+    }
+    return series;
+  }
+}

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -53,6 +53,14 @@ export class SettingsService {
 
   isShowID = new BehaviorSubject(false);
   isShowCOM = new BehaviorSubject(false);
+  /**
+   * A link whose centre of mass to draw while the reader is asking about it.
+   *
+   * Hovering the analysis panel's centre-of-mass heading points at the thing on
+   * the grid the numbers under it describe, without turning the setting on
+   * behind the reader's back.
+   */
+  previewCoMLinkId: string | null = null;
   tempGridDisable: boolean = false; //This is to hide the grid lines to fit only to the linkage when doing a svg fit
 
   isGridDebugOn: boolean = false;

--- a/src/mytheme.scss
+++ b/src/mytheme.scss
@@ -25,6 +25,7 @@
 @use 'app/component/BLOCKS/tri-button/tri-button.component.scss' as tri-button;
 @use 'src/app/component/analysis-panel/analysis-panel.component.scss' as analysis-panel;
 @use 'src/app/component/analysis-graph/analysis-graph.component.scss' as analysis-graph;
+@use 'src/app/component/analysis-graph-section/analysis-graph-section.component.scss' as analysis-graph-section;
 @use 'src/app/component/right-panel/right-panel.component.scss' as right-panel;
 @use 'src/app/component/settings-panel/settings-panel.component.scss' as settings-panel;
 @use 'src/app/component/synthesis-panel/synthesis-panel.component.scss' as synthesis-panel;
@@ -89,6 +90,7 @@ $my-theme: mat.m2-define-light-theme(
 @include edit-panel.css($my-theme);
 @include analysis-panel.css($my-theme);
 @include analysis-graph.css($my-theme);
+@include analysis-graph-section.css($my-theme);
 @include right-panel.css($my-theme);
 @include settings-panel.css($my-theme);
 @include synthesis-panel.css($my-theme);


### PR DESCRIPTION
Rebuilds the analysis panel around the value rather than the graph, and takes the
scaffolding around it away.

## What changed

**Every graph shows its value before you open it.** A reader asking "where is
joint B" had to open a graph to find out, and a joint and a link between them
offer ten graphs to open. Each card now carries its own numbers in its header —
the pose on screen, not the whole cycle — so the graph is what you open when the
number is not enough.

**The two accordions are gone.** "Kinematic Analysis" and "Force Analysis" named
the mode the reader had already chosen and were one more thing to open before
reaching a graph. The panel's own title says it: *Kinematic Analysis for Joint B*.

**The series checkboxes became the values row.** One row does both jobs: closed
it reads the series out, open it is the legend — click an entry and its line goes
off and dims. With a rule in each series' own colour, which three checkboxes
never showed.

**The Download Data button is gone**, to be offered somewhere it can appear once
rather than ten times.

## Underneath

`AnalysisSampleService` is the switch that used to sit inside the graph's
plotting loop. The only way to ask what a quantity reads *right now* was to build
all 360 samples and take one point out; both callers share the arithmetic now —
the graph by walking every index, the header by asking for one.

Twelve near-identical forty-line expansion panels collapsed into one component
used twelve times, which is most of the 481 lines this takes off the panel
template.

## Bugs found on the way

- **Charts were built at the wrong width.** Apex measures its host once, at
  construction, and keeps that width. Every chart on a panel's first render was
  built while the panel was still settling, so it stayed 387px wide in a 364px
  box and the last label on the time axis sat past the card's edge. Toggling the
  card rebuilt it and it came back right, which is what made this look like a
  rendering fault rather than a measuring one.
- **Single-series graphs had their bottom cut off** — a 210px host holding a
  250px chart, and the bottom forty pixels are where the axis title lives.
- **The white box over the plot** was the time annotation's label, pushed above
  the top of its line and clipped by the card.
- **The force-mode row ran 15px past the panel edge**: the panel stretches its
  children to its own width, so a side margin pushes the right edge out instead
  of narrowing the box.
- The two axes lettered their ticks at different sizes (Apex defaults both to
  11px; the time axis had been set to 12px on its own).
- Material gives `mat-icon` a 24px box whatever glyph is inside it, so the help
  mark sat at the top of its box — and its own rules land later in the bundle,
  so one class does not beat one class.

## Verification

The extraction changes no numbers, proved two ways:

- **In the browser** — 4-Bar and Cylinder_Boom, every selectable joint, all three
  graphs, `chartOptions.series` dumped before and after: 56 series, 20,168
  points, zero differences.
- **Old code against new, in one run** — the pre-refactor `determineAnalysis`
  copied verbatim out of `git show HEAD` and run beside the new one over all 8
  fixtures × every joint and link × every property × both force modes × every
  reaction link: 1,268 graphs, 854,207 values compared with `Object.is`, so NaN
  placement, `-0` and series lengths all count. Zero differences.

986 unit tests pass across 113 files (976 before, plus 10 for the new service).
Prettier clean on every file touched.

One caveat for reviewers: several of the heaviest verification specs sit close to
the 5s per-test timeout, and on a loaded machine they scatter failures that are
timeouts rather than assertions. On a quiet machine the suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
