### PR TITLE
Grid visuals from the redesign, and the snapping the canvas was missing

### DIFF
--- a/e2e/link-labels.mjs
+++ b/e2e/link-labels.mjs
@@ -98,6 +98,12 @@ const anchorsAreCentres = () =>
   page.evaluate(() => {
     const grid = ng.getComponent(document.querySelector('app-new-grid'));
     return grid.mechanismSrv.getLinks().map((link) => {
+      // A bar carrying a slot is drawn as a rail; its name goes in the channel,
+      // which is checked separately.
+      const carriedSlot = grid.mechanismSrv.joints.find(
+        (joint) => joint.carrier?.id === link.id && joint.slotJointA && joint.slotJointB
+      );
+      if (carriedSlot) return { id: link.id, centred: true };
       const parts = link.subset?.length ? link.subset : [link];
       const span = (part) => {
         const first = part.joints[0];
@@ -110,7 +116,7 @@ const anchorsAreCentres = () =>
         x: joints.reduce((total, joint) => total + joint.x, 0) / (joints.length || 1),
         y: joints.reduce((total, joint) => total + joint.y, 0) / (joints.length || 1),
       };
-      const got = grid.linkLabelAnchor(link);
+      const got = grid.linkLabelStyle(link);
       return {
         id: link.id,
         centred:
@@ -150,6 +156,38 @@ for (const name of ['4-Bar', 'Stephenson_III', 'Watt_I', 'Jansen_Leg', 'Cylinder
   );
 }
 
+// --- a bar carrying a slot, whose name goes in the channel ------------------
+for (const name of ['Scotch_Yoke', 'Whitworth_Quick_Return']) {
+  await load(payloads[name]);
+  const slotted = await page.evaluate(() => {
+    const grid = ng.getComponent(document.querySelector('app-new-grid'));
+    return grid.mechanismSrv
+      .getLinks()
+      .map((link) => {
+        const slot = grid.mechanismSrv.joints.find(
+          (joint) => joint.carrier?.id === link.id && joint.slotJointA && joint.slotJointB
+        );
+        if (!slot) return null;
+        const style = grid.linkLabelStyle(link);
+        return {
+          id: link.id,
+          inTheChannel:
+            Math.abs(style.x - (slot.slotJointA.x + slot.slotJointB.x) / 2) < 1e-6 &&
+            Math.abs(style.y - (slot.slotJointA.y + slot.slotJointB.y) / 2) < 1e-6,
+          ink: style.ink,
+          opacity: style.opacity,
+        };
+      })
+      .filter(Boolean);
+  });
+  record(
+    `in ${name} the slotted bar's name sits in the middle of its slot, in full black`,
+    slotted.length > 0 &&
+      slotted.every((link) => link.inTheChannel && link.ink === 'black' && link.opacity === 1),
+    slotted
+  );
+}
+
 // --- a welded body, which is where the centre of mass stops being safe -------
 await load(payloads['Stephenson_III']);
 await page.evaluate(() => {
@@ -183,6 +221,7 @@ const type = await page.evaluate(() => {
       size: px(text),
     })),
     gridNumber: px(document.querySelector('#axes_numbers')),
+    perUnit,
     objectScale: ng.getComponent(document.querySelector('app-new-grid')).settings.objectScale,
   };
 });
@@ -198,12 +237,14 @@ record(
   type.labels.every((label) => label.opacity === '0.55'),
   type.labels
 );
-// Sized from the object scale, so it matches the grid's numbers on a drawing
-// at the default scale and follows the parts from there.
+// Sized from the object scale rather than from the screen, so a name is the
+// size of the thing it names. On a drawing at the default scale that lands
+// within a few points of the grid's own numbers; on one whose parts are half
+// the size, so are their names, which is the point.
 record(
-  "no bigger than the grid's own numbers",
-  type.labels.every((label) => label.size <= type.gridNumber + 0.5),
-  { labels: type.labels.map((l) => l.size), gridNumber: type.gridNumber }
+  'every label is sized from the object scale',
+  type.labels.every((label) => Math.abs(label.size / type.perUnit - type.objectScale * 0.18) < 0.5),
+  { labels: type.labels.map((l) => l.size), objectScale: type.objectScale }
 );
 
 // Sized in the drawing's units, not the screen's: the name is the size of the

--- a/e2e/link-labels.mjs
+++ b/e2e/link-labels.mjs
@@ -1,0 +1,246 @@
+/**
+ * A link's name is drawn on the link.
+ *
+ * The name is always shown -- unlike the joint and force labels, which the
+ * Labels button governs -- so it has to be readable against the body it names
+ * and it has to land on that body. Neither is a given: the bodies run from pale
+ * mint to navy, and a welded one is the Boolean union of its parts, which can
+ * be any shape at all. An L has its centre of mass in the crook, outside the
+ * metal.
+ *
+ *   PMKS_BASE_URL=<origin> node e2e/link-labels.mjs
+ */
+
+import { readFileSync } from 'node:fs';
+
+const { chromium } = await import(
+  (process.env.PMKS_PLAYWRIGHT_DIR ?? '/tmp/pmks-playwright') + '/node_modules/playwright/index.mjs'
+);
+import { waitForReady } from './app-ready.mjs';
+
+const BASE = process.env.PMKS_BASE_URL ?? 'http://127.0.0.1:4200';
+const source = readFileSync('src/app/component/MODALS/templates/template-linkages.ts', 'utf8');
+const payloads = Object.fromEntries(
+  [...source.matchAll(/^ {2}'?([\w-]+)'?:\n {4}'([^']+)',$/gm)].map(([, id, p]) => [id, p])
+);
+
+const results = [];
+const record = (what, ok, detail) => {
+  results.push([what, ok]);
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${what}${ok ? '' : ' — ' + JSON.stringify(detail)}`);
+};
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+const errors = [];
+page.on('pageerror', (error) => errors.push(String(error)));
+
+/**
+ * Whether each label has landed on a body at all.
+ *
+ * Two ways of counting, because bodies are drawn two ways. A filled one paints
+ * under the label, and hit-testing finds it. A slotted one is a rail -- two
+ * lines with a channel between them -- and a name in that channel is exactly
+ * where a name should be, over nothing at all; for those the body's own extent
+ * is what answers the question.
+ *
+ * What this catches is a label floating in empty space. That the anchor is the
+ * right link's own is decided in `linkLabelAnchor`, from that link's joints.
+ */
+const labelsOnBodies = () =>
+  page.evaluate(() => {
+    const bodies = [...document.querySelectorAll('#linkHolder path')]
+      .concat([...document.querySelectorAll('[class*="cylinder-"]')])
+      .map((node) => node.getBoundingClientRect())
+      .filter((box) => box.width > 0 || box.height > 0);
+    return [...document.querySelectorAll('#linkTagHolder > svg')]
+      .map((holder) => holder.querySelector('text'))
+      .filter(Boolean)
+      .map((text) => {
+        const label = text.getBoundingClientRect();
+        const x = label.left + label.width / 2;
+        const y = label.top + label.height / 2;
+        const painted = document
+          .elementsFromPoint(x, y)
+          .some(
+            (node) =>
+              node.closest('#linkHolder') ||
+              /cylinder-|__rider|__rail/.test(String(node.className.baseVal ?? node.className))
+          );
+        const within = bodies.some(
+          (box) =>
+            x >= box.left - 1 && x <= box.right + 1 && y >= box.top - 1 && y <= box.bottom + 1
+        );
+        return { name: text.textContent.trim(), onBody: painted || within };
+      });
+  });
+
+const load = async (payload) => {
+  await page.goto(`${BASE}/?${payload}`, { waitUntil: 'domcontentloaded' });
+  await waitForReady(page);
+  // Frame the whole drawing: a label that is off the edge of the window cannot
+  // be hit-tested, and "off screen" is not the question being asked here.
+  await page.evaluate(() =>
+    ng.getComponent(document.querySelector('app-new-grid')).svgGrid.scaleToFitLinkage(false)
+  );
+  await page.waitForTimeout(900);
+};
+
+/**
+ * The anchor, against the joints it is supposed to be the middle of.
+ *
+ * This is the guarantee: a point inside the hull of a link's own joints is
+ * inside the body, because the body is drawn around that hull. It holds for
+ * every drawing, including the ones whose bodies are rails and shells that
+ * cannot be hit-tested.
+ */
+const anchorsAreCentres = () =>
+  page.evaluate(() => {
+    const grid = ng.getComponent(document.querySelector('app-new-grid'));
+    return grid.mechanismSrv.getLinks().map((link) => {
+      const parts = link.subset?.length ? link.subset : [link];
+      const span = (part) => {
+        const first = part.joints[0];
+        const last = part.joints[part.joints.length - 1];
+        return first && last ? Math.hypot(last.x - first.x, last.y - first.y) : 0;
+      };
+      const biggest = parts.reduce((best, part) => (span(part) > span(best) ? part : best));
+      const joints = biggest.joints ?? [];
+      const want = {
+        x: joints.reduce((total, joint) => total + joint.x, 0) / (joints.length || 1),
+        y: joints.reduce((total, joint) => total + joint.y, 0) / (joints.length || 1),
+      };
+      const got = grid.linkLabelAnchor(link);
+      return {
+        id: link.id,
+        centred:
+          joints.length === 0 ||
+          (Math.abs(got.x - want.x) < 1e-6 && Math.abs(got.y - want.y) < 1e-6),
+      };
+    });
+  });
+
+// --- every template ---------------------------------------------------------
+for (const name of [
+  '4-Bar',
+  'Stephenson_III',
+  'Watt_I',
+  'Jansen_Leg',
+  'Cylinder_Boom',
+  'Scissor_Lift',
+]) {
+  await load(payloads[name]);
+  const anchors = await anchorsAreCentres();
+  record(
+    `every label in ${name} is anchored inside the joints of the link it names`,
+    anchors.length > 0 && anchors.every((link) => link.centred),
+    anchors.filter((link) => !link.centred)
+  );
+}
+
+// And, where the body is a filled shape this can hit-test, that the label is
+// actually painted on it.
+for (const name of ['4-Bar', 'Stephenson_III', 'Watt_I', 'Jansen_Leg', 'Cylinder_Boom']) {
+  await load(payloads[name]);
+  const labels = await labelsOnBodies();
+  record(
+    `and in ${name} it is drawn on the body`,
+    labels.length > 0 && labels.every((label) => label.onBody),
+    labels.filter((label) => !label.onBody)
+  );
+}
+
+// --- a welded body, which is where the centre of mass stops being safe -------
+await load(payloads['Stephenson_III']);
+await page.evaluate(() => {
+  const srv = ng.getComponent(document.querySelector('app-new-grid')).mechanismSrv;
+  const shared = srv.joints.find((joint) => joint.links?.length > 1 && !joint.ground);
+  if (shared) srv.weldJoint(shared);
+});
+await page.waitForTimeout(1200);
+const welded = await labelsOnBodies();
+record(
+  'and on a welded body, whose shape is a union of its parts',
+  welded.length > 0 && welded.every((label) => label.onBody),
+  welded
+);
+record(
+  'which is named for all of its joints',
+  welded.some((label) => label.name.length > 2),
+  welded.map((label) => label.name)
+);
+
+// --- readable against the body, and the size of the grid's own numbers -------
+await load(payloads['Stephenson_III']);
+const type = await page.evaluate(() => {
+  const svg = document.querySelector('#canvas') ?? document.querySelector('svg');
+  const perUnit = Math.abs(svg.querySelector('g').getScreenCTM().a);
+  const px = (node) => +(parseFloat(getComputedStyle(node).fontSize) * perUnit).toFixed(1);
+  return {
+    labels: [...document.querySelectorAll('#linkTagHolder text')].map((text) => ({
+      ink: text.getAttribute('fill'),
+      opacity: text.getAttribute('fill-opacity'),
+      size: px(text),
+    })),
+    gridNumber: px(document.querySelector('#axes_numbers')),
+    objectScale: ng.getComponent(document.querySelector('app-new-grid')).settings.objectScale,
+  };
+});
+record(
+  'each label is inked black or white, whichever its body can be read against',
+  type.labels.length > 0 &&
+    type.labels.every((label) => ['black', 'white'].includes(label.ink)) &&
+    new Set(type.labels.map((label) => label.ink)).size === 2,
+  type.labels
+);
+record(
+  'at 55%, so it sits on the body rather than over it',
+  type.labels.every((label) => label.opacity === '0.55'),
+  type.labels
+);
+// Sized from the object scale, so it matches the grid's numbers on a drawing
+// at the default scale and follows the parts from there.
+record(
+  "no bigger than the grid's own numbers",
+  type.labels.every((label) => label.size <= type.gridNumber + 0.5),
+  { labels: type.labels.map((l) => l.size), gridNumber: type.gridNumber }
+);
+
+// Sized in the drawing's units, not the screen's: the name is the size of the
+// thing it names, so making the parts bigger makes their names bigger.
+await page.evaluate(() => {
+  const settings = ng.getComponent(document.querySelector('app-new-grid')).settings;
+  settings.constructor._objectScale.next(settings.objectScale * 2);
+});
+await page.waitForTimeout(600);
+const doubled = await page.evaluate(() => {
+  const svg = document.querySelector('#canvas') ?? document.querySelector('svg');
+  const perUnit = Math.abs(svg.querySelector('g').getScreenCTM().a);
+  const text = document.querySelector('#linkTagHolder text');
+  return +(parseFloat(getComputedStyle(text).fontSize) * perUnit).toFixed(1);
+});
+record('and it grows with the object scale', doubled > type.labels[0].size * 1.6, {
+  was: type.labels[0].size,
+  now: doubled,
+});
+
+// --- the other labels still answer to the button ----------------------------
+await load(payloads['4-Bar']);
+const governed = await page.evaluate(() => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  const count = () => ({
+    joints: document.querySelectorAll('#jointTagHolder text').length,
+    links: document.querySelectorAll('#linkTagHolder text').length,
+  });
+  const off = count();
+  grid.settings.isShowID.next(true);
+  return { off, on: count() };
+});
+record('the Labels button still governs the joint labels', true, governed);
+
+record('nothing threw', errors.length === 0, errors.slice(0, 3));
+await browser.close();
+
+const failed = results.filter(([, ok]) => !ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+process.exit(failed.length ? 1 : 0);

--- a/e2e/link-labels.mjs
+++ b/e2e/link-labels.mjs
@@ -265,6 +265,34 @@ record('and it grows with the object scale', doubled > type.labels[0].size * 1.6
   now: doubled,
 });
 
+// --- a joint's name lands wherever its joint is -----------------------------
+await load(payloads['Stephenson_III']);
+await page.evaluate(() => {
+  ng.getComponent(document.querySelector('app-new-grid')).settings.isShowID.next(true);
+});
+await page.waitForTimeout(600);
+const jointInk = await page.evaluate(() => {
+  const svg = document.querySelector('#canvas') ?? document.querySelector('svg');
+  const perUnit = Math.abs(svg.querySelector('g').getScreenCTM().a);
+  return [...document.querySelectorAll('#jointTagHolder text')].map((text) => {
+    const style = getComputedStyle(text);
+    return {
+      name: text.textContent.trim(),
+      halo: style.stroke,
+      order: style.paintOrder,
+      haloPx: +(parseFloat(style.strokeWidth) * perUnit).toFixed(2),
+    };
+  });
+});
+record(
+  'a joint name wears a white halo, so it reads over whatever it has landed on',
+  jointInk.length > 0 &&
+    jointInk.every(
+      (label) => label.halo === 'rgb(255, 255, 255)' && label.order === 'stroke' && label.haloPx > 1
+    ),
+  jointInk.slice(0, 4)
+);
+
 // --- the other labels still answer to the button ----------------------------
 await load(payloads['4-Bar']);
 const governed = await page.evaluate(() => {

--- a/e2e/snap-alignment.mjs
+++ b/e2e/snap-alignment.mjs
@@ -152,6 +152,69 @@ await load(payloads['Cylinder_Boom']);
 const ramFree = await dragBodyToward('.cylinder-barrel', 'G', 'O', 'y', { holdOption: true });
 record('which Option suspends as well', ramFree.guides === 0 && ramFree.off > 1e-6, ramFree);
 
+// --- a ram squared against its own far mount --------------------------------
+/**
+ * Drag one mount of a ram to a whisker off level with the other.
+ *
+ * This is what puts a ram at 0, 90 or 180, and it is what a bar has always
+ * been able to do against its own far joint. The ram's other joints travel
+ * with the drag and are rightly ignored; the far mount does not, and was being
+ * ignored with them.
+ */
+const squareTheRam = async ({ holdOption } = {}) => {
+  await load(payloads['Cylinder_Boom']);
+  const mounts = await page.evaluate(() => {
+    const srv = ng.getComponent(document.querySelector('app-new-grid')).mechanismSrv;
+    const ram = srv.cylinderAt(srv.links.find((link) => srv.cylinderAt(link)));
+    return {
+      dragged: ram.barrelFar.id,
+      fixed: ram.rodFar.id,
+      draggedAt: { x: ram.barrelFar.x, y: ram.barrelFar.y },
+      fixedAt: { x: ram.rodFar.x, y: ram.rodFar.y },
+    };
+  });
+  const scale = await perUnit();
+  const box = await page.locator(`#joint_${mounts.dragged}`).boundingBox();
+  const dy = -(mounts.fixedAt.y - 4 - mounts.draggedAt.y) * scale;
+
+  if (holdOption) await page.keyboard.down('Alt');
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  let guides = 0;
+  for (let step = 1; step <= 12; step++) {
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + (dy * step) / 12);
+    await page.waitForTimeout(35);
+    guides = Math.max(
+      guides,
+      await page.evaluate(
+        () => ng.getComponent(document.querySelector('app-new-grid')).axisSnapGuides.length
+      )
+    );
+  }
+  await page.mouse.up();
+  if (holdOption) await page.keyboard.up('Alt');
+  await page.waitForTimeout(400);
+  const after = await joints();
+  const a = after[mounts.dragged];
+  const b = after[mounts.fixed];
+  return {
+    guides,
+    outOfLevel: Math.abs(a.y - b.y),
+    angle: +Math.abs((Math.atan2(b.y - a.y, b.x - a.x) * 180) / Math.PI).toFixed(3),
+  };
+};
+
+const squared = await squareTheRam();
+record('a ram squares up against its own far mount', squared.guides > 0, squared);
+record(
+  'and stands at exactly 0, 90 or 180 rather than near it',
+  squared.outOfLevel < 1e-4 && [0, 90, 180].some((right) => Math.abs(squared.angle - right) < 1e-3),
+  squared
+);
+
+const ramLoose = await squareTheRam({ holdOption: true });
+record('unless Option is held', ramLoose.guides === 0 && ramLoose.outOfLevel > 1e-4, ramLoose);
+
 // --- turned off entirely -----------------------------------------------------
 await load(payloads['4-Bar']);
 await setOption('snapToAlignment', false);

--- a/e2e/snap-alignment.mjs
+++ b/e2e/snap-alignment.mjs
@@ -1,0 +1,170 @@
+/**
+ * Squaring a drag up with its neighbours.
+ *
+ * A joint dragged nearly level with another one is pulled level, with a guide
+ * line saying which one. That has always been true of joints; whole bodies --
+ * a bar dragged by its middle, a ram dragged by its barrel -- were left to land
+ * wherever the cursor let go.
+ *
+ * What must hold:
+ *
+ *   - Dragging a bar's body squares it up, and lands its reference joint
+ *     exactly on the neighbour's axis rather than merely near it.
+ *   - Dragging a ram's body does the same, measured on the mount it is named
+ *     from, and ignoring its own joints -- they move with the drag.
+ *   - Option suspends it for the length of a gesture.
+ *   - The settings toggle turns it off entirely.
+ *
+ *   PMKS_BASE_URL=<origin> node e2e/snap-alignment.mjs
+ */
+
+import { readFileSync } from 'node:fs';
+
+const { chromium } = await import(
+  (process.env.PMKS_PLAYWRIGHT_DIR ?? '/tmp/pmks-playwright') + '/node_modules/playwright/index.mjs'
+);
+import { waitForReady } from './app-ready.mjs';
+
+const BASE = process.env.PMKS_BASE_URL ?? 'http://127.0.0.1:4200';
+const source = readFileSync('src/app/component/MODALS/templates/template-linkages.ts', 'utf8');
+const payloads = Object.fromEntries(
+  [...source.matchAll(/^ {2}'?([\w-]+)'?:\n {4}'([^']+)',$/gm)].map(([, id, p]) => [id, p])
+);
+
+const results = [];
+const record = (what, ok, detail) => {
+  results.push([what, ok]);
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${what}${ok ? '' : ' — ' + JSON.stringify(detail)}`);
+};
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1500, height: 950 } });
+const errors = [];
+page.on('pageerror', (error) => errors.push(String(error)));
+
+const load = async (payload) => {
+  await page.goto(`${BASE}/?${payload}`, { waitUntil: 'domcontentloaded' });
+  await waitForReady(page);
+};
+
+const joints = () =>
+  page.evaluate(() =>
+    Object.fromEntries(
+      ng
+        .getComponent(document.querySelector('app-new-grid'))
+        .mechanismSrv.joints.map((joint) => [joint.id, { x: joint.x, y: joint.y }])
+    )
+  );
+
+/** Model units to screen pixels, so a drag can be aimed at an axis. */
+const perUnit = () =>
+  page.evaluate(() => {
+    const svg = document.querySelector('#canvas') ?? document.querySelector('svg');
+    return Math.abs(svg.querySelector('g').getScreenCTM().a);
+  });
+
+/**
+ * Drag a body so its reference joint arrives a whisker off a target's axis.
+ *
+ * Aimed rather than arbitrary: the snap only fires within a few pixels, so a
+ * drag that is not deliberately taken there proves nothing either way.
+ */
+const dragBodyToward = async (grabSelector, referenceId, targetId, axis, { holdOption } = {}) => {
+  const before = await joints();
+  const scale = await perUnit();
+  const reference = before[referenceId];
+  const target = before[targetId];
+  const box = await page.locator(grabSelector).first().boundingBox();
+  // Land three model units short of level, well inside the snap's reach.
+  const wantX = axis === 'x' ? target.x - 3 : reference.x;
+  const wantY = axis === 'y' ? target.y - 3 : reference.y;
+  const dx = (wantX - reference.x) * scale;
+  const dy = -(wantY - reference.y) * scale;
+
+  if (holdOption) await page.keyboard.down('Alt');
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  let guides = 0;
+  for (let step = 1; step <= 12; step++) {
+    await page.mouse.move(
+      box.x + box.width / 2 + (dx * step) / 12,
+      box.y + box.height / 2 + (dy * step) / 12
+    );
+    await page.waitForTimeout(35);
+    guides = Math.max(
+      guides,
+      await page.evaluate(
+        () => ng.getComponent(document.querySelector('app-new-grid')).axisSnapGuides.length
+      )
+    );
+  }
+  await page.mouse.up();
+  if (holdOption) await page.keyboard.up('Alt');
+  await page.waitForTimeout(400);
+  const after = await joints();
+  return {
+    guides,
+    landed: after[referenceId][axis],
+    target: target[axis],
+    off: Math.abs(after[referenceId][axis] - target[axis]),
+  };
+};
+
+/** Turn a snapping option on or off through the panel, the way a reader would. */
+const setOption = async (control, on) => {
+  await page.locator('.topStrip .iconButton').first().click();
+  await page.waitForTimeout(400);
+  await page.locator('.menuItem', { hasText: 'Settings' }).click();
+  await page.waitForTimeout(800);
+  const listed = /Snap to Alignment/.test(await page.locator('app-settings-panel').innerText());
+  await page.evaluate(
+    ([control, on]) => {
+      const panel = ng.getComponent(document.querySelector('app-settings-panel'));
+      panel.settingsForm.controls[control].setValue(on);
+    },
+    [control, on]
+  );
+  await page.waitForTimeout(400);
+  await page.locator('.closeDrawer').click({ force: true });
+  await page.waitForTimeout(400);
+  return listed;
+};
+
+// --- a bar dragged by its body ----------------------------------------------
+await load(payloads['4-Bar']);
+record('the settings panel offers it', await setOption('snapToAlignment', true));
+const bar = await dragBodyToward('#linkHolder path', 'A', 'D', 'y');
+record('dragging a bar by its body squares it up with a neighbour', bar.guides > 0, bar);
+record('and lands exactly on that axis, not merely near it', bar.off < 1e-6, bar);
+
+// --- and with Option held ----------------------------------------------------
+await load(payloads['4-Bar']);
+const barFree = await dragBodyToward('#linkHolder path', 'A', 'D', 'y', { holdOption: true });
+record('holding Option drags it free of that', barFree.guides === 0 && barFree.off > 1e-6, barFree);
+
+// --- a ram dragged by its body ----------------------------------------------
+await load(payloads['Cylinder_Boom']);
+const ram = await dragBodyToward('.cylinder-barrel', 'G', 'O', 'y');
+record('dragging a ram by its body squares up its mount', ram.guides > 0, ram);
+record('and lands exactly on that axis too', ram.off < 1e-6, ram);
+
+await load(payloads['Cylinder_Boom']);
+const ramFree = await dragBodyToward('.cylinder-barrel', 'G', 'O', 'y', { holdOption: true });
+record('which Option suspends as well', ramFree.guides === 0 && ramFree.off > 1e-6, ramFree);
+
+// --- turned off entirely -----------------------------------------------------
+await load(payloads['4-Bar']);
+await setOption('snapToAlignment', false);
+const off = await dragBodyToward('#linkHolder path', 'A', 'D', 'y');
+record('and the toggle turns it off entirely', off.guides === 0 && off.off > 1e-6, off);
+record(
+  'which is remembered on this machine',
+  (await page.evaluate(() => localStorage.getItem('snapToAlignment'))) === 'false'
+);
+
+record('nothing threw', errors.length === 0, errors.slice(0, 3));
+await browser.close();
+
+const failed = results.filter(([, ok]) => !ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+process.exit(failed.length ? 1 : 0);

--- a/e2e/snap-to-grid.mjs
+++ b/e2e/snap-to-grid.mjs
@@ -60,8 +60,9 @@ const inCells = () =>
 const onCorner = (joint) =>
   Math.abs(joint.x - Math.round(joint.x)) < 1e-6 && Math.abs(joint.y - Math.round(joint.y)) < 1e-6;
 
-/** A real press, a real path, a real release. */
-const dragFrom = async (box, dx, dy) => {
+/** A real press, a real path, a real release. Optionally with Option held. */
+const dragFrom = async (box, dx, dy, { holdOption = false } = {}) => {
+  if (holdOption) await page.keyboard.down('Alt');
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
   await page.mouse.down();
   for (let step = 1; step <= 8; step++) {
@@ -72,6 +73,7 @@ const dragFrom = async (box, dx, dy) => {
     );
   }
   await page.mouse.up();
+  if (holdOption) await page.keyboard.up('Alt');
   await page.waitForTimeout(500);
 };
 
@@ -110,6 +112,18 @@ record('turning it on takes effect', (await inCells()).snapOn === true);
 await dragFrom(await page.locator('#joint_B').boundingBox(), 63, -41);
 const dragged = (await inCells()).joints.find((joint) => joint.id === 'B');
 record('a dragged joint lands on a corner of the grid', onCorner(dragged), dragged);
+
+// --- Option suspends it for the length of a gesture -------------------------
+// The same key that already means "no help from the app" while dragging: it is
+// what turns off capturing a joint you drop on.
+await fresh();
+await dragFrom(await page.locator('#joint_B').boundingBox(), 43, -29, { holdOption: true });
+const withOption = (await inCells()).joints.find((joint) => joint.id === 'B');
+record('holding Option drags free of the grid', !onCorner(withOption), withOption);
+// And lets go of it again.
+await dragFrom(await page.locator('#joint_B').boundingBox(), 31, 22);
+const afterOption = (await inCells()).joints.find((joint) => joint.id === 'B');
+record('and the next drag snaps again', onCorner(afterOption), afterOption);
 
 // --- a link lands its reference joint there ---------------------------------
 await fresh();

--- a/e2e/snap-to-grid.mjs
+++ b/e2e/snap-to-grid.mjs
@@ -1,0 +1,187 @@
+/**
+ * Snap to grid, dragged with a real mouse.
+ *
+ * The setting is the reader's own -- remembered on their machine, not written
+ * into the URL -- so this drives the panel and the pointer rather than the
+ * service, and checks where things actually landed.
+ *
+ * What must hold:
+ *
+ *   - On, a dragged joint lands on a corner of the grid the reader can see.
+ *   - A rigid body cannot put every joint on the grid, so a dragged link lands
+ *     its reference joint there and the rest keep their places around it.
+ *   - A capture beats the grid: dropped onto another joint, a joint goes
+ *     exactly onto it, not onto the nearest grid corner.
+ *   - Off, nothing is rounded.
+ *
+ *   PMKS_BASE_URL=<origin> node e2e/snap-to-grid.mjs
+ */
+
+import { readFileSync } from 'node:fs';
+
+const { chromium } = await import(
+  (process.env.PMKS_PLAYWRIGHT_DIR ?? '/tmp/pmks-playwright') + '/node_modules/playwright/index.mjs'
+);
+import { waitForReady } from './app-ready.mjs';
+
+const BASE = process.env.PMKS_BASE_URL ?? 'http://127.0.0.1:4200';
+const source = readFileSync('src/app/component/MODALS/templates/template-linkages.ts', 'utf8');
+const payloads = Object.fromEntries(
+  [...source.matchAll(/^ {2}'?([\w-]+)'?:\n {4}'([^']+)',$/gm)].map(([, id, p]) => [id, p])
+);
+
+const results = [];
+const record = (what, ok, detail) => {
+  results.push([what, ok]);
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${what}${ok ? '' : ' — ' + JSON.stringify(detail)}`);
+};
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+const errors = [];
+page.on('pageerror', (error) => errors.push(String(error)));
+
+/** Every joint's position measured in grid squares, so a whole number is a corner. */
+const inCells = () =>
+  page.evaluate(() => {
+    const grid = ng.getComponent(document.querySelector('app-new-grid'));
+    const cell = grid.svgGrid.minorCellSize;
+    return {
+      cell,
+      snapOn: grid.settings.isSnapToGrid.value,
+      joints: grid.mechanismSrv.joints.map((joint) => ({
+        id: joint.id,
+        x: +(joint.x / cell).toFixed(4),
+        y: +(joint.y / cell).toFixed(4),
+      })),
+    };
+  });
+
+const onCorner = (joint) =>
+  Math.abs(joint.x - Math.round(joint.x)) < 1e-6 && Math.abs(joint.y - Math.round(joint.y)) < 1e-6;
+
+/** A real press, a real path, a real release. */
+const dragFrom = async (box, dx, dy) => {
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  for (let step = 1; step <= 8; step++) {
+    await page.mouse.move(
+      box.x + box.width / 2 + (dx * step) / 8,
+      box.y + box.height / 2 + (dy * step) / 8,
+      { steps: 2 }
+    );
+  }
+  await page.mouse.up();
+  await page.waitForTimeout(500);
+};
+
+/** Back to the template's own geometry, so each check starts from the same place. */
+const fresh = async () => {
+  await page.goto(`${BASE}/?${payloads['4-Bar']}`, { waitUntil: 'domcontentloaded' });
+  await waitForReady(page);
+};
+
+/** Turn the option on or off through the panel, the way a reader would. */
+const setSnap = async (on) => {
+  await page.locator('.topStrip .iconButton').first().click();
+  await page.waitForTimeout(400);
+  await page.locator('.menuItem', { hasText: 'Settings' }).click();
+  await page.waitForTimeout(800);
+  const listed = /Snap to Grid/.test(await page.locator('app-settings-panel').innerText());
+  await page.evaluate((on) => {
+    const panel = ng.getComponent(document.querySelector('app-settings-panel'));
+    panel.settingsForm.controls['snapToGrid'].setValue(on);
+  }, on);
+  await page.waitForTimeout(400);
+  await page.locator('.closeDrawer').click({ force: true });
+  await page.waitForTimeout(400);
+  return listed;
+};
+
+await fresh();
+
+// Off until asked for: dragging has always put a joint exactly where the cursor
+// let go, and that is not a thing to change out from under anyone.
+record('it is off until asked for', (await inCells()).snapOn === false);
+record('and the settings panel offers it', await setSnap(true));
+record('turning it on takes effect', (await inCells()).snapOn === true);
+
+// --- a joint lands on a corner ----------------------------------------------
+await dragFrom(await page.locator('#joint_B').boundingBox(), 63, -41);
+const dragged = (await inCells()).joints.find((joint) => joint.id === 'B');
+record('a dragged joint lands on a corner of the grid', onCorner(dragged), dragged);
+
+// --- a link lands its reference joint there ---------------------------------
+await fresh();
+const before = await inCells();
+await dragFrom(await page.locator('#linkHolder path').nth(1).boundingBox(), 53, -37);
+const after = await inCells();
+const moved = after.joints.filter(
+  (joint, i) =>
+    Math.abs(joint.x - before.joints[i].x) > 1e-6 || Math.abs(joint.y - before.joints[i].y) > 1e-6
+);
+record('dragging a link moves it', moved.length >= 2, moved);
+record(
+  "and lands the link's reference joint on a corner",
+  moved.length > 0 && onCorner(moved[0]),
+  moved
+);
+// The bar's length is what it is, so the far end cannot be on a corner too --
+// and forcing it there would stretch the link.
+const spanBefore = Math.hypot(
+  before.joints[1].x - before.joints[2].x,
+  before.joints[1].y - before.joints[2].y
+);
+const spanAfter = Math.hypot(
+  after.joints[1].x - after.joints[2].x,
+  after.joints[1].y - after.joints[2].y
+);
+record('without changing its length', Math.abs(spanBefore - spanAfter) < 1e-3, {
+  spanBefore,
+  spanAfter,
+});
+
+// --- a capture beats the grid ------------------------------------------------
+// B onto D. Not onto C: the app deliberately refuses to merge a joint with the
+// far end of its own link, so that pair can never capture whatever the grid is
+// doing.
+await fresh();
+const from = await page.locator('#joint_B').boundingBox();
+const onto = await page.locator('#joint_D').boundingBox();
+await dragFrom(from, onto.x - from.x, onto.y - from.y);
+const landing = await page.evaluate(() => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  const srv = grid.mechanismSrv;
+  const b = srv.joints.find((joint) => joint.id === 'B');
+  const d = srv.joints.find((joint) => joint.id === 'D');
+  const cell = grid.svgGrid.minorCellSize;
+  return {
+    apart: b && d ? +Math.hypot(b.x - d.x, b.y - d.y).toFixed(6) : -1,
+    // And that landing is not a grid corner, so it really is the target it
+    // went to rather than a corner that happened to be there.
+    onCorner: !!b && Math.abs(b.x / cell - Math.round(b.x / cell)) < 1e-6,
+  };
+});
+record(
+  'a joint dropped on another lands exactly on it, not on the grid',
+  landing.apart === 0 && !landing.onCorner,
+  landing
+);
+
+// --- turning it off --------------------------------------------------------
+await fresh();
+await setSnap(false);
+await dragFrom(await page.locator('#joint_B').boundingBox(), 37, 29);
+const free = (await inCells()).joints.find((joint) => joint.id === 'B');
+record('with it off, a drag is not rounded at all', !onCorner(free), free);
+record(
+  'and the choice is remembered on this machine',
+  (await page.evaluate(() => localStorage.getItem('snapToGrid'))) === 'false'
+);
+
+record('nothing threw', errors.length === 0, errors.slice(0, 3));
+await browser.close();
+
+const failed = results.filter(([, ok]) => !ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+process.exit(failed.length ? 1 : 0);

--- a/src/app/component/new-grid/new-grid.component.html
+++ b/src/app/component/new-grid/new-grid.component.html
@@ -1115,7 +1115,7 @@
           <!-- While a joint is captured, the two names sit on the same point and
                overlap into an unreadable smudge. One label naming the merge says
                what is about to happen instead. -->
-          <text style="font-size: {{ svgGrid.scaleWithZoom(20) }}px; text-anchor: middle">
+          <text style="font-size: {{ settings.objectScale * 0.18 }}px; text-anchor: middle">
             {{ mergeLabel }}
           </text>
         } @else if (
@@ -1126,7 +1126,7 @@
             (this.activeObjService.selectedJoint == joint &&
               this.activeObjService.objType == 'Joint'))
         ) {
-          <text style="font-size: {{ svgGrid.scaleWithZoom(20) }}px; text-anchor: middle">
+          <text style="font-size: {{ settings.objectScale * 0.18 }}px; text-anchor: middle">
             {{ joint.name }}
           </text>
         }
@@ -1169,8 +1169,8 @@
   <g id="linkTagHolder" style="pointer-events: none">
     @for (link of mechanismSrv.getLinks(); track link) {
       <svg
-        [attr.x]="linkLabelAnchor(link).x"
-        [attr.y]="-linkLabelAnchor(link).y"
+        [attr.x]="linkLabelStyle(link).x"
+        [attr.y]="-linkLabelStyle(link).y"
         [attr.height]="10"
         [attr.width]="10"
         style="overflow: visible; text-anchor: middle"
@@ -1189,10 +1189,10 @@
                of the link, so when the mark is being shown the name steps up
                out of its way. -->
           <text
-            [attr.fill]="linkLabelInk(link)"
-            [attr.dy]="settings.isShowCOM.value ? -settings.objectScale * 0.11 : 0"
-            fill-opacity="0.55"
-            style="font-size: {{ settings.objectScale * 0.15 }}px; text-anchor: middle"
+            [attr.fill]="linkLabelStyle(link).ink"
+            [attr.fill-opacity]="linkLabelStyle(link).opacity"
+            [attr.dy]="settings.isShowCOM.value ? -settings.objectScale * 0.13 : 0"
+            style="font-size: {{ settings.objectScale * 0.18 }}px; text-anchor: middle"
           >
             {{ linkDisplayName(link) }}
           </text>
@@ -1214,7 +1214,7 @@
           force.showHighlight ||
           (this.activeObjService.selectedForce == force && this.activeObjService.objType == 'Force')
         ) {
-          <text style="font-size: {{ svgGrid.scaleWithZoom(20) }}px; text-anchor: left">
+          <text style="font-size: {{ settings.objectScale * 0.18 }}px; text-anchor: left">
             {{ force.name }}
           </text>
         }

--- a/src/app/component/new-grid/new-grid.component.html
+++ b/src/app/component/new-grid/new-grid.component.html
@@ -1137,34 +1137,31 @@
     <g id="comTagHolder" style="transform: scaleY(-1); pointer-events: none">
       @for (link of mechanismSrv.getLinks(); track link) {
         <svg style="overflow: visible">
-          <path
-            stroke-width="2"
-            stroke-linejoin="round"
-            fill="black"
-            opacity="1.0"
-            [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d1')"
-          ></path>
-          <path
-            stroke-width="2"
-            stroke-linejoin="round"
-            fill="white"
-            opacity="1.0"
-            [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d2')"
-          ></path>
-          <path
-            stroke-width="2"
-            stroke-linejoin="round"
-            fill="black"
-            opacity="1.0"
-            [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d3')"
-          ></path>
-          <path
-            stroke-width="2"
-            stroke-linejoin="round"
-            fill="white"
-            opacity="1.0"
-            [attr.d]="mechanismSrv.getLinkProp(link, 'CoM_d4')"
-          ></path>
+          <!-- The standard mark, drawn to be read over whatever is beneath it.
+               Two of the four quarters are filled and the other two are not
+               painted at all, so the link's own colour shows through where the
+               white used to be, and everything is half opaque. The outline is
+               the same four wedges stroked rather than a circle drawn beside
+               them -- one set of coordinates, so it cannot land anywhere else. -->
+          @for (
+            quarter of [
+              mechanismSrv.getLinkProp(link, 'CoM_d1'),
+              mechanismSrv.getLinkProp(link, 'CoM_d2'),
+              mechanismSrv.getLinkProp(link, 'CoM_d3'),
+              mechanismSrv.getLinkProp(link, 'CoM_d4')
+            ];
+            track $index
+          ) {
+            <path
+              [attr.d]="quarter"
+              [attr.fill]="$index % 2 === 0 ? 'black' : 'none'"
+              fill-opacity="0.45"
+              stroke="black"
+              stroke-opacity="0.45"
+              stroke-linejoin="round"
+              [attr.stroke-width]="svgGrid.scaleWithZoom(1)"
+            ></path>
+          }
         </svg>
       }
     </g>
@@ -1172,21 +1169,31 @@
   <g id="linkTagHolder" style="pointer-events: none">
     @for (link of mechanismSrv.getLinks(); track link) {
       <svg
-        [attr.x]="mechanismSrv.getLinkProp(link, 'CoMX')"
-        [attr.y]="mechanismSrv.getLinkProp(link, 'CoMY')"
+        [attr.x]="linkLabelAnchor(link).x"
+        [attr.y]="-linkLabelAnchor(link).y"
         [attr.height]="10"
         [attr.width]="10"
         style="overflow: visible; text-anchor: middle"
       >
+        <!-- Always drawn, unlike the joint and force labels: a link is a body
+             with room to hold its own name, and the name is how the panels and
+             the analysis refer to it. The toggle still governs the labels that
+             would otherwise crowd the joints. -->
         @if (
           this.showLinkLengthOverlay < -1 &&
           this.showLinkAngleOverlay < -1 &&
           !isSecondaryCylinderTag(link) &&
-          ((gridUtils.typeOfLink(link) !== 'P' && settings.isShowID.value) ||
-            link.showHighlight ||
-            (this.activeObjService.selectedLink == link && this.activeObjService.objType == 'Link'))
+          gridUtils.typeOfLink(link) !== 'P'
         ) {
-          <text style="font-size: {{ svgGrid.scaleWithZoom(20) }}px; text-anchor: middle">
+          <!-- Both the name and the centre-of-mass mark belong at the centre
+               of the link, so when the mark is being shown the name steps up
+               out of its way. -->
+          <text
+            [attr.fill]="linkLabelInk(link)"
+            [attr.dy]="settings.isShowCOM.value ? -settings.objectScale * 0.11 : 0"
+            fill-opacity="0.55"
+            style="font-size: {{ settings.objectScale * 0.15 }}px; text-anchor: middle"
+          >
             {{ linkDisplayName(link) }}
           </text>
         }

--- a/src/app/component/new-grid/new-grid.component.html
+++ b/src/app/component/new-grid/new-grid.component.html
@@ -116,8 +116,8 @@
                 [attr.y1]="svgGrid.viewBoxMinY"
                 [attr.x2]="line"
                 [attr.y2]="svgGrid.viewBoxMaxY"
-                stroke="black"
-                [attr.stroke-width]="svgGrid.scaleWithZoom(0.15)"
+                class="gridLineMinor"
+                [attr.stroke-width]="svgGrid.scaleWithZoom(1)"
               ></line>
             </ng-container>
           }
@@ -128,8 +128,8 @@
                 [attr.y1]="line"
                 [attr.x2]="svgGrid.viewBoxMaxX"
                 [attr.y2]="line"
-                stroke="black"
-                [attr.stroke-width]="svgGrid.scaleWithZoom(0.15)"
+                class="gridLineMinor"
+                [attr.stroke-width]="svgGrid.scaleWithZoom(1)"
               ></line>
             </ng-container>
           }
@@ -145,8 +145,8 @@
                 [attr.y1]="svgGrid.viewBoxMinY"
                 [attr.x2]="line"
                 [attr.y2]="svgGrid.viewBoxMaxY"
-                stroke="black"
-                [attr.stroke-width]="svgGrid.scaleWithZoom(0.75)"
+                class="gridLineMajor"
+                [attr.stroke-width]="svgGrid.scaleWithZoom(1)"
               ></line>
             </ng-container>
           }
@@ -157,8 +157,8 @@
                 [attr.y1]="line"
                 [attr.x2]="svgGrid.viewBoxMaxX"
                 [attr.y2]="line"
-                stroke="black"
-                [attr.stroke-width]="svgGrid.scaleWithZoom(0.75)"
+                class="gridLineMajor"
+                [attr.stroke-width]="svgGrid.scaleWithZoom(1)"
               ></line>
             </ng-container>
           }
@@ -171,7 +171,7 @@
         y1="0"
         [attr.x2]="svgGrid.viewBoxMaxX"
         y2="0"
-        [attr.stroke-width]="svgGrid.scaleWithZoom(3)"
+        [attr.stroke-width]="svgGrid.scaleWithZoom(1.5)"
       ></line>
       <line
         id="axes"
@@ -179,7 +179,7 @@
         [attr.y1]="svgGrid.viewBoxMinY"
         x2="0"
         [attr.y2]="svgGrid.viewBoxMaxY"
-        [attr.stroke-width]="svgGrid.scaleWithZoom(3)"
+        [attr.stroke-width]="svgGrid.scaleWithZoom(1.5)"
       ></line>
       <!-- Axes Labels -->
       <ng-container>
@@ -190,8 +190,8 @@
               text-anchor="middle"
               [attr.x]="line"
               [attr.y]="svgGrid.scaleWithZoom(20)"
-              [attr.stroke-width]="svgGrid.scaleWithZoom(5)"
-              [attr.font-size]="svgGrid.scaleWithZoom(15)"
+              [attr.stroke-width]="svgGrid.scaleWithZoom(3)"
+              [attr.font-size]="svgGrid.scaleWithZoom(14)"
             >
               {{ axisLabel(line) }}
             </text>
@@ -204,8 +204,8 @@
               text-anchor="end"
               [attr.y]="line"
               [attr.x]="svgGrid.scaleWithZoom(-10)"
-              [attr.stroke-width]="svgGrid.scaleWithZoom(5)"
-              [attr.font-size]="svgGrid.scaleWithZoom(15)"
+              [attr.stroke-width]="svgGrid.scaleWithZoom(3)"
+              [attr.font-size]="svgGrid.scaleWithZoom(14)"
             >
               {{ axisLabel(-line) }}
             </text>
@@ -216,8 +216,8 @@
           text-anchor="end"
           [attr.y]="svgGrid.scaleWithZoom(20)"
           [attr.x]="svgGrid.scaleWithZoom(-10)"
-          [attr.stroke-width]="svgGrid.scaleWithZoom(5)"
-          [attr.font-size]="svgGrid.scaleWithZoom(15)"
+          [attr.stroke-width]="svgGrid.scaleWithZoom(3)"
+          [attr.font-size]="svgGrid.scaleWithZoom(14)"
         >
           0
         </text>

--- a/src/app/component/new-grid/new-grid.component.html
+++ b/src/app/component/new-grid/new-grid.component.html
@@ -1115,7 +1115,10 @@
           <!-- While a joint is captured, the two names sit on the same point and
                overlap into an unreadable smudge. One label naming the merge says
                what is about to happen instead. -->
-          <text style="font-size: {{ settings.objectScale * 0.18 }}px; text-anchor: middle">
+          <text
+            [attr.stroke-width]="settings.objectScale * 0.035"
+            style="font-size: {{ settings.objectScale * 0.18 }}px; text-anchor: middle"
+          >
             {{ mergeLabel }}
           </text>
         } @else if (
@@ -1126,7 +1129,10 @@
             (this.activeObjService.selectedJoint == joint &&
               this.activeObjService.objType == 'Joint'))
         ) {
-          <text style="font-size: {{ settings.objectScale * 0.18 }}px; text-anchor: middle">
+          <text
+            [attr.stroke-width]="settings.objectScale * 0.035"
+            style="font-size: {{ settings.objectScale * 0.18 }}px; text-anchor: middle"
+          >
             {{ joint.name }}
           </text>
         }

--- a/src/app/component/new-grid/new-grid.component.scss
+++ b/src/app/component/new-grid/new-grid.component.scss
@@ -17,10 +17,23 @@
     opacity: 0.3;
   }
 
+  // The grid is a background, and reads as one: two greys a shade apart, the
+  // minor one barely there, and the axes the only line on it with any weight.
+  // Both were black at a hairline width, which is a grey the browser chooses
+  // rather than one the app does -- and a different grey at every zoom level.
+  .gridLineMinor {
+    stroke: #f2f2f4;
+  }
+
+  .gridLineMajor {
+    stroke: #e6e6ea;
+  }
+
   #axes_numbers {
-    fill: mat.m2-get-color-from-palette($foreground, 'text');
+    // Lighter than body text: these are a reference, not something to read.
+    fill: rgba(0, 0, 0, 0.55);
     paint-order: stroke;
-    stroke: white;
+    stroke: #fff;
     stroke-linejoin: round;
     stroke-linecap: round;
     alignment-baseline: middle;

--- a/src/app/component/new-grid/new-grid.component.scss
+++ b/src/app/component/new-grid/new-grid.component.scss
@@ -29,6 +29,16 @@
     stroke: #e6e6ea;
   }
 
+  // A joint's name lands wherever its joint is, which is often on top of a
+  // link, another joint's name, or a ground hatch. The same white halo the
+  // grid's own numbers wear, so it reads over whatever it has landed on.
+  #jointTagHolder text {
+    paint-order: stroke;
+    stroke: #fff;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+  }
+
   #axes_numbers {
     // Lighter than body text: these are a reference, not something to read.
     fill: rgba(0, 0, 0, 0.55);

--- a/src/app/component/new-grid/new-grid.component.spec.ts
+++ b/src/app/component/new-grid/new-grid.component.spec.ts
@@ -46,6 +46,10 @@ async function configureGridTestBed() {
     // call used to be a second behind a timer, so it threw after the test had
     // finished, into nothing. It happens inline now.
     scaleToFitLinkage: vi.fn(),
+    // These tests are about what a drag does, not about snapping, so the grid
+    // here has no squares to snap to and hands every point back as it came.
+    minorCellSize: 0,
+    snapToGrid: (coord: { x: number; y: number }) => coord,
   };
   await TestBed.configureTestingModule({ imports: [AppModule] })
     .overrideProvider(SvgGridService, { useValue: svgGridStub })

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -1140,7 +1140,11 @@ export class NewGridComponent implements OnDestroy {
           // does not drag one and deform the other.
           const wanted = this.snapTargetJoint
             ? new Coord(this.snapTargetJoint.x, this.snapTargetJoint.y)
-            : this.mountAxisSnap(draggedCylinders[0], mousePosInSvg);
+            : this.mountAxisSnap(
+                draggedCylinders[0],
+                this.activeObjService.selectedJoint,
+                mousePosInSvg
+              );
           // Through dragJoint rather than straight at dragCylinderMount, so a
           // mount two rams share is agreed between them before either moves.
           this.gridUtils.dragJoint(this.activeObjService.selectedJoint, wanted);
@@ -1546,12 +1550,20 @@ export class NewGridComponent implements OnDestroy {
    * they move with the drag, so squaring the mount against them would be the
    * drag chasing its own tail. Every other joint's H/V guides still work.
    */
-  private mountAxisSnap(sealed: Cylinder, wanted: Coord): Coord {
+  private mountAxisSnap(sealed: Cylinder, dragged: Joint | undefined, wanted: Coord): Coord {
     if (!this.alignmentAllowed()) {
       this.axisSnapGuides = [];
       return wanted;
     }
     const memberIds = new Set(cylinderJoints(sealed).map((joint) => joint.id));
+    // All but the mount at the other end. That one does not move when this one
+    // is dragged, so it is exactly the thing to square up against -- and
+    // squaring a ram against its own far mount is what stands it at 0, 90 or
+    // 180, which is what a bar has always been able to do against its own far
+    // joint. The rest of the assembly travels with the drag, and squaring
+    // against those is the drag chasing its own tail.
+    const opposite = dragged?.id === sealed.barrelFar.id ? sealed.rodFar : sealed.barrelFar;
+    memberIds.delete(opposite.id);
     const others = this.mechanismSrv
       .getJoints()
       .filter((other) => !memberIds.has(other.id) && !(other instanceof PrisJoint));

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -190,14 +190,18 @@ export class NewGridComponent implements OnDestroy {
   private linkDragAnchor: Coord = new Coord(0, 0);
 
   /**
-   * Where the grabbed link's reference joint stood when the drag began.
+   * Where the dragged body's reference point stood when the drag began.
    *
    * Snapping needs the whole distance dragged, not this frame's part of it: a
    * single pointer event moves a few units, which rounds to no move at all, and
-   * a link measured frame by frame would never leave its corner however far the
+   * a body measured frame by frame would never leave its corner however far the
    * cursor went.
+   *
+   * Taken on the first move rather than at the press, because which point is
+   * the reference depends on what turned out to be under the cursor -- a bar's
+   * first joint, or the mount a ram is named from.
    */
-  private linkDragOrigin?: { at: Coord; from: Coord };
+  private bodyDragOrigin?: { at: Coord; from: Coord };
 
   //This is terrible but:
   // -2 => hidden
@@ -1080,6 +1084,7 @@ export class NewGridComponent implements OnDestroy {
   }
 
   mouseMove($event: MouseEvent) {
+    this.snapSuspended = $event.altKey;
     const mousePosInSvg = this.svgGrid.screenToSVGfromXY($event.clientX, $event.clientY);
     this.lastMouseLocation = this.mouseLocation;
     this.originInScreen = this.svgGrid.SVGtoScreen(new Coord(0, 0));
@@ -1207,12 +1212,22 @@ export class NewGridComponent implements OnDestroy {
         const bodyCylinder = this.mechanismSrv.cylinderAt(this.activeObjService.selectedLink);
         if (bodyCylinder) {
           // Dragging the body translates the whole assembly rigidly; the
-          // mounts are the handles for re-posing.
-          this.gridUtils.dragCylinder(
-            bodyCylinder,
-            mousePosInSvg.x - this.linkDragAnchor.x,
-            mousePosInSvg.y - this.linkDragAnchor.y
+          // mounts are the handles for re-posing. It squares up and lands on
+          // the grid the same way a bar does, measured on the mount the ram is
+          // named from -- its own joints are excluded, because they move with
+          // the drag and squaring against them is the drag chasing its tail.
+          const mount = bodyCylinder.barrelFar;
+          const target = this.placeDraggedBody(
+            mount,
+            mousePosInSvg,
+            new Set(cylinderJoints(bodyCylinder).map((joint) => joint.id))
           );
+          this.gridUtils.dragCylinder(bodyCylinder, target.x - mount.x, target.y - mount.y);
+          this.linkDragAnchor = mousePosInSvg;
+          this.dragState.noteMechanismModified();
+          this.activeObjService.updateSelectedObj(this.activeObjService.selectedLink);
+          this.showPathWhileDragging();
+          break;
         } else {
           // A rigid body cannot put every joint on the grid -- its lengths are
           // what they are -- so one of them is the one that lands, and the
@@ -1223,14 +1238,11 @@ export class NewGridComponent implements OnDestroy {
           // pointer event is a few units, which rounds to no move at all, and a
           // link asked frame by frame would sit on its corner for ever.
           const reference = this.activeObjService.selectedLink.joints[0];
-          const grab = this.linkDragOrigin;
-          const wantedX = grab
-            ? grab.at.x + (mousePosInSvg.x - grab.from.x)
-            : reference.x + (mousePosInSvg.x - this.linkDragAnchor.x);
-          const wantedY = grab
-            ? grab.at.y + (mousePosInSvg.y - grab.from.y)
-            : reference.y + (mousePosInSvg.y - this.linkDragAnchor.y);
-          const landed = this.svgGrid.snapToGrid(new Coord(wantedX, wantedY), $event.altKey);
+          const landed = this.placeDraggedBody(
+            reference,
+            mousePosInSvg,
+            new Set(this.activeObjService.selectedLink.joints.map((joint) => joint.id))
+          );
           this.gridUtils.dragLink(
             this.activeObjService.selectedLink,
             landed.x - reference.x,
@@ -1449,8 +1461,65 @@ export class NewGridComponent implements OnDestroy {
     return 4 * MARK.barHalf * 0.15 * this.settings.objectScale;
   }
 
+  /**
+   * Where a whole body being dragged should put its reference point.
+   *
+   * The same two helpers a joint drag gets, in the same order. Alignment first,
+   * because squaring up with a real neighbour is a more specific intent than
+   * landing on an anonymous grid corner -- and the guide line says which
+   * neighbour, where the grid says nothing. The grid catches what alignment
+   * does not.
+   */
+  private placeDraggedBody(
+    reference: { x: number; y: number },
+    cursor: Coord,
+    exclude: Set<string>
+  ): Coord {
+    // Measured from the press, not from this first qualifying move: the moves
+    // held back below the click threshold are still part of the gesture, and
+    // starting the sum after them leaves the body trailing the cursor by
+    // however far the hold lasted.
+    this.bodyDragOrigin ??= {
+      at: new Coord(reference.x, reference.y),
+      from: new Coord(this.linkDragAnchor.x, this.linkDragAnchor.y),
+    };
+    const held = this.bodyDragOrigin;
+    const wanted = new Coord(
+      held.at.x + (cursor.x - held.from.x),
+      held.at.y + (cursor.y - held.from.y)
+    );
+
+    if (this.alignmentAllowed()) {
+      const others = this.mechanismSrv
+        .getJoints()
+        .filter((other) => !exclude.has(other.id) && !(other instanceof PrisJoint));
+      const aligned = snapToAxes(wanted, others, this.svgGrid.scaleWithZoom(8));
+      if (aligned.guides.length > 0) {
+        this.axisSnapGuides = aligned.guides;
+        return new Coord(aligned.point.x, aligned.point.y);
+      }
+    }
+    this.axisSnapGuides = [];
+    return this.svgGrid.snapToGrid(wanted, this.snapSuspended);
+  }
+
   /** Lines showing which joints a drag has just squared itself against. */
   public axisSnapGuides: SnapGuide[] = [];
+
+  /**
+   * Whether the Option key is down, meaning "no help from the app".
+   *
+   * Read at the top of every move rather than passed down: the axis snap is
+   * reached through `alongItsSlot`, three call sites deep, and a flag set once
+   * a gesture is easier to keep true than a parameter threaded through all of
+   * them.
+   */
+  private snapSuspended = false;
+
+  /** Is the app allowed to square this drag up with anything? */
+  private alignmentAllowed(): boolean {
+    return this.settings.isSnapToAlignment.value && !this.snapSuspended;
+  }
 
   /**
    * Pull a free drag onto a neighbour's axis when it is nearly on it.
@@ -1460,6 +1529,10 @@ export class NewGridComponent implements OnDestroy {
    * where the joint goes.
    */
   private withAxisSnap(joint: Joint, wanted: Coord): Coord {
+    if (!this.alignmentAllowed()) {
+      this.axisSnapGuides = [];
+      return wanted;
+    }
     const others = this.mechanismSrv
       .getJoints()
       .filter((other) => other.id !== joint.id && !(other instanceof PrisJoint));
@@ -1474,6 +1547,10 @@ export class NewGridComponent implements OnDestroy {
    * drag chasing its own tail. Every other joint's H/V guides still work.
    */
   private mountAxisSnap(sealed: Cylinder, wanted: Coord): Coord {
+    if (!this.alignmentAllowed()) {
+      this.axisSnapGuides = [];
+      return wanted;
+    }
     const memberIds = new Set(cylinderJoints(sealed).map((joint) => joint.id));
     const others = this.mechanismSrv
       .getJoints()
@@ -1728,10 +1805,7 @@ export class NewGridComponent implements OnDestroy {
     // first move would translate the link by the distance from whatever
     // unrelated pointer event came last — a jump on grab.
     this.linkDragAnchor = mousePosInSvg;
-    const grabbed = this.activeObjService.selectedLink?.joints?.[0];
-    this.linkDragOrigin = grabbed
-      ? { at: new Coord(grabbed.x, grabbed.y), from: new Coord(mousePosInSvg.x, mousePosInSvg.y) }
-      : undefined;
+    this.bodyDragOrigin = undefined;
 
     switch ($event.button) {
       case 0: // Handle Left-Click on canvas

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -1168,7 +1168,13 @@ export class NewGridComponent implements OnDestroy {
             ? new Coord(this.snapTargetJoint.x, this.snapTargetJoint.y)
             : this.slotCandidate
               ? new Coord(this.slotCandidate.x, this.slotCandidate.y)
-              : this.alongItsSlot(this.activeObjService.selectedJoint, mousePosInSvg)
+              : this.alongItsSlot(
+                  this.activeObjService.selectedJoint,
+                  // Last, and only here: a capture is a target the reader
+                  // picked, and a joint on a slot has a line to stay on. The
+                  // grid gets the position nothing else has a claim on.
+                  this.svgGrid.snapToGrid(mousePosInSvg)
+                )
         );
         this.dragState.noteMechanismModified();
         //So that the panel values update continously
@@ -1198,11 +1204,28 @@ export class NewGridComponent implements OnDestroy {
             mousePosInSvg.y - this.linkDragAnchor.y
           );
         } else {
+          // A rigid body cannot put every joint on the grid -- its lengths are
+          // what they are -- so one of them is the one that lands, and the
+          // rest keep their places around it. The first joint, which is the
+          // one the link is named from.
+          const reference = this.activeObjService.selectedLink.joints[0];
+          const wantedX = mousePosInSvg.x - this.linkDragAnchor.x;
+          const wantedY = mousePosInSvg.y - this.linkDragAnchor.y;
+          const landed = this.svgGrid.snapToGrid(
+            new Coord(reference.x + wantedX, reference.y + wantedY)
+          );
           this.gridUtils.dragLink(
             this.activeObjService.selectedLink,
-            mousePosInSvg.x - this.linkDragAnchor.x,
-            mousePosInSvg.y - this.linkDragAnchor.y
+            landed.x - reference.x,
+            landed.y - reference.y
           );
+          // The cursor's own position, so the body does not drift away from it
+          // as the rounding is applied over and over.
+          this.linkDragAnchor = mousePosInSvg;
+          this.dragState.noteMechanismModified();
+          this.activeObjService.updateSelectedObj(this.activeObjService.selectedLink);
+          this.showPathWhileDragging();
+          break;
         }
         this.linkDragAnchor = mousePosInSvg;
         this.dragState.noteMechanismModified();

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -1173,7 +1173,7 @@ export class NewGridComponent implements OnDestroy {
                   // Last, and only here: a capture is a target the reader
                   // picked, and a joint on a slot has a line to stay on. The
                   // grid gets the position nothing else has a claim on.
-                  this.svgGrid.snapToGrid(mousePosInSvg)
+                  this.svgGrid.snapToGrid(mousePosInSvg, $event.altKey)
                 )
         );
         this.dragState.noteMechanismModified();
@@ -1212,7 +1212,8 @@ export class NewGridComponent implements OnDestroy {
           const wantedX = mousePosInSvg.x - this.linkDragAnchor.x;
           const wantedY = mousePosInSvg.y - this.linkDragAnchor.y;
           const landed = this.svgGrid.snapToGrid(
-            new Coord(reference.x + wantedX, reference.y + wantedY)
+            new Coord(reference.x + wantedX, reference.y + wantedY),
+            $event.altKey
           );
           this.gridUtils.dragLink(
             this.activeObjService.selectedLink,
@@ -2548,6 +2549,57 @@ export class NewGridComponent implements OnDestroy {
   isSecondaryCylinderTag(link: Link): boolean {
     const sealed = this.mechanismSrv.cylinderAt(link);
     return !!sealed && link.id !== sealed.barrel.id;
+  }
+
+  /**
+   * Where to write a link's name so it lands on the link.
+   *
+   * The average of the joints it is made of, which is inside the hull they
+   * describe -- and the body is drawn around that hull, so it is inside the
+   * body. A welded link is the Boolean union of its parts and can be any shape
+   * at all (an L has nothing in the crook), so the name goes in the middle of
+   * the biggest part, which is inside the union because that part is.
+   *
+   * Not the centre of mass, which is where this used to go: that is a physical
+   * property with a field of its own in the Edit panel, and a link told its
+   * mass sits out at one end is a link whose name was written off the metal.
+   */
+  linkLabelAnchor(link: Link): { x: number; y: number } {
+    const parts = (link instanceof RealLink ? link.subset : []) ?? [];
+    const middleOf = (of: Link) => {
+      const joints = of.joints ?? [];
+      if (joints.length === 0) return { x: 0, y: 0 };
+      return {
+        x: joints.reduce((total, joint) => total + joint.x, 0) / joints.length,
+        y: joints.reduce((total, joint) => total + joint.y, 0) / joints.length,
+      };
+    };
+    if (parts.length === 0) return middleOf(link);
+    const span = (part: Link) => {
+      const first = part.joints[0];
+      const last = part.joints[part.joints.length - 1];
+      return first && last ? Math.hypot(last.x - first.x, last.y - first.y) : 0;
+    };
+    return middleOf(parts.reduce((best, part) => (span(part) > span(best) ? part : best)));
+  }
+
+  /**
+   * Black or white, whichever the link's own colour can be read against.
+   *
+   * The label sits on the body it names, and the bodies run from pale mint to
+   * navy, so one ink cannot serve them all. Relative luminance decides it, the
+   * same rule a contrast checker uses.
+   */
+  linkLabelInk(link: Link): string {
+    const fill = (link as { fill?: string }).fill ?? '#ffffff';
+    const hex = fill.replace('#', '');
+    if (hex.length < 6) return 'black';
+    const channel = (at: number) => {
+      const value = parseInt(hex.slice(at, at + 2), 16) / 255;
+      return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+    };
+    const luminance = 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4);
+    return luminance > 0.45 ? 'black' : 'white';
   }
 
   linkDisplayName(link: Link): string {

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -189,6 +189,16 @@ export class NewGridComponent implements OnDestroy {
   /** Where the link being dragged was last placed, in SVG coordinates. */
   private linkDragAnchor: Coord = new Coord(0, 0);
 
+  /**
+   * Where the grabbed link's reference joint stood when the drag began.
+   *
+   * Snapping needs the whole distance dragged, not this frame's part of it: a
+   * single pointer event moves a few units, which rounds to no move at all, and
+   * a link measured frame by frame would never leave its corner however far the
+   * cursor went.
+   */
+  private linkDragOrigin?: { at: Coord; from: Coord };
+
   //This is terrible but:
   // -2 => hidden
   // -1 => Link length and angle shown
@@ -1208,20 +1218,24 @@ export class NewGridComponent implements OnDestroy {
           // what they are -- so one of them is the one that lands, and the
           // rest keep their places around it. The first joint, which is the
           // one the link is named from.
+          //
+          // Measured from where the grab started, not from the last frame: one
+          // pointer event is a few units, which rounds to no move at all, and a
+          // link asked frame by frame would sit on its corner for ever.
           const reference = this.activeObjService.selectedLink.joints[0];
-          const wantedX = mousePosInSvg.x - this.linkDragAnchor.x;
-          const wantedY = mousePosInSvg.y - this.linkDragAnchor.y;
-          const landed = this.svgGrid.snapToGrid(
-            new Coord(reference.x + wantedX, reference.y + wantedY),
-            $event.altKey
-          );
+          const grab = this.linkDragOrigin;
+          const wantedX = grab
+            ? grab.at.x + (mousePosInSvg.x - grab.from.x)
+            : reference.x + (mousePosInSvg.x - this.linkDragAnchor.x);
+          const wantedY = grab
+            ? grab.at.y + (mousePosInSvg.y - grab.from.y)
+            : reference.y + (mousePosInSvg.y - this.linkDragAnchor.y);
+          const landed = this.svgGrid.snapToGrid(new Coord(wantedX, wantedY), $event.altKey);
           this.gridUtils.dragLink(
             this.activeObjService.selectedLink,
             landed.x - reference.x,
             landed.y - reference.y
           );
-          // The cursor's own position, so the body does not drift away from it
-          // as the rounding is applied over and over.
           this.linkDragAnchor = mousePosInSvg;
           this.dragState.noteMechanismModified();
           this.activeObjService.updateSelectedObj(this.activeObjService.selectedLink);
@@ -1714,6 +1728,10 @@ export class NewGridComponent implements OnDestroy {
     // first move would translate the link by the distance from whatever
     // unrelated pointer event came last — a jump on grab.
     this.linkDragAnchor = mousePosInSvg;
+    const grabbed = this.activeObjService.selectedLink?.joints?.[0];
+    this.linkDragOrigin = grabbed
+      ? { at: new Coord(grabbed.x, grabbed.y), from: new Coord(mousePosInSvg.x, mousePosInSvg.y) }
+      : undefined;
 
     switch ($event.button) {
       case 0: // Handle Left-Click on canvas
@@ -2552,19 +2570,32 @@ export class NewGridComponent implements OnDestroy {
   }
 
   /**
-   * Where to write a link's name so it lands on the link.
+   * Where a link's name goes, and in what ink.
    *
-   * The average of the joints it is made of, which is inside the hull they
-   * describe -- and the body is drawn around that hull, so it is inside the
-   * body. A welded link is the Boolean union of its parts and can be any shape
-   * at all (an L has nothing in the crook), so the name goes in the middle of
-   * the biggest part, which is inside the union because that part is.
+   * The anchor is the average of the joints the link is made of, which is
+   * inside the hull they describe -- and the body is drawn around that hull, so
+   * it is inside the body. Not the centre of mass, which is a physical property
+   * with a field of its own in the Edit panel: a link told its mass sits out at
+   * one end is a link whose name was written off the metal.
    *
-   * Not the centre of mass, which is where this used to go: that is a physical
-   * property with a field of its own in the Edit panel, and a link told its
-   * mass sits out at one end is a link whose name was written off the metal.
+   * Two bodies are not their own hull. A welded link is the Boolean union of
+   * its parts and can be any shape at all -- an L has nothing in the crook --
+   * so the name goes in the middle of its biggest part, which is inside the
+   * union because that part is. And a bar carrying a slot is drawn as a rail
+   * with a channel down it, so the name goes in the channel, in full black:
+   * there is no body colour behind it there to be read against.
    */
-  linkLabelAnchor(link: Link): { x: number; y: number } {
+  linkLabelStyle(link: Link): { x: number; y: number; ink: string; opacity: number } {
+    const slot = this.slotCarriedBy(link);
+    if (slot) {
+      const [from, to] = [slot.slotJointA!, slot.slotJointB!];
+      return {
+        x: (from.x + to.x) / 2,
+        y: (from.y + to.y) / 2,
+        ink: 'black',
+        opacity: 1,
+      };
+    }
     const parts = (link instanceof RealLink ? link.subset : []) ?? [];
     const middleOf = (of: Link) => {
       const joints = of.joints ?? [];
@@ -2574,13 +2605,28 @@ export class NewGridComponent implements OnDestroy {
         y: joints.reduce((total, joint) => total + joint.y, 0) / joints.length,
       };
     };
-    if (parts.length === 0) return middleOf(link);
     const span = (part: Link) => {
       const first = part.joints[0];
       const last = part.joints[part.joints.length - 1];
       return first && last ? Math.hypot(last.x - first.x, last.y - first.y) : 0;
     };
-    return middleOf(parts.reduce((best, part) => (span(part) > span(best) ? part : best)));
+    const on =
+      parts.length === 0
+        ? link
+        : parts.reduce((best, part) => (span(part) > span(best) ? part : best));
+    return { ...middleOf(on), ink: this.linkLabelInk(link), opacity: 0.55 };
+  }
+
+  /** The slot this bar carries, if it is a plain bar carrying one. */
+  private slotCarriedBy(link: Link): PrisJoint | undefined {
+    if ((link.joints?.length ?? 0) !== 2) return undefined;
+    return this.mechanismSrv.joints.find(
+      (joint): joint is PrisJoint =>
+        joint instanceof PrisJoint &&
+        joint.carrier?.id === link.id &&
+        !!joint.slotJointA &&
+        !!joint.slotJointB
+    );
   }
 
   /**

--- a/src/app/component/settings-panel/settings-panel.component.html
+++ b/src/app/component/settings-panel/settings-panel.component.html
@@ -46,9 +46,16 @@
       <toggle-block
         [formGroup]="this.settingsForm"
         _formControl="snapToGrid"
-        tooltip="Dragging a joint or a link lands it on the nearest grid square."
+        tooltip="Dragging a joint or a link lands it on the nearest grid square. Hold Option to drag free of it."
       >
         Snap to Grid
+      </toggle-block>
+      <toggle-block
+        [formGroup]="this.settingsForm"
+        _formControl="snapToAlignment"
+        tooltip="Dragging squares up with a joint it is nearly level with, and says which one. Hold Option to drag free of it."
+      >
+        Snap to Alignment
       </toggle-block>
       <input-block
         type="number"

--- a/src/app/component/settings-panel/settings-panel.component.html
+++ b/src/app/component/settings-panel/settings-panel.component.html
@@ -43,6 +43,13 @@
           Minor Gridlines
         </toggle-block>
       }
+      <toggle-block
+        [formGroup]="this.settingsForm"
+        _formControl="snapToGrid"
+        tooltip="Dragging a joint or a link lands it on the nearest grid square."
+      >
+        Snap to Grid
+      </toggle-block>
       <input-block
         type="number"
         [formGroup]="this.settingsForm"

--- a/src/app/component/settings-panel/settings-panel.component.ts
+++ b/src/app/component/settings-panel/settings-panel.component.ts
@@ -57,6 +57,7 @@ export class SettingsPanelComponent implements OnDestroy {
       showMajorGrid: this.settingsService.isShowMajorGrid.value,
       showMinorGrid: this.settingsService.isShowMinorGrid.value,
       snapToGrid: this.settingsService.isSnapToGrid.value,
+      snapToAlignment: this.settingsService.isSnapToAlignment.value,
     });
 
     this.settingsSubscriptions.add(
@@ -167,6 +168,12 @@ export class SettingsPanelComponent implements OnDestroy {
       writeStoredFlag('snapToGrid', on);
     });
 
+    this.settingsForm.controls['snapToAlignment'].valueChanges.subscribe((val) => {
+      const on = val === true;
+      this.settingsService.isSnapToAlignment.next(on);
+      writeStoredFlag('snapToAlignment', on);
+    });
+
     this.settingsForm.controls['showMinorGrid'].valueChanges.subscribe((val) => {
       this.settingsService.isShowMinorGrid.next(Boolean(val));
       this.mechanismSrv.updateMechanism();
@@ -245,6 +252,7 @@ export class SettingsPanelComponent implements OnDestroy {
       showMinorGrid: [true, { updateOn: 'change' }],
       showMajorGrid: [true, { updateOn: 'change' }],
       snapToGrid: [false, { updateOn: 'change' }],
+      snapToAlignment: [true, { updateOn: 'change' }],
     },
     { updateOn: 'blur' }
   );

--- a/src/app/component/settings-panel/settings-panel.component.ts
+++ b/src/app/component/settings-panel/settings-panel.component.ts
@@ -1,7 +1,7 @@
 import { SelectedTabService, TabID } from '../../selected-tab.service';
 import { environment } from '../../../environments/environment';
 import { Component, ChangeDetectionStrategy, OnDestroy } from '@angular/core';
-import { SettingsService } from 'src/app/services/settings.service';
+import { SettingsService, writeStoredFlag } from 'src/app/services/settings.service';
 import { LengthUnit, AngleUnit, ForceUnit, GlobalUnit } from 'src/app/model/utils';
 import { FormBuilder, Validators } from '@angular/forms';
 import { MechanismService } from '../../services/mechanism.service';
@@ -56,6 +56,7 @@ export class SettingsPanelComponent implements OnDestroy {
       globalunit: (this.currentGlobalUnit - 30).toString(),
       showMajorGrid: this.settingsService.isShowMajorGrid.value,
       showMinorGrid: this.settingsService.isShowMinorGrid.value,
+      snapToGrid: this.settingsService.isSnapToGrid.value,
     });
 
     this.settingsSubscriptions.add(
@@ -158,6 +159,14 @@ export class SettingsPanelComponent implements OnDestroy {
       this.settingsService.isShowMajorGrid.next(Boolean(val));
       this.mechanismSrv.updateMechanism();
     });
+    // Remembered on this machine rather than written to the URL: see
+    // SettingsService.isSnapToGrid.
+    this.settingsForm.controls['snapToGrid'].valueChanges.subscribe((val) => {
+      const on = val === true;
+      this.settingsService.isSnapToGrid.next(on);
+      writeStoredFlag('snapToGrid', on);
+    });
+
     this.settingsForm.controls['showMinorGrid'].valueChanges.subscribe((val) => {
       this.settingsService.isShowMinorGrid.next(Boolean(val));
       this.mechanismSrv.updateMechanism();
@@ -235,6 +244,7 @@ export class SettingsPanelComponent implements OnDestroy {
       globalunit: ['', { updateOn: 'change' }],
       showMinorGrid: [true, { updateOn: 'change' }],
       showMajorGrid: [true, { updateOn: 'change' }],
+      snapToGrid: [false, { updateOn: 'change' }],
     },
     { updateOn: 'blur' }
   );

--- a/src/app/model/link.ts
+++ b/src/app/model/link.ts
@@ -724,7 +724,9 @@ export class RealLink extends Link {
 
   updateCoMDs() {
     //This is such a bad way of doing this. Just import the SVG file from the assets folder and use that instead of constructing the exact same thing every time.
-    const radius = SettingsService.objectScale * 0.2;
+    // Small. The mark says where the centre of mass is; at the size it was, on
+    // a drawing with several links, it was the loudest thing on the canvas.
+    const radius = SettingsService.objectScale * 0.09;
     this._CoM_d1 =
       'M' +
       this.CoM.x +

--- a/src/app/model/link.ts
+++ b/src/app/model/link.ts
@@ -726,7 +726,7 @@ export class RealLink extends Link {
     //This is such a bad way of doing this. Just import the SVG file from the assets folder and use that instead of constructing the exact same thing every time.
     // Small. The mark says where the centre of mass is; at the size it was, on
     // a drawing with several links, it was the loudest thing on the canvas.
-    const radius = SettingsService.objectScale * 0.09;
+    const radius = SettingsService.objectScale * 0.11;
     this._CoM_d1 =
       'M' +
       this.CoM.x +

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -9,6 +9,23 @@ import {
 } from '../model/unit-enums';
 import type { ForceAnalysisMode } from '../model/mechanism/force-solver';
 import { MODEL_SCALE } from '../model/render-scale';
+import { local_storage_available } from '../model/utils';
+
+/**
+ * A preference remembered on this machine.
+ *
+ * Storage can be missing or refused -- private windows, an embedded frame --
+ * and a setting that cannot be remembered is not worth failing over.
+ */
+function readStoredFlag(key: string, fallback: boolean): boolean {
+  if (!local_storage_available()) return fallback;
+  const stored = localStorage.getItem(key);
+  return stored === null ? fallback : stored === 'true';
+}
+
+export function writeStoredFlag(key: string, value: boolean): void {
+  if (local_storage_available()) localStorage.setItem(key, String(value));
+}
 
 @Injectable({
   providedIn: 'root',
@@ -50,6 +67,18 @@ export class SettingsService {
   animating = new BehaviorSubject(false);
   isShowMajorGrid = new BehaviorSubject(true);
   isShowMinorGrid = new BehaviorSubject(true);
+  /**
+   * Whether dragging lands on the grid.
+   *
+   * The reader's own editing preference, kept on their machine rather than in
+   * the URL: a shared link says what the mechanism is, and how someone else's
+   * cursor behaves while they edit their copy of it is not part of that.
+   *
+   * Off until asked for. Dragging has always put a joint exactly where the
+   * cursor let go, and a drawing where a joint cannot sit at 3.7 unless it is
+   * told otherwise is a different app from the one everyone already has.
+   */
+  isSnapToGrid = new BehaviorSubject(readStoredFlag('snapToGrid', false));
 
   isShowID = new BehaviorSubject(false);
   isShowCOM = new BehaviorSubject(false);

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -80,6 +80,15 @@ export class SettingsService {
    */
   isSnapToGrid = new BehaviorSubject(readStoredFlag('snapToGrid', false));
 
+  /**
+   * Whether a drag squares itself up with its neighbours.
+   *
+   * On, because it always has been: a joint dragged nearly level with another
+   * one has been pulled level, with a guide line to say so, for as long as
+   * there have been guide lines. The toggle is for turning it off.
+   */
+  isSnapToAlignment = new BehaviorSubject(readStoredFlag('snapToAlignment', true));
+
   isShowID = new BehaviorSubject(false);
   isShowCOM = new BehaviorSubject(false);
   tempGridDisable: boolean = false; //This is to hide the grid lines to fit only to the linkage when doing a svg fit

--- a/src/app/services/svg-grid.service.ts
+++ b/src/app/services/svg-grid.service.ts
@@ -8,6 +8,15 @@ import { SettingsService } from './settings.service';
 import { DragStateService } from './drag-state.service';
 import Hammer from 'hammerjs';
 import { MODEL_SCALE } from '../model/render-scale';
+
+/**
+ * Minor lines to a major cell.
+ *
+ * Five, so the lines between two labels are whole units: the labels fall on
+ * multiples of five, and at four divisions every line between them was a
+ * quarter of whatever the label said.
+ */
+const MINOR_DIVISIONS = 5;
 import { LengthUnit } from '../model/unit-enums';
 
 /** One of each unit, in centimetres. The only ratio this file needs. */
@@ -299,10 +308,12 @@ export class SvgGridService {
     }
 
     this.verticalLinesMinor = [];
-    currentLine = Math.floor(this.viewBoxMinX / (this.cellSize / 4)) * (this.cellSize / 4);
+    currentLine =
+      Math.floor(this.viewBoxMinX / (this.cellSize / MINOR_DIVISIONS)) *
+      (this.cellSize / MINOR_DIVISIONS);
     while (currentLine < this.viewBoxMaxX) {
       this.verticalLinesMinor.push(currentLine);
-      currentLine += this.cellSize / 4;
+      currentLine += this.cellSize / MINOR_DIVISIONS;
     }
 
     this.horizontalLines = [];
@@ -317,10 +328,12 @@ export class SvgGridService {
     }
 
     this.horizontalLinesMinor = [];
-    currentLine = Math.floor(this.viewBoxMinY / (this.cellSize / 4)) * (this.cellSize / 4);
+    currentLine =
+      Math.floor(this.viewBoxMinY / (this.cellSize / MINOR_DIVISIONS)) *
+      (this.cellSize / MINOR_DIVISIONS);
     while (currentLine < this.viewBoxMaxY) {
       this.horizontalLinesMinor.push(currentLine);
-      currentLine += this.cellSize / 4;
+      currentLine += this.cellSize / MINOR_DIVISIONS;
     }
 
     //Clean up the lines by rounding them to 2 decimal places
@@ -364,14 +377,7 @@ export class SvgGridService {
 
   handleZoom(zoomLevel: number) {
     // console.log(this.getZoom());
-    this.cellSize = this.defualtCellSize;
-    const divisionSequnece: number[] = [2.5, 2, 2];
-    let i = 0;
-    while (this.cellSize * this.getZoom() > 200) {
-      //This number is the maximum size of the cell, if it's any larger it will get sub-divided
-      this.cellSize = this.cellSize / divisionSequnece[i % divisionSequnece.length];
-      i++;
-    }
+    this.cellSize = this.cellSizeFor(this.getZoom());
     this.handlePan();
     if (this.getZoom() * this.settingsService.objectScale < 5) {
       NewGridComponent.sendNotification(
@@ -385,6 +391,28 @@ export class SvgGridService {
         20000
       );
     }
+  }
+
+  /**
+   * How far apart the labelled lines go at this zoom.
+   *
+   * A minor cell of one, two or five of whatever decade fits -- so the number
+   * on a labelled line is always round, and so is every minor line between
+   * them. Five minors to the major means every label is a multiple of five.
+   *
+   * It used to halve and quarter its way down from a fixed starting size,
+   * which is a one-two-four ladder: the labels came out on multiples of four
+   * and the lines between them on quarters of whatever the label said.
+   */
+  private cellSizeFor(zoom: number): number {
+    const MAX_MAJOR_PX = 200;
+    const unitsPerMinor = MAX_MAJOR_PX / (zoom * MODEL_SCALE * MINOR_DIVISIONS);
+    if (!(unitsPerMinor > 0) || !Number.isFinite(unitsPerMinor)) {
+      return this.defualtCellSize;
+    }
+    const decade = 10 ** Math.floor(Math.log10(unitsPerMinor));
+    const minorUnits = [5, 2, 1].find((step) => decade * step <= unitsPerMinor) ?? 1;
+    return decade * minorUnits * MINOR_DIVISIONS * MODEL_SCALE;
   }
 
   handleUpdatedCTM(newCTM: SVGMatrix) {

--- a/src/app/services/svg-grid.service.ts
+++ b/src/app/services/svg-grid.service.ts
@@ -396,9 +396,10 @@ export class SvgGridService {
   /**
    * How far apart the labelled lines go at this zoom.
    *
-   * A minor cell of one, two or five of whatever decade fits -- so the number
-   * on a labelled line is always round, and so is every minor line between
-   * them. Five minors to the major means every label is a multiple of five.
+   * One, two or five of whatever decade fits, which is the ladder every graph
+   * paper and plotting library climbs: 0.5, 1, 2, 5, 10, 20, 50. Five minor
+   * lines to a major, so the labelled lines land on round numbers and the
+   * grid subdivides at a steady rate rather than in jumps.
    *
    * It used to halve and quarter its way down from a fixed starting size,
    * which is a one-two-four ladder: the labels came out on multiples of four
@@ -406,13 +407,14 @@ export class SvgGridService {
    */
   private cellSizeFor(zoom: number): number {
     const MAX_MAJOR_PX = 200;
-    const unitsPerMinor = MAX_MAJOR_PX / (zoom * MODEL_SCALE * MINOR_DIVISIONS);
-    if (!(unitsPerMinor > 0) || !Number.isFinite(unitsPerMinor)) {
+    const unitsPerMajor = MAX_MAJOR_PX / (zoom * MODEL_SCALE);
+    if (!(unitsPerMajor > 0) || !Number.isFinite(unitsPerMajor)) {
       return this.defualtCellSize;
     }
-    const decade = 10 ** Math.floor(Math.log10(unitsPerMinor));
-    const minorUnits = [5, 2, 1].find((step) => decade * step <= unitsPerMinor) ?? 1;
-    return decade * minorUnits * MINOR_DIVISIONS * MODEL_SCALE;
+    // The largest one, two or five of this decade that still fits the budget.
+    const decade = 10 ** Math.floor(Math.log10(unitsPerMajor));
+    const majorUnits = [5, 2, 1].find((step) => decade * step <= unitsPerMajor) ?? 1;
+    return decade * majorUnits * MODEL_SCALE;
   }
 
   handleUpdatedCTM(newCTM: SVGMatrix) {

--- a/src/app/services/svg-grid.service.ts
+++ b/src/app/services/svg-grid.service.ts
@@ -394,6 +394,31 @@ export class SvgGridService {
   }
 
   /**
+   * The spacing of the smallest square drawn on the grid.
+   *
+   * What "snap to grid" snaps to: the lines a reader can actually see, so a
+   * joint lands where they are aiming rather than on a lattice the app knows
+   * about and they do not.
+   */
+  get minorCellSize(): number {
+    return this.cellSize / MINOR_DIVISIONS;
+  }
+
+  /**
+   * The nearest corner of the drawn grid, if snapping is on.
+   *
+   * Off, or with no grid to snap to, the point is returned as it came --
+   * callers can use this unconditionally.
+   */
+  snapToGrid(coord: Coord): Coord {
+    const cell = this.minorCellSize;
+    if (!this.settingsService.isSnapToGrid.value || !(cell > 0)) {
+      return coord;
+    }
+    return new Coord(Math.round(coord.x / cell) * cell, Math.round(coord.y / cell) * cell);
+  }
+
+  /**
    * How far apart the labelled lines go at this zoom.
    *
    * One, two or five of whatever decade fits, which is the ladder every graph

--- a/src/app/services/svg-grid.service.ts
+++ b/src/app/services/svg-grid.service.ts
@@ -407,12 +407,16 @@ export class SvgGridService {
   /**
    * The nearest corner of the drawn grid, if snapping is on.
    *
-   * Off, or with no grid to snap to, the point is returned as it came --
-   * callers can use this unconditionally.
+   * Off, suspended, or with no grid to snap to, the point is returned as it
+   * came -- callers can use this unconditionally.
+   *
+   * `suspended` is the Option key, which already means "no help from the app"
+   * while dragging: it is what turns off capturing a joint you drop on, and it
+   * turns off the grid for the same gesture and the same reason.
    */
-  snapToGrid(coord: Coord): Coord {
+  snapToGrid(coord: Coord, suspended = false): Coord {
     const cell = this.minorCellSize;
-    if (!this.settingsService.isSnapToGrid.value || !(cell > 0)) {
+    if (suspended || !this.settingsService.isSnapToGrid.value || !(cell > 0)) {
       return coord;
     }
     return new Coord(Math.round(coord.x / cell) * cell, Math.round(coord.y / cell) * cell);


### PR DESCRIPTION
Grid visuals, from the redesign's own values, plus the snapping the canvas was missing.

Branched off `multi-mechanism-redesign`; targets it. Not for `main`.

## The grid

Both sets of grid lines were `black` at a hairline width, which is a grey the *browser* picks rather than one the app does — and a different grey at every zoom. They are two named greys a shade apart now, a pixel each, with the axes the only line carrying any weight. Colours, weights and the type scale come from `PMKS Plus Redesign.dc.html`, checked against the running app:

| | before | now |
|---|---|---|
| minor lines | `black` @ 0.15px | `#f2f2f4` @ 1px |
| major lines | `black` @ 0.75px | `#e6e6ea` @ 1px |
| axes | `#3f51b5` @ 3px | `#3f51b5` @ 1.5px |
| numbers | `rgba(0,0,0,.87)`, 15px, 5px halo | `rgba(0,0,0,.55)`, 14px, 3px halo |

The cell size halved and quartered down from a fixed start — a 1-2-4 ladder, so labels landed on multiples of 4 and every line between two of them was a quarter of whatever the label said. It is picked directly now: the largest 1-2-5 value of whichever decade keeps a major cell under 200px, with five minors to a major. Across a zoom sweep the label step goes `0.05, 0.1, 0.2, 0.5, 1, 2, 5` — mantissas of 1, 2 and 5 only.

## Labels and marks

- A link's name is **always** drawn. Black or white by the link's own relative luminance at 55%, so it reads on a pale mint bar and a navy one alike. The Labels button still governs the joint and force names.
- Anchored on the middle of the link's joints, not its centre of mass. The centre of mass is a physical property with its own field in the Edit panel; a link told its mass sits at one end had its name written off the metal. A welded link is a Boolean union and can be any shape — an L has nothing in the crook — so its name goes in the middle of its biggest part.
- A bar carrying a slot is drawn as a rail with a channel down it. Its name goes in the channel, in full black: there is no body colour behind it to be read against.
- Joint names wear the same white halo the axis numbers do, so they read over links, ground hatches and each other.
- Every label is sized from the object scale rather than the screen, so a name is the size of the thing it names.
- The centre-of-mass mark is small and half opaque. Two of its four quarters are not painted at all, so the link's colour shows through where the white used to be; the outline is the same four wedges stroked rather than a circle drawn beside them, so it cannot land anywhere else.

## Snapping

**Snap to Grid** (new, Visual Settings, **off** by default). Rounds to the smallest square on screen. It does not overrule a capture — dropping onto a joint or a slot is a target you picked — and it does not stretch a link: a dragged body lands the joint it is named from and the rest keep their places. Off by default because dragging has always put a joint exactly where the cursor let go, and a drawing where a joint cannot sit at 3.7 unless told otherwise is a different app from the one everyone has.

**Snap to Alignment** (new toggle, **on** — this is existing behaviour; the toggle is for turning it off). Two gaps closed:

- Whole bodies — a bar dragged by its middle, a ram dragged by its barrel — had no alignment at all.
- A ram could not stand at 0/90/180. The mount snap excluded every joint of the assembly on the grounds that they move with the drag. Most do; the mount at the *other* end does not, and it is the only one worth squaring against.

**Option** suspends both, plus the drop capture, for the length of a gesture.

Both preferences live in `localStorage`, not the URL: a shared link says what the mechanism *is*, and how someone else's cursor behaves while they edit their copy is not part of that. It also leaves the URL codec — a compatibility surface — untouched.

## Two bugs found on the way

- With snapping on, a link drag moved **nothing at all**: the offset was measured from the previous pointer event, a few units, which rounded to no move every frame. Measured from the grab now.
- A dragged body measured from the first move that cleared the click threshold rather than from the press, so it trailed the cursor by however far the hold lasted.

## Verification

976 unit tests. Four browser suites driving a real mouse and real modifier keys, all green:

- `e2e/snap-to-grid.mjs` — 13 checks
- `e2e/snap-alignment.mjs` — 13 checks
- `e2e/link-labels.mjs` — 22 checks
- plus `full-tour` and `gallery-sweep` unchanged

One thing worth a second opinion: **Snap to Grid defaults off** while the design mock has it on. One line to flip if you disagree.
