### PR TITLE
Say it once, in a voice that fits what happened

### DIFF
--- a/docs/notification-inventory.md
+++ b/docs/notification-inventory.md
@@ -8,9 +8,10 @@ list at the bottom instead.
 > **This describes the old system.** What replaced it is in
 > `src/app/services/notification.service.ts`: four kinds (`success`, `refusal`,
 > `warning`, `failure`), each with its own colour, glyph, and answer to whether
-> it takes itself away; and a cooldown per message id rather than one for the
-> whole app. Every message below now has an id. The faults listed under "What is
-> wrong with the system" are fixed except where marked.
+> it takes itself away; a cooldown per message id rather than one for the whole
+> app; up to three on screen at once; and an optional action, so a message that
+> knows the fix can carry it. Every message below now has an id. The faults
+> listed under "What is wrong with the system" are fixed except where marked.
 
 Two surfaces existed:
 
@@ -90,7 +91,7 @@ snackbar is the third telling of the same fact.
 
 `Select something first — Delete removes whatever is selected.` — Delete key
 
-### Rejected typed values (6, `NOT_A`) — **debug panel only**
+### Rejected typed values (6, `NOT_A`) — was debug-only, now on every field
 
 `That is not a length. Type a number, with or without a unit — 2, 2 cm, 0.75 in.` ·
 `That is not an angle. Type a number of degrees.` ·
@@ -99,8 +100,13 @@ snackbar is the third telling of the same fact.
 `That is not a force. Type a number.` ·
 `A name has to be letters or numbers, and cannot be one already in use.`
 
-These fire from the linkage table, which is rendered only inside the Debug tab
-(Project menu → Debug). The shipping Edit panel rejects bad numbers silently.
+These fired only from the linkage table, inside the Debug tab (Project menu →
+Debug), while the Edit panel put the old value back without a word.
+
+They now fire from all thirteen of the Edit panel's numeric fields as well, and
+each one names the units its field accepts. Every numeric field in the app takes
+`2 cm` and `0.75 in` as readily as `2`, and nothing on screen said so — a
+rejected value is the moment somebody is most willing to be told.
 
 ### Rejected renames (2) — Edit panel title
 
@@ -187,6 +193,27 @@ Fixed:
   else.
 - **Messages have ids**, so they can be deduplicated and asserted on. `e2e/notifications.mjs`
   does both.
+- **Up to three stand at once.** The old snackbar showed one and took the
+  previous one away to do it, so a refusal could silently swallow a warning
+  nobody had read. A fourth displaces the oldest message that was going to
+  leave by itself, never one still waiting to be dismissed.
+- **A message can carry its own fix.** The zoom warnings offer *Fit to zoom*,
+  which is the button they used to send the reader to Settings to find.
+
+Removed entirely:
+
+- **The four mode and timing refusals** — "Switch to Edit mode to change the
+  mechanism", "Cannot edit while the animation is running", "Step back to the
+  start to edit". Every guard stays; none of them announces itself. Which mode
+  you are in is written across the top strip and down the side of the window,
+  and whether the animation is running is the thing you are watching.
+- **The four driven-joint refusals**, which turned out to be unreachable. Both
+  the context menu item and the panel button are disabled on `canToggleInput`,
+  which is `input || canDrive` — and `canDrive` is exactly "describeActuator
+  did not refuse", asked of the same joint `adjustInput` re-tests. Checked
+  across all 25 templates: 147 presses of every enabled control, no refusal.
+  The guard stays, silent. The four sentences are still used by the setup
+  panel's blocker list, which is where they are actually read.
 
 Reworded or removed:
 
@@ -207,11 +234,8 @@ Reworded or removed:
 
 Still open:
 
-- **The eleven drop refusals** are still snackbars, on top of the canvas
-  refusal marker and the joint shake. Deferred: judge it once the new system is
-  on screen.
-- **The six `NOT_A` messages** are still debug-only, and the Edit panel still
-  rejects bad numbers in silence.
+- **The eleven drop refusals** are still messages, on top of the canvas refusal
+  marker and the joint shake. Kept deliberately for now.
 - **Deleting a joint is not undoable.** `deleteJoint` ends in
   `finishStructuralEdit(false)`, so no history entry is written and Undo cannot
   bring it back. Found while wiring Ctrl+Z; pre-existing, and the `false` is

--- a/docs/notification-inventory.md
+++ b/docs/notification-inventory.md
@@ -236,10 +236,16 @@ Still open:
 
 - **The eleven drop refusals** are still messages, on top of the canvas refusal
   marker and the joint shake. Kept deliberately for now.
-- **Deleting a joint is not undoable.** `deleteJoint` ends in
-  `finishStructuralEdit(false)`, so no history entry is written and Undo cannot
-  bring it back. Found while wiring Ctrl+Z; pre-existing, and the `false` is
-  explicit enough to be worth asking about before changing.
+- **The six `NOT_A` messages** now fire from the Edit panel too, but the
+  linkage table they came from is still reachable only through the Debug tab.
+  Whether that table should exist at all is a separate question.
+
+Closed since:
+
+- **Deleting a joint is now undoable** (`Let Ctrl+Z put back a joint you
+  deleted`). It ended in `finishStructuralEdit(false)`, so no history entry was
+  written and Undo could not bring it back — found while wiring Ctrl+Z, which
+  is what made it visible.
 
 ## Dead — coded but not reachable
 

--- a/docs/notification-inventory.md
+++ b/docs/notification-inventory.md
@@ -1,0 +1,227 @@
+# Every message the app can say
+
+An inventory of the snackbar, taken **before** rebuilding it, and kept as the
+record of what was there. Only messages that were **reachable** are listed — a
+call site that no template bound, or that sat behind a comment, is in the dead
+list at the bottom instead.
+
+> **This describes the old system.** What replaced it is in
+> `src/app/services/notification.service.ts`: four kinds (`success`, `refusal`,
+> `warning`, `failure`), each with its own colour, glyph, and answer to whether
+> it takes itself away; and a cooldown per message id rather than one for the
+> whole app. Every message below now has an id. The faults listed under "What is
+> wrong with the system" are fixed except where marked.
+
+Two surfaces existed:
+
+- `NewGridComponent.sendNotification(text, rateLimitMS?)` — everything below
+  except one. Top-centre, white, 4s, no icon, no dismiss.
+- `UrlProcessorService` opened its own `MatSnackBar` directly, without the
+  `my-custom-snackbar` class or the rate limit.
+
+Nothing carried a severity, an id, or an action.
+
+---
+
+## Good — something the user wanted, happened (3)
+
+| Message | Reached by |
+| --- | --- |
+| `Loaded Mechanism from File` | Project menu → Open, after the file reads |
+| `Mechanism URL copied. If you make additional changes, copy the URL again.` | Project menu → Share Project |
+| `Message sent. Thank you for your feedback!` | Help → feedback form, on success |
+
+## Neutral — it happened, but you should know something (4)
+
+| Message | Reached by |
+| --- | --- |
+| `Merged joint A into B, but B cannot be welded` | Dragging a joint onto a weldable target that cannot take the weld |
+| `A and B are now pinned together twice. The linkage still moves, but its forces have no unique solution.` | An edit that creates a duplicate pin |
+| `The visual size of the links might be too small. Try using the "Update Object Scale" button…` | Zooming far out — **but see the rate-limit note** |
+| `The visual size of the links might be too large. Try using the "Update Object Scale" button…` | Zooming far in — same |
+
+## Bad — you tried something and it did not happen (39)
+
+### Wrong mode, wrong moment (4 texts, many doors)
+
+| Message | Reached by |
+| --- | --- |
+| `Switch to Edit mode to change the mechanism.` | Any drag or context menu in Analyze |
+| `Switch to Edit mode to change the mechanism.` | Same text, separate constant, in Synthesis |
+| `Cannot edit while the animation is running.` | Drag, context menu, or any context-menu item while animating |
+| `Step back to the start to edit.` | Drag or context menu at a timestep other than 0 |
+
+### Refused drops (11) — all from dragging one joint onto another
+
+`A joint cannot be merged into itself` ·
+`These joints are on the same link, so merging them would collapse it` ·
+`Drop onto the pin of a slider, not onto its slot` ·
+`Only one of these joints can carry a slider` ·
+`Merging here would tie the same two joints together twice, over-constraining the linkage` ·
+`A slider cannot ride on a link it is part of` ·
+`This joint cannot be merged` ·
+`A cylinder is one sealed part — attach at its mounts instead` ·
+`A welded joint cannot merge with a cylinder mount — unweld it first` ·
+`A driven joint can only join two bodies — remove the input first, or attach somewhere else` ·
+`A cylinder cannot fold onto itself`
+
+Each is also drawn on the canvas as a refusal marker and a shake, so the
+snackbar is the third telling of the same fact.
+
+### Refused inputs (4) — right-click → Add Input
+
+`Only a joint can be driven.` ·
+`This joint is welded, so the bodies it joins cannot move relative to each other. Unweld it, or drive a joint that has a freedom.` ·
+`A driven joint needs two bodies to move relative to each other.` ·
+`This joint joins N bodies, so "driven" would not say which pair moves. Drive a joint where exactly two meet.`
+
+### Refused structural edits (6)
+
+| Message | Reached by |
+| --- | --- |
+| `This joint is welded, so a cylinder mounted on it would be a third body inside one rigid one. Unweld it, or attach the cylinder to the link instead.` | Drawing a cylinder onto a welded joint |
+| `A cylinder is one sealed part — delete the cylinder instead of editing its slider.` | Editing a cylinder's slider |
+| `Several links meet at that joint, so a force there would not say which one it acts on.` | Attaching a force at a multi-link joint |
+| `That is the shortest cylinder there is — any less and the barrel has no room to slide in.` | Dragging a cylinder shorter than its minimum |
+| `Those two joints are already on one link.` | Drawing a link between two joints already linked |
+| `Cannot link to a bar. Please create and select a tracer point on the link.` | Starting a link from a bar |
+
+### Nothing selected (1)
+
+`Select something first — Delete removes whatever is selected.` — Delete key
+
+### Rejected typed values (6, `NOT_A`) — **debug panel only**
+
+`That is not a length. Type a number, with or without a unit — 2, 2 cm, 0.75 in.` ·
+`That is not an angle. Type a number of degrees.` ·
+`That is not a mass. Type a number.` ·
+`That is not a moment of inertia. Type a number.` ·
+`That is not a force. Type a number.` ·
+`A name has to be letters or numbers, and cannot be one already in use.`
+
+These fire from the linkage table, which is rendered only inside the Debug tab
+(Project menu → Debug). The shipping Edit panel rejects bad numbers silently.
+
+### Rejected renames (2) — Edit panel title
+
+`The new ID cannot be empty.` · `The new ID must only contain letters and numbers.`
+
+### Feedback form (3)
+
+`Please fill out the form correctly.` ·
+`It looks like you are in a development environment. If this is not the case, please try again later or contact us directly at: gr-pmksplus@wpi.edu` ·
+`Message failed to send. Please try again later or contact us directly at: gr-pmksplus@wpi.edu`
+
+### File and URL (2)
+
+`No file selected` — Project menu → Open, cancelled ·
+`Unable to load the shared mechanism URL.` — a share link that will not decode
+(the one message that bypasses `sendNotification` entirely)
+
+## Does not belong to any of the three (1)
+
+| Message | Reached by |
+| --- | --- |
+| `You attempted to undo. What were you trying to undo? Please let us know through the report button in the help section.` | **Ctrl/Cmd+Z** |
+
+Undo exists and works — it is a button in the top bar, backed by
+`SaveHistoryService`. The keyboard shortcut for it fires a user-survey question
+from an earlier study and undoes nothing. Verified in the browser: the message
+appears, the model is unchanged.
+
+---
+
+## What is wrong with the system, not the words
+
+1. **Ctrl+Z asks a survey question instead of undoing.** Above.
+
+2. **The rate limit is global, and starts armed.** There is one
+   `lastNotificationTime` for the whole app, set to `Date.now()` when the canvas
+   is constructed. So:
+   - nothing at all can be said in the first second after load;
+   - the two zoom warnings pass `20000`, which means they are muted for the
+     first twenty seconds of every session, and for twenty seconds after any
+     other message — I could not make them appear at all until I waited the
+     window out, and then they appeared immediately;
+   - two *different* refusals within a second show only the first. Drag-refuse,
+     then click-refuse, and the second is silent.
+
+3. **Every message looks identical.** Same white bar, same place, same 4s.
+   `Message sent. Thank you for your feedback!` and `A cylinder cannot fold onto
+   itself` are indistinguishable until you read them.
+
+4. **Nothing can be dismissed or kept.** The action is `''`, so there is no
+   button; 4 seconds or nothing. A message you were still reading is gone, and
+   a message you have already understood sits there.
+
+5. **Two snackbar paths.** `UrlProcessorService` opens its own, unstyled and
+   unlimited, so the one message about a *broken share link* is the one that
+   looks unlike the rest.
+
+6. **Messages have no identity.** They are bare strings, so nothing can be
+   deduplicated, grouped, counted, replaced in place, or asserted on by id.
+
+7. **Six of them are unreachable outside the Debug tab**, while the panel that
+   ships rejects the same bad values in silence.
+
+8. **Two constants, one sentence.** `CANNOT_EDIT.analyzeMode` and
+   `.synthesizeMode` hold the same text.
+
+---
+
+## What changed
+
+Fixed:
+
+- **Ctrl+Z undoes**, and Ctrl+Shift+Z / Ctrl+Y redo. Neither says anything. A
+  keystroke aimed at a text field is left to that field, which also stops
+  Delete from removing a joint while its name is being typed.
+- **The cooldown is per message id**, and starts unarmed. Two different
+  refusals in the same second both speak; the same one twice speaks once; a
+  message asking for a long quiet period can speak the moment the page loads.
+- **The four kinds look different** — colour on the glyph and the left edge,
+  the sentence in the app's own text colour.
+- **Warnings and failures wait to be dismissed**; successes and refusals take
+  themselves away. Everything has a close button.
+- **One path.** `UrlProcessorService` goes through the service like everything
+  else.
+- **Messages have ids**, so they can be deduplicated and asserted on. `e2e/notifications.mjs`
+  does both.
+
+Reworded or removed:
+
+- `No file selected` — **gone**. It fired when the file picker was dismissed,
+  and cancelling a dialogue is not a thing that went wrong.
+- The two zoom warnings no longer name buttons; they say what is wrong and
+  where to fix it.
+- `Mechanism URL copied. If you make additional changes, copy the URL again.` →
+  `Link copied. Copy again after your next change.`
+- `Loaded Mechanism from File` → `Mechanism loaded.`
+- `Cannot link to a bar. Please create and select a tracer point on the link.` →
+  `A link joins two joints. Add a tracer point to that bar, then draw to it.`
+- `Merged joint A into B, but B cannot be welded` now says what became of the
+  weld, and waits.
+- `Unable to load the shared mechanism URL.` now says what probably caused it.
+- The context menu's guard said the animation was running when what it had
+  actually tested was the timestep. It now says what it tested.
+
+Still open:
+
+- **The eleven drop refusals** are still snackbars, on top of the canvas
+  refusal marker and the joint shake. Deferred: judge it once the new system is
+  on screen.
+- **The six `NOT_A` messages** are still debug-only, and the Edit panel still
+  rejects bad numbers in silence.
+- **Deleting a joint is not undoable.** `deleteJoint` ends in
+  `finishStructuralEdit(false)`, so no history entry is written and Undo cannot
+  bring it back. Found while wiring Ctrl+Z; pre-existing, and the `false` is
+  explicit enough to be worth asking about before changing.
+
+## Dead — coded but not reachable
+
+- `synthesis-panel.handleButton()` — `Call your backend function with these
+  values! A0: (…)`. No template binds it.
+- `NOT_BUILT_YET` in `ui-text.ts` — exported, never imported.
+- ~20 commented-out debug calls in `synthesis-panel.component.ts`.
+- The Escape-key easter egg and the "tutorial is not ready yet" message, both
+  commented out.

--- a/e2e/notifications.mjs
+++ b/e2e/notifications.mjs
@@ -35,23 +35,19 @@ const record = (what, ok, detail) => {
   console.log(`${ok ? 'PASS' : 'FAIL'}  ${what}${ok ? '' : ' — ' + JSON.stringify(detail)}`);
 };
 
-/** Every message opened since the last drain, with the kind it was opened as. */
+/** Every message that actually reached the stack since the last drain. */
 const watch = () =>
   page.evaluate(() => {
     window.__said = [];
     const notify = ng.getComponent(document.querySelector('app-new-grid')).notify;
     for (const kind of ['success', 'refusal', 'warning', 'failure']) {
       const original = notify[kind].bind(notify);
-      notify[kind] = (id, text, cooldown) => {
-        const before = document.querySelectorAll('.pmksNotification').length;
-        original(id, text, cooldown);
-        // Recorded only if it actually opened, so a suppressed message is
-        // absent here rather than present and invisible.
-        setTimeout(() => {
-          if (document.querySelectorAll('.pmksNotification').length > before || before > 0) {
-            window.__said.push({ kind, id });
-          }
-        }, 60);
+      notify[kind] = (id, text, options) => {
+        const before = notify.live.length;
+        original(id, text, options);
+        // Only if it was really added: a suppressed message is absent here
+        // rather than present and invisible.
+        if (notify.live.length > before) window.__said.push({ kind, id });
       };
     }
   });
@@ -63,17 +59,38 @@ const drain = () =>
     return said;
   });
 
-const say = (kind, id, text, cooldown) =>
+const say = (kind, id, text, options) =>
   page.evaluate(
-    ({ kind, id, text, cooldown }) =>
-      ng.getComponent(document.querySelector('app-new-grid')).notify[kind](id, text, cooldown),
-    { kind, id, text, cooldown }
+    ({ kind, id, text, options }) =>
+      ng.getComponent(document.querySelector('app-new-grid')).notify[kind](id, text, options),
+    { kind, id, text, options }
   );
 
-const showing = () => page.locator('.pmksNotification').count();
+/**
+ * Send the welcome tour away.
+ *
+ * Its overlay swallows clicks, so a suite that presses anything has to get past
+ * it first -- and so does a reader, which is why it is dismissed rather than
+ * clicked through.
+ */
+const closeTour = async () => {
+  await page
+    .locator('.introjs-skipbutton, .introjs-tooltip .introjs-skipbutton')
+    .first()
+    .click({ timeout: 3000 })
+    .catch(() => {});
+  await page.evaluate(() => {
+    document
+      .querySelectorAll('.introjs-overlay, .introjs-tooltipReferenceLayer, .introjs-helperLayer')
+      .forEach((node) => node.remove());
+  });
+  await page.waitForTimeout(200);
+};
+
+const showing = () => page.locator('.notification').count();
 const clear = async () => {
   await page.evaluate(() =>
-    ng.getComponent(document.querySelector('app-new-grid')).notify.dismiss()
+    ng.getComponent(document.querySelector('app-new-grid')).notify.dismissAll()
   );
   await page.waitForTimeout(350);
 };
@@ -81,15 +98,16 @@ const clear = async () => {
 await page.goto(BASE, { waitUntil: 'domcontentloaded' });
 await page.waitForSelector('app-new-grid svg', { timeout: 30000 });
 await waitForReady(page);
+await closeTour();
 await watch();
 
 // ---- the four kinds are told apart on screen -------------------------------
 
 for (const [kind, cls] of [
-  ['success', 'pmksNotification--success'],
-  ['refusal', 'pmksNotification--refusal'],
-  ['warning', 'pmksNotification--warning'],
-  ['failure', 'pmksNotification--failure'],
+  ['success', 'notification--success'],
+  ['refusal', 'notification--refusal'],
+  ['warning', 'notification--warning'],
+  ['failure', 'notification--failure'],
 ]) {
   await say(kind, `probe.${kind}`, `A ${kind}.`);
   await page.waitForTimeout(500);
@@ -154,11 +172,86 @@ await clear();
 // the page loaded -- the fault that kept the zoom warnings quiet for the first
 // twenty seconds of every session.
 await drain();
-await say('warning', 'rate.patient', 'Rare, but not on page load.', 20000);
+await say('warning', 'rate.patient', 'Rare, but not on page load.', { cooldownMs: 20000 });
 await page.waitForTimeout(400);
 const rare = await drain();
 record('a message with a long cooldown can still speak at once', rare.length === 1, rare);
 await clear();
+
+// ---- more than one at a time ------------------------------------------------
+
+await clear();
+await drain();
+await say('warning', 'stack.a', 'The first, waiting.');
+await say('failure', 'stack.b', 'The second, waiting.');
+await say('refusal', 'stack.c', 'The third, leaving by itself.');
+await page.waitForTimeout(500);
+record('three messages stand together', (await showing()) === 3, await showing());
+
+// A fourth pushes out the one that was going to leave anyway, not a warning
+// the reader has not dealt with.
+await say('warning', 'stack.d', 'The fourth, waiting.');
+await page.waitForTimeout(500);
+const stacked = await page.evaluate(() =>
+  ng.getComponent(document.querySelector('app-new-grid')).notify.live.map((one) => one.id)
+);
+record(
+  'a fourth displaces the one that was leaving anyway',
+  stacked.length === 3 && !stacked.includes('stack.c') && stacked.includes('stack.d'),
+  stacked
+);
+await clear();
+
+// ---- a message that can fix the thing it is about ---------------------------
+
+await drain();
+const ran = await page.evaluate(async () => {
+  const notify = ng.getComponent(document.querySelector('app-new-grid')).notify;
+  let done = false;
+  notify.warning('act.probe', 'Something is off.', {
+    action: { label: 'Put it right', run: () => (done = true) },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const button = document.querySelector('.notificationAction');
+  const label = button?.textContent?.trim();
+  button?.click();
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  return { label, done, left: notify.live.length };
+});
+record('a message can carry the fix for what it is about', ran.label === 'Put it right', ran);
+record('pressing it does the thing, and takes the message away', ran.done && ran.left === 0, ran);
+
+// ---- the zoom warning is the real one that carries one -----------------------
+
+await page.evaluate(() => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  for (let i = 0; i < 60; i++) grid.svgGrid.zoomOut();
+  grid.svgGrid.handleZoom(grid.svgGrid.getZoom());
+});
+await page.waitForTimeout(500);
+const zoomed = await page.evaluate(() => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  const one = grid.notify.live.find((n) => n.id.startsWith('zoom.'));
+  return { id: one?.id, label: one?.action?.label };
+});
+record('zooming past the band warns, with a way out', !!zoomed.id && !!zoomed.label, zoomed);
+
+const fixed = await page.evaluate(async () => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  const before = grid.settings.objectScale;
+  document.querySelector('.notificationAction')?.click();
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  const zoom = grid.svgGrid.getZoom();
+  return { before, after: grid.settings.objectScale, drawnAt: zoom * grid.settings.objectScale };
+});
+record(
+  'and taking it puts the drawing back inside the band',
+  fixed.drawnAt > 5 && fixed.drawnAt < 200,
+  fixed
+);
+await clear();
+
+// ---- a value that will not parse says what would --------------------------
 
 // ---- Ctrl+Z undoes -----------------------------------------------------------
 
@@ -172,6 +265,7 @@ const joints = () =>
 // separate fault and not this suite's business.
 await page.goto(`${BASE}/?${FOUR_BAR}`, { waitUntil: 'domcontentloaded' });
 await waitForReady(page);
+await closeTour();
 await watch();
 
 const jointX = () =>

--- a/e2e/notifications.mjs
+++ b/e2e/notifications.mjs
@@ -209,7 +209,7 @@ const ran = await page.evaluate(async () => {
   const notify = ng.getComponent(document.querySelector('app-new-grid')).notify;
   let done = false;
   notify.warning('act.probe', 'Something is off.', {
-    action: { label: 'Put it right', run: () => (done = true) },
+    actions: [{ label: 'Put it right', run: () => (done = true) }],
   });
   await new Promise((resolve) => setTimeout(resolve, 300));
   const button = document.querySelector('.notificationAction');
@@ -221,7 +221,14 @@ const ran = await page.evaluate(async () => {
 record('a message can carry the fix for what it is about', ran.label === 'Put it right', ran);
 record('pressing it does the thing, and takes the message away', ran.done && ran.left === 0, ran);
 
-// ---- the zoom warning is the real one that carries one -----------------------
+// ---- the zoom warning is the real one that carries them ----------------------
+
+// With a linkage on the grid: "Reset view" fits the view to the drawing, and an
+// empty grid has nothing to fit to -- the same as the Reset View button.
+await page.goto(`${BASE}/?${FOUR_BAR}`, { waitUntil: 'domcontentloaded' });
+await waitForReady(page);
+await closeTour();
+await watch();
 
 await page.evaluate(() => {
   const grid = ng.getComponent(document.querySelector('app-new-grid'));
@@ -232,26 +239,67 @@ await page.waitForTimeout(500);
 const zoomed = await page.evaluate(() => {
   const grid = ng.getComponent(document.querySelector('app-new-grid'));
   const one = grid.notify.live.find((n) => n.id.startsWith('zoom.'));
-  return { id: one?.id, label: one?.action?.label };
-});
-record('zooming past the band warns, with a way out', !!zoomed.id && !!zoomed.label, zoomed);
-
-const fixed = await page.evaluate(async () => {
-  const grid = ng.getComponent(document.querySelector('app-new-grid'));
-  const before = grid.settings.objectScale;
-  document.querySelector('.notificationAction')?.click();
-  await new Promise((resolve) => setTimeout(resolve, 400));
-  const zoom = grid.svgGrid.getZoom();
-  return { before, after: grid.settings.objectScale, drawnAt: zoom * grid.settings.objectScale };
+  return { id: one?.id, labels: (one?.actions ?? []).map((a) => a.label) };
 });
 record(
-  'and taking it puts the drawing back inside the band',
-  fixed.drawnAt > 5 && fixed.drawnAt < 200,
-  fixed
+  'zooming past the band warns, with both ways out',
+  !!zoomed.id && zoomed.labels.join('|') === 'Fit to zoom|Reset view',
+  zoomed
+);
+
+// Fit to zoom keeps the view and resizes the drawing.
+const fitted = await page.evaluate(async () => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  const zoomBefore = grid.svgGrid.getZoom();
+  document.querySelectorAll('.notificationAction')[0]?.click();
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  const zoom = grid.svgGrid.getZoom();
+  return {
+    zoomHeld: Math.abs(zoom - zoomBefore) < zoomBefore * 0.01,
+    drawnAt: zoom * grid.settings.objectScale,
+  };
+});
+record(
+  'Fit to zoom resizes the drawing and leaves the view alone',
+  fitted.drawnAt > 5 && fitted.drawnAt < 200 && fitted.zoomHeld,
+  fitted
 );
 await clear();
 
-// ---- a value that will not parse says what would --------------------------
+// Reset view keeps the drawing and moves the view. Zooming the *other* way, so
+// this raises `zoom.links-huge` -- `zoom.links-tiny` asked for a minute of quiet
+// when it spoke above, and per-message cooldowns are the point of them.
+await page.evaluate(() => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  for (let i = 0; i < 120; i++) grid.svgGrid.zoomIn();
+  grid.svgGrid.handleZoom(grid.svgGrid.getZoom());
+});
+await page.waitForTimeout(500);
+const scaleBefore = await page.evaluate(
+  () => ng.getComponent(document.querySelector('app-new-grid')).settings.objectScale
+);
+const zoomBefore = await page.evaluate(() =>
+  ng.getComponent(document.querySelector('app-new-grid')).svgGrid.getZoom()
+);
+// A real click, not a synthetic one. `scaleToFitLinkage` finishes in an
+// `afterNextRender`, so it needs a change-detection pass behind it -- calling
+// the method from the console leaves the fit permanently pending.
+await page.locator('.notificationAction', { hasText: 'Reset view' }).click();
+await page.waitForTimeout(1500);
+const reset = await page.evaluate(() => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  return {
+    scale: grid.settings.objectScale,
+    zoom: grid.svgGrid.getZoom(),
+    left: grid.notify.live.length,
+  };
+});
+record(
+  'Reset view moves the view and leaves the drawing alone',
+  reset.scale === scaleBefore && reset.zoom !== zoomBefore && reset.left === 0,
+  { scaleBefore, zoomBefore, ...reset }
+);
+await clear();
 
 // ---- Ctrl+Z undoes -----------------------------------------------------------
 

--- a/e2e/notifications.mjs
+++ b/e2e/notifications.mjs
@@ -1,0 +1,234 @@
+/**
+ * What the app says out loud, and when it stops saying it.
+ *
+ * The old snackbar had one timestamp for every message in the app, armed at the
+ * moment the canvas was built. That made two things untestable and both wrong:
+ * a second, different refusal within a second was swallowed, and a message
+ * asking for a long quiet period was silent for that period from page load
+ * rather than from the last time it had spoken. Both are checked here.
+ *
+ *   PMKS_BASE_URL=<origin> node e2e/notifications.mjs
+ */
+
+import { readFileSync } from 'node:fs';
+
+const { chromium } = await import(
+  (process.env.PMKS_PLAYWRIGHT_DIR ?? '/tmp/pmks-playwright') + '/node_modules/playwright/index.mjs'
+);
+import { waitForReady } from './app-ready.mjs';
+
+const BASE = process.env.PMKS_BASE_URL ?? 'http://localhost:4600';
+
+const templates = readFileSync('src/app/component/MODALS/templates/template-linkages.ts', 'utf8');
+const FOUR_BAR = Object.fromEntries(
+  [...templates.matchAll(/^ {2}'?([\w-]+)'?:\n {4}'([^']+)',$/gm)].map(([, id, p]) => [id, p])
+)['4-Bar'];
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1500, height: 950 } });
+const errors = [];
+page.on('pageerror', (error) => errors.push(String(error)));
+
+const results = [];
+const record = (what, ok, detail) => {
+  results.push([what, ok]);
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${what}${ok ? '' : ' — ' + JSON.stringify(detail)}`);
+};
+
+/** Every message opened since the last drain, with the kind it was opened as. */
+const watch = () =>
+  page.evaluate(() => {
+    window.__said = [];
+    const notify = ng.getComponent(document.querySelector('app-new-grid')).notify;
+    for (const kind of ['success', 'refusal', 'warning', 'failure']) {
+      const original = notify[kind].bind(notify);
+      notify[kind] = (id, text, cooldown) => {
+        const before = document.querySelectorAll('.pmksNotification').length;
+        original(id, text, cooldown);
+        // Recorded only if it actually opened, so a suppressed message is
+        // absent here rather than present and invisible.
+        setTimeout(() => {
+          if (document.querySelectorAll('.pmksNotification').length > before || before > 0) {
+            window.__said.push({ kind, id });
+          }
+        }, 60);
+      };
+    }
+  });
+
+const drain = () =>
+  page.evaluate(() => {
+    const said = window.__said ?? [];
+    window.__said = [];
+    return said;
+  });
+
+const say = (kind, id, text, cooldown) =>
+  page.evaluate(
+    ({ kind, id, text, cooldown }) =>
+      ng.getComponent(document.querySelector('app-new-grid')).notify[kind](id, text, cooldown),
+    { kind, id, text, cooldown }
+  );
+
+const showing = () => page.locator('.pmksNotification').count();
+const clear = async () => {
+  await page.evaluate(() =>
+    ng.getComponent(document.querySelector('app-new-grid')).notify.dismiss()
+  );
+  await page.waitForTimeout(350);
+};
+
+await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+await page.waitForSelector('app-new-grid svg', { timeout: 30000 });
+await waitForReady(page);
+await watch();
+
+// ---- the four kinds are told apart on screen -------------------------------
+
+for (const [kind, cls] of [
+  ['success', 'pmksNotification--success'],
+  ['refusal', 'pmksNotification--refusal'],
+  ['warning', 'pmksNotification--warning'],
+  ['failure', 'pmksNotification--failure'],
+]) {
+  await say(kind, `probe.${kind}`, `A ${kind}.`);
+  await page.waitForTimeout(500);
+  const marked = await page.locator(`.${cls}`).count();
+  const iconed = await page.locator('.notificationIcon').count();
+  record(`a ${kind} is marked as one, with its own glyph`, marked === 1 && iconed === 1, {
+    marked,
+    iconed,
+  });
+  await clear();
+}
+
+// ---- who waits, and who does not -------------------------------------------
+
+await say('success', 'probe.brief', 'Gone shortly.');
+await page.waitForTimeout(3200);
+record('a success takes itself away', (await showing()) === 0);
+
+await say('refusal', 'probe.refusal-2', 'Also gone shortly.');
+await page.waitForTimeout(4600);
+record('so does a refusal', (await showing()) === 0);
+
+await say('warning', 'probe.patient', 'Still here.');
+await page.waitForTimeout(6000);
+record('a warning waits to be dismissed', (await showing()) === 1);
+await page.locator('.notificationClose').first().click();
+await page.waitForTimeout(400);
+record('and the close button takes it away', (await showing()) === 0);
+
+await say('failure', 'probe.failure-2', 'Still here too.');
+await page.waitForTimeout(6000);
+record('a failure waits as well', (await showing()) === 1);
+await clear();
+
+// ---- the rate limit is per message, not per app ----------------------------
+
+await drain();
+await say('refusal', 'rate.one', 'The first rule.');
+await page.waitForTimeout(200);
+await clear();
+await say('refusal', 'rate.two', 'A different rule, a moment later.');
+await page.waitForTimeout(300);
+const both = await drain();
+record(
+  'a second, different refusal within a second is still said',
+  both.length === 2 && both[0].id === 'rate.one' && both[1].id === 'rate.two',
+  both
+);
+await clear();
+
+await drain();
+await say('refusal', 'rate.same', 'The same rule.');
+await page.waitForTimeout(200);
+await clear();
+await say('refusal', 'rate.same', 'The same rule.');
+await page.waitForTimeout(300);
+const repeated = await drain();
+record('but the same one twice in a second is said once', repeated.length === 1, repeated);
+await clear();
+
+// A long cooldown is measured from when the message last spoke, not from when
+// the page loaded -- the fault that kept the zoom warnings quiet for the first
+// twenty seconds of every session.
+await drain();
+await say('warning', 'rate.patient', 'Rare, but not on page load.', 20000);
+await page.waitForTimeout(400);
+const rare = await drain();
+record('a message with a long cooldown can still speak at once', rare.length === 1, rare);
+await clear();
+
+// ---- Ctrl+Z undoes -----------------------------------------------------------
+
+const joints = () =>
+  page.evaluate(
+    () => ng.getComponent(document.querySelector('app-new-grid')).mechanismSrv.joints.length
+  );
+
+// A four-bar, then an edit worth undoing. A drag, because it is the gesture
+// that reliably writes an undo entry -- deleting a joint does not, which is a
+// separate fault and not this suite's business.
+await page.goto(`${BASE}/?${FOUR_BAR}`, { waitUntil: 'domcontentloaded' });
+await waitForReady(page);
+await watch();
+
+const jointX = () =>
+  page.evaluate(
+    () => ng.getComponent(document.querySelector('app-new-grid')).mechanismSrv.joints[0].x
+  );
+const canUndo = () =>
+  page.evaluate(() =>
+    ng.getComponent(document.querySelector('app-new-grid')).saveHistoryService.canUndo()
+  );
+
+const before = await jointX();
+const box = await page.locator('[id^="joint_"]').first().boundingBox();
+await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+await page.mouse.down();
+await page.mouse.move(box.x + 70, box.y + 45, { steps: 12 });
+await page.mouse.up();
+await page.waitForTimeout(900);
+const moved = await jointX();
+record('a joint was dragged, and the drag is undoable', moved !== before && (await canUndo()), {
+  before,
+  moved,
+});
+
+await drain();
+await page.keyboard.press('Control+z');
+await page.waitForTimeout(1000);
+record('Ctrl+Z undoes rather than asking a question', (await jointX()) === before, {
+  before,
+  after: await jointX(),
+});
+record('and says nothing while doing it', (await drain()).length === 0);
+
+await page.keyboard.press('Control+Shift+z');
+await page.waitForTimeout(1000);
+// Near, not equal: a redone state is replayed through the URL codec, which
+// rounds. What is under test is that the joint went back, not that it
+// round-tripped to the last decimal.
+const redone = await jointX();
+record('Ctrl+Shift+Z puts the drag back', Math.abs(redone - moved) < 1, { moved, redone });
+
+// A keystroke aimed at a text field belongs to the field.
+await page.evaluate(() => {
+  const field = document.querySelector('input:not([type="file"]):not([type="checkbox"])');
+  field?.focus();
+});
+const parked = await jointX();
+await page.keyboard.press('Control+z');
+await page.waitForTimeout(800);
+record('Ctrl+Z in a text field leaves the mechanism alone', (await jointX()) === parked, {
+  parked,
+  after: await jointX(),
+});
+
+record('nothing threw', errors.length === 0, errors.slice(0, 3));
+await browser.close();
+
+const failed = results.filter(([, ok]) => !ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+process.exit(failed.length ? 1 : 0);

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,6 +5,8 @@
 <app-left-tabs></app-left-tabs>
 <app-playback-bar></app-playback-bar>
 <app-right-panel></app-right-panel>
+<!-- Last, so it sits over the chrome rather than under it. -->
+<app-notification-stack></app-notification-stack>
 <!--<app-templates-popup></app-templates-popup>-->
 <!--<app-templates></app-templates>-->
 <!--<app-shape-selector></app-shape-selector>-->

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -15,6 +15,7 @@ import { SynthesisBuilderService } from './services/synthesis/synthesis-builder.
 import { ColorService } from './services/color.service';
 import { KinematicsSolver } from './model/mechanism/kinematic-solver';
 import { euclideanDistance } from './model/utils';
+import { silentNotifications } from '../test-utils/notification-stub';
 
 describe('SixbarService', () => {
   // it('should show the calculated position of the Joints DO match the expected', () => {
@@ -31,7 +32,8 @@ describe('SixbarService', () => {
   const svgGridService: SvgGridService = new SvgGridService(
     settingsService,
     new DragStateService(),
-    {} as unknown as Injector
+    {} as unknown as Injector,
+    silentNotifications()
   );
   const synthesisBuilder: SynthesisBuilderService = new SynthesisBuilderService(
     nup,
@@ -50,7 +52,8 @@ describe('SixbarService', () => {
     activeObjService,
     Injector.create({ providers: [] }),
     settingsService,
-    nup
+    nup,
+    silentNotifications()
   );
 
   // Link AB

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -53,10 +53,12 @@ import { DualButtonComponent } from './component/BLOCKS/dual-button/dual-button.
 import { ColorPickerComponent } from './component/BLOCKS/color-picker/color-picker.component';
 import { TriButtonComponent } from './component/BLOCKS/tri-button/tri-button.component';
 import { BottombarComponent } from './component/bottombar/bottombar.component';
+import { NotificationComponent } from './component/notification/notification.component';
 
 @NgModule({
   declarations: [
     AppComponent,
+    NotificationComponent,
     LinkageTableComponent,
     TopBarComponent,
     AnalysisSetupComponent,

--- a/src/app/component/BLOCKS/editable-title/editable-title.component.ts
+++ b/src/app/component/BLOCKS/editable-title/editable-title.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
-import { NewGridComponent } from '../../new-grid/new-grid.component';
 import { ActiveObjService } from 'src/app/services/active-obj.service';
 import { MechanismService } from 'src/app/services/mechanism.service';
+import { NotificationService } from '../../../services/notification.service';
 
 @Component({
   selector: 'editable-title-block',
@@ -22,7 +22,8 @@ export class EditableTitleComponent {
   constructor(
     private fb: FormBuilder,
     public activeObjService: ActiveObjService,
-    private mechanismService: MechanismService
+    private mechanismService: MechanismService,
+    private notify: NotificationService
   ) {}
 
   newIDForm = this.fb.group({ newID: [''] });
@@ -58,7 +59,7 @@ export class EditableTitleComponent {
     // If the new ID is not valid, send error notif and do not update to new id
     let error = this.validateNewID(newID);
     if (error !== '') {
-      NewGridComponent.sendNotification(error);
+      this.notify.refusal('rename.invalid', error);
       this.editMode = false;
       return;
     }

--- a/src/app/component/context-menu/context-menu.component.ts
+++ b/src/app/component/context-menu/context-menu.component.ts
@@ -20,8 +20,11 @@ export class cMenuItem {
   }
 
   actionWrapper() {
+    // The test is the timestep, so the reason has to be the timestep. It said
+    // the animation was running, which it need not be -- a mechanism parked
+    // anywhere but the start pose refuses edits whether it is moving or not.
     if (NewGridComponent.instance.mechanismSrv.mechanismTimeStep !== 0) {
-      NewGridComponent.sendNotification(CANNOT_EDIT.animating);
+      NewGridComponent.instance.notify.refusal('edit.away-from-start', CANNOT_EDIT.awayFromStart);
       return;
     }
     this.action();

--- a/src/app/component/context-menu/context-menu.component.ts
+++ b/src/app/component/context-menu/context-menu.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, Input, ChangeDetectionStrategy } from '@angular/core
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { MechanismService } from '../../services/mechanism.service';
 import { NewGridComponent } from '../new-grid/new-grid.component';
-import { CANNOT_EDIT } from '../../ui-text';
 
 export class cMenuItem {
   public label: string = 'none';
@@ -20,11 +19,11 @@ export class cMenuItem {
   }
 
   actionWrapper() {
-    // The test is the timestep, so the reason has to be the timestep. It said
-    // the animation was running, which it need not be -- a mechanism parked
-    // anywhere but the start pose refuses edits whether it is moving or not.
+    // Silently, like every other guard on editing away from the start pose: the
+    // transport says where the mechanism is parked, and it said the wrong thing
+    // anyway -- the test here is the timestep, and the message it showed was
+    // the one about the animation running, which it need not be.
     if (NewGridComponent.instance.mechanismSrv.mechanismTimeStep !== 0) {
-      NewGridComponent.instance.notify.refusal('edit.away-from-start', CANNOT_EDIT.awayFromStart);
       return;
     }
     this.action();

--- a/src/app/component/edit-panel/edit-panel.component.ts
+++ b/src/app/component/edit-panel/edit-panel.component.ts
@@ -34,6 +34,8 @@ import {
   cylinderMinimumSpan,
   cylinderSizeOf,
 } from '../../model/cylinder';
+import { NotificationService } from 'src/app/services/notification.service';
+import { NOT_A } from 'src/app/ui-text';
 
 /**
  * Input Settings unit choices, in the order the picker shows them. The labels
@@ -169,7 +171,8 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
     private nup: NumberUnitParserService,
     private cd: ChangeDetectorRef,
     public mechanismService: MechanismService,
-    public gridUtils: GridUtilsService
+    public gridUtils: GridUtilsService,
+    private notify: NotificationService
   ) {
     //Set the instance to this
     EditPanelComponent.instance = this;
@@ -662,6 +665,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
           this.settingsService.lengthUnit.getValue()
         );
         if (!success) {
+          this.notify.refusal('value.length', NOT_A.length);
           this.jointForm.patchValue({
             xPos: this.nup.formatModelLength(
               this.activeSrv.selectedJoint.x,
@@ -699,6 +703,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
           this.settingsService.lengthUnit.getValue()
         );
         if (!success) {
+          this.notify.refusal('value.length', NOT_A.length);
           this.jointForm.patchValue({
             yPos: this.nup.formatModelLength(
               this.activeSrv.selectedJoint.y,
@@ -738,6 +743,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
         if (!this.activeSrv.selectedJoint) return;
         if (!this.gridUtils.isAttachedToSlider(this.activeSrv.selectedJoint)) return;
         if (!success) {
+          this.notify.refusal('value.angle', NOT_A.angle);
           // Two things had to be true for this to recurse until the stack ran
           // out, and both were: the angle was read off the *pin*, which has no
           // angle_rad, so the field was restored to the string "NaN"; and the
@@ -915,6 +921,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
           this.settingsService.lengthUnit.getValue()
         );
         if (!success) {
+          this.notify.refusal('value.length', NOT_A.length);
           this.linkForm.patchValue({
             length: this.nup.formatModelLength(
               this.activeSrv.selectedLink.length,
@@ -1023,8 +1030,10 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
           val!,
           this.settingsService.angleUnit.getValue()
         );
-        if (!success) this.patchCylinderForm();
-        else
+        if (!success) {
+          this.notify.refusal('value.angle', NOT_A.angle);
+          this.patchCylinderForm();
+        } else
           this.reposeCylinder(
             undefined,
             this.nup.convertAngle(
@@ -1043,6 +1052,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
           this.settingsService.angleUnit.getValue()
         );
         if (!success) {
+          this.notify.refusal('value.angle', NOT_A.angle);
           this.linkForm.patchValue({
             angle: this.nup
               .convertAngle(
@@ -1140,6 +1150,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
           this.settingsService.forceUnit.getValue()
         );
         if (!success) {
+          this.notify.refusal('value.force', NOT_A.force);
           this.forceForm.patchValue({
             magnitude: this.activeSrv.selectedForce.mag.toFixed(2).toString(),
           });
@@ -1167,6 +1178,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
           this.settingsService.angleUnit.getValue()
         );
         if (!success) {
+          this.notify.refusal('value.angle', NOT_A.angle);
           this.forceForm.patchValue({
             angle: this.activeSrv.selectedForce.angleRad.toFixed(2).toString(),
           });
@@ -1199,6 +1211,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
           this.settingsService.forceUnit.getValue()
         );
         if (!success) {
+          this.notify.refusal('value.force', NOT_A.force);
           this.forceForm.patchValue({
             xComp: this.activeSrv.selectedForce.xComp.toFixed(2).toString(),
           });
@@ -1223,6 +1236,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
           this.settingsService.forceUnit.getValue()
         );
         if (!success) {
+          this.notify.refusal('value.force', NOT_A.force);
           this.forceForm.patchValue({
             yComp: this.activeSrv.selectedForce.yComp.toFixed(2).toString(),
           });
@@ -1387,6 +1401,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
     );
     const link = this.activeSrv.selectedLink;
     if (!success) {
+      this.notify.refusal('value.length', NOT_A.length);
       this.linkForm.patchValue(
         {
           [axis === 'x' ? 'comX' : 'comY']: this.nup.formatModelLength(
@@ -1609,6 +1624,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
             this.settingsService.lengthUnit.getValue()
           );
           if (!success) {
+            this.notify.refusal('value.length', NOT_A.length);
             this.otherJoints.controls[i * 2].patchValue(
               this.nup.formatModelLength(
                 this.getDistanceBetweenJoints(this.activeSrv.selectedJoint, joint),
@@ -1634,6 +1650,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
             this.settingsService.angleUnit.getValue()
           );
           if (!success) {
+            this.notify.refusal('value.angle', NOT_A.angle);
             this.otherJoints.controls[i * 2 + 1].patchValue(
               this.nup
                 .convertAngle(

--- a/src/app/component/linkage-table/linkage-table.component.ts
+++ b/src/app/component/linkage-table/linkage-table.component.ts
@@ -14,9 +14,9 @@ import { roundNumber } from '../../model/utils';
 import { Mechanism } from '../../model/mechanism/mechanism';
 import { InstantCenter } from '../../model/instant-center';
 import { MechanismService } from '../../services/mechanism.service';
-import { NewGridComponent } from '../new-grid/new-grid.component';
 import { MODEL_SCALE } from '../../model/render-scale';
 import { NOT_A } from '../../ui-text';
+import { NotificationService } from '../../services/notification.service';
 
 @Component({
   selector: 'app-linkage-table',
@@ -32,7 +32,10 @@ export class LinkageTableComponent implements OnInit {
   private static forceButton: SVGElement;
   private static showLinkageTableButton: SVGElement;
 
-  constructor(private mechanismService: MechanismService) {}
+  constructor(
+    private mechanismService: MechanismService,
+    private notify: NotificationService
+  ) {}
 
   // The table's cells speak the user's units; the model is MODEL_SCALE times
   // larger (render-scale.ts), so every length converts at this boundary.
@@ -76,7 +79,7 @@ export class LinkageTableComponent implements OnInit {
     const sealed = this.mechanismService.cylinderAt(joint);
     if (sealed && (jointProp === 'x' || jointProp === 'y')) {
       if (isNaN(Number($event.target.value))) {
-        return NewGridComponent.sendNotification(NOT_A.length);
+        return this.notify.refusal('value.length', NOT_A.length);
       }
       const value = Number($event.target.value) * MODEL_SCALE;
       const wanted = new Coord(
@@ -93,7 +96,7 @@ export class LinkageTableComponent implements OnInit {
       // TODO: When changing the joint positions, be sure to also change the ('d') path of the link
       case 'x':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.length);
+          return this.notify.refusal('value.length', NOT_A.length);
         }
         joint.x = Number($event.target.value) * MODEL_SCALE;
         joint.links.forEach((l) => {
@@ -115,7 +118,7 @@ export class LinkageTableComponent implements OnInit {
         break;
       case 'y':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.length);
+          return this.notify.refusal('value.length', NOT_A.length);
         }
         joint.y = Number($event.target.value) * MODEL_SCALE;
         joint.links.forEach((l) => {
@@ -135,7 +138,7 @@ export class LinkageTableComponent implements OnInit {
         break;
       case 'id':
         if (!(typeof $event.target.value === 'string')) {
-          return NewGridComponent.sendNotification(NOT_A.name);
+          return this.notify.refusal('value.name', NOT_A.name);
         }
         joint.links.forEach((l) => {
           l.id = l.id.replace(joint.id, $event.target.value);
@@ -144,7 +147,7 @@ export class LinkageTableComponent implements OnInit {
         break;
       case 'angle':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.angle);
+          return this.notify.refusal('value.angle', NOT_A.angle);
         }
         if (!(joint instanceof PrisJoint)) {
           return;
@@ -164,25 +167,25 @@ export class LinkageTableComponent implements OnInit {
     switch (linkProp) {
       case 'mass':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.mass);
+          return this.notify.refusal('value.mass', NOT_A.mass);
         }
         link.mass = Number($event.target.value);
         break;
       case 'massMoI':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.momentOfInertia);
+          return this.notify.refusal('value.momentOfInertia', NOT_A.momentOfInertia);
         }
         link.massMoI = Number($event.target.value);
         break;
       case 'CoMX':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.length);
+          return this.notify.refusal('value.length', NOT_A.length);
         }
         link.CoM.x = Number($event.target.value) * MODEL_SCALE;
         break;
       case 'CoMY':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.length);
+          return this.notify.refusal('value.length', NOT_A.length);
         }
         link.CoM.y = Number($event.target.value) * MODEL_SCALE;
         break;
@@ -198,31 +201,31 @@ export class LinkageTableComponent implements OnInit {
     switch (forceProp) {
       case 'id':
         if (!(typeof $event.target.value === 'string')) {
-          return NewGridComponent.sendNotification(NOT_A.name);
+          return this.notify.refusal('value.name', NOT_A.name);
         }
         force.id = $event.target.value;
         break;
       case 'xPos':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.length);
+          return this.notify.refusal('value.length', NOT_A.length);
         }
         force.moveAnchor(new Coord(Number($event.target.value) * MODEL_SCALE, force.startCoord.y));
         break;
       case 'yPos':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.length);
+          return this.notify.refusal('value.length', NOT_A.length);
         }
         force.moveAnchor(new Coord(force.startCoord.x, Number($event.target.value) * MODEL_SCALE));
         break;
       case 'mag':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.force);
+          return this.notify.refusal('value.force', NOT_A.force);
         }
         force.setMagnitude(Number($event.target.value));
         break;
       case 'angle':
         if (isNaN(Number($event.target.value))) {
-          return NewGridComponent.sendNotification(NOT_A.angle);
+          return this.notify.refusal('value.angle', NOT_A.angle);
         }
         force.setDirectionRadians(Number($event.target.value) * (Math.PI / 180));
         break;

--- a/src/app/component/mechanism-panel/mechanism-panel.component.ts
+++ b/src/app/component/mechanism-panel/mechanism-panel.component.ts
@@ -136,10 +136,15 @@ export class MechanismPanelComponent {
     }
     // Deleting its joints takes the links with them, which is what "delete this
     // mechanism" means: nothing of it is left, and nothing else is touched.
+    //
+    // The joints go one at a time, but the gesture is a single press: none of
+    // them saves, and the removal is minted as one undo entry below. Otherwise
+    // restoring the mechanism would cost one undo per joint it happened to have.
     [...partition.ownJoints].forEach((joint) => {
       this.activeObj.updateSelectedObj(joint);
-      this.mechanism.deleteJoint();
+      this.mechanism.deleteJoint(false);
     });
     this.activeObj.updateSelectedObj(null);
+    this.mechanism.finishStructuralEdit(true);
   }
 }

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -116,7 +116,6 @@ export interface SlotStackItem {
   plate?: WeldPlate;
 }
 import introJs from 'intro.js';
-import { CANNOT_EDIT } from '../../ui-text';
 
 @Component({
   selector: 'app-new-grid',
@@ -973,7 +972,7 @@ export class NewGridComponent implements OnDestroy {
       this.notify.refusal(
         'force.ambiguous-anchor',
         'Several links meet at that joint, so a force there would not say which one it acts on.',
-        1500
+        { cooldownMs: 1500 }
       );
       return;
     }
@@ -1308,21 +1307,25 @@ export class NewGridComponent implements OnDestroy {
   }
 
   /**
-   * Whether an edit is allowed right now, notifying the user when it is not.
+   * Whether an edit is allowed right now.
+   *
    * Editing is only defined at the t=0 pose in Edit mode: the solved timesteps
    * are derived from it, so a change made anywhere else has nothing to write to.
+   *
+   * Silently. Each of these used to announce itself, and each was saying
+   * something the reader could already see — which mode they are in is written
+   * across the top strip and down the side of the window, and whether the
+   * animation is running is the thing they are watching. A message for it was
+   * a fifth place saying the same word.
    */
   private canEditNow(): boolean {
     if (this.mechanismSrv.isPlaying) {
-      this.notify.refusal('edit.animating', CANNOT_EDIT.animating);
       return false;
     }
     if (this.mechanismSrv.mechanismTimeStep !== 0) {
-      this.notify.refusal('edit.away-from-start', CANNOT_EDIT.awayFromStart);
       return false;
     }
     if (this.tabService.getCurrentTab() === TabID.SYNTHESIZE) {
-      this.notify.refusal('edit.synthesize-mode', CANNOT_EDIT.synthesizeMode);
       return false;
     }
     // Analyze already refuses to open an edit context menu (see onContextMenu),
@@ -1333,7 +1336,6 @@ export class NewGridComponent implements OnDestroy {
     // same solved cycle and is no more able to survive the geometry moving
     // under it.
     if (this.tabService.isAnalysisMode()) {
-      this.notify.refusal('edit.analyze-mode', CANNOT_EDIT.analyzeMode);
       return false;
     }
     return true;
@@ -1685,7 +1687,6 @@ export class NewGridComponent implements OnDestroy {
 
   onContextMenu($event: MouseEvent) {
     if (this.tabService.getCurrentTab() === TabID.SYNTHESIZE) {
-      this.notify.refusal('edit.synthesize-mode', CANNOT_EDIT.synthesizeMode);
       this.cMenuItems = [];
       return;
     }
@@ -1698,12 +1699,10 @@ export class NewGridComponent implements OnDestroy {
     }
 
     if (this.mechanismSrv.isPlaying == true) {
-      this.notify.refusal('edit.animating', CANNOT_EDIT.animating);
       this.cMenuItems = [];
       return;
     }
     if (this.mechanismSrv.mechanismTimeStep !== 0) {
-      this.notify.refusal('edit.away-from-start', CANNOT_EDIT.awayFromStart);
       this.cMenuItems = [];
       //Close the MatContextMenu
       // console.log(this.contextMenu);

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -36,7 +36,7 @@ import {
 } from '../../model/utils';
 import { Force } from '../../model/force';
 import { PositionSolver } from '../../model/mechanism/position-solver';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { NotificationService } from '../../services/notification.service';
 import { animate, style, transition, trigger } from '@angular/animations';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { CdkContextMenuTrigger, Menu } from '@angular/cdk/menu';
@@ -81,6 +81,7 @@ import {
 import {
   JointDropCandidate,
   MERGE_REFUSAL_MESSAGES,
+  MergeRefusal,
   resolveDropCandidate,
   resolveSlotDropTarget,
   SlotDropCandidate,
@@ -141,7 +142,9 @@ export class NewGridComponent implements OnDestroy {
     public activeObjService: ActiveObjService,
     private tabService: SelectedTabService,
     public synthesisBuilder: SynthesisBuilderService,
-    private snackBar: MatSnackBar,
+    // Public because `cMenuItem` is a plain class with no injector and reaches
+    // the canvas for its guards, exactly as it already does for the mechanism.
+    public notify: NotificationService,
     public dialog: MatDialog,
     public saveHistoryService: SaveHistoryService,
     private colorService: ColorService,
@@ -211,7 +214,6 @@ export class NewGridComponent implements OnDestroy {
   public showLinkAngleOverlay: number = -2;
 
   static instance: NewGridComponent;
-  private lastNotificationTime: number = Date.now();
   //To distinguish between a click and a drag
   public delta: number = 6;
   private startX!: number;
@@ -968,7 +970,8 @@ export class NewGridComponent implements OnDestroy {
     const link = force.link;
     const anchor = this.gridUtils.forceAnchorAt(link, wanted, this.settings.objectScale);
     if (!anchor) {
-      this.sendNotification(
+      this.notify.refusal(
+        'force.ambiguous-anchor',
         'Several links meet at that joint, so a force there would not say which one it acts on.',
         1500
       );
@@ -1164,7 +1167,8 @@ export class NewGridComponent implements OnDestroy {
           // is noise rather than an explanation.
           if (atMinimum && !this.cylinderFloorReported) {
             this.cylinderFloorReported = true;
-            this.sendNotification(
+            this.notify.refusal(
+              'cylinder.at-minimum',
               'That is the shortest cylinder there is — any less and the barrel has no room to slide in.'
             );
           }
@@ -1310,15 +1314,15 @@ export class NewGridComponent implements OnDestroy {
    */
   private canEditNow(): boolean {
     if (this.mechanismSrv.isPlaying) {
-      this.sendNotification(CANNOT_EDIT.animating);
+      this.notify.refusal('edit.animating', CANNOT_EDIT.animating);
       return false;
     }
     if (this.mechanismSrv.mechanismTimeStep !== 0) {
-      this.sendNotification(CANNOT_EDIT.awayFromStart);
+      this.notify.refusal('edit.away-from-start', CANNOT_EDIT.awayFromStart);
       return false;
     }
     if (this.tabService.getCurrentTab() === TabID.SYNTHESIZE) {
-      this.sendNotification(CANNOT_EDIT.synthesizeMode);
+      this.notify.refusal('edit.synthesize-mode', CANNOT_EDIT.synthesizeMode);
       return false;
     }
     // Analyze already refuses to open an edit context menu (see onContextMenu),
@@ -1329,7 +1333,7 @@ export class NewGridComponent implements OnDestroy {
     // same solved cycle and is no more able to survive the geometry moving
     // under it.
     if (this.tabService.isAnalysisMode()) {
-      this.sendNotification(CANNOT_EDIT.analyzeMode);
+      this.notify.refusal('edit.analyze-mode', CANNOT_EDIT.analyzeMode);
       return false;
     }
     return true;
@@ -1646,9 +1650,15 @@ export class NewGridComponent implements OnDestroy {
     return '';
   }
 
-  /** Shake the dropped joint and say why it could not land where it was aimed. */
-  private refuseDrop(jointID: string, message: string): void {
-    this.sendNotification(message);
+  /**
+   * Shake the dropped joint and say why it could not land where it was aimed.
+   *
+   * The reason is its own message rather than a shared "cannot drop here", so
+   * dragging against one rule and then another says both instead of falling
+   * silent on the second.
+   */
+  private refuseDrop(jointID: string, reason: MergeRefusal): void {
+    this.notify.refusal(`merge.${reason}`, MERGE_REFUSAL_MESSAGES[reason]);
     this.shakingJointID = jointID;
     setTimeout(() => (this.shakingJointID = undefined), 420);
   }
@@ -1675,7 +1685,7 @@ export class NewGridComponent implements OnDestroy {
 
   onContextMenu($event: MouseEvent) {
     if (this.tabService.getCurrentTab() === TabID.SYNTHESIZE) {
-      this.sendNotification(CANNOT_EDIT.synthesizeMode);
+      this.notify.refusal('edit.synthesize-mode', CANNOT_EDIT.synthesizeMode);
       this.cMenuItems = [];
       return;
     }
@@ -1688,12 +1698,12 @@ export class NewGridComponent implements OnDestroy {
     }
 
     if (this.mechanismSrv.isPlaying == true) {
-      this.sendNotification(CANNOT_EDIT.animating);
+      this.notify.refusal('edit.animating', CANNOT_EDIT.animating);
       this.cMenuItems = [];
       return;
     }
     if (this.mechanismSrv.mechanismTimeStep !== 0) {
-      this.sendNotification(CANNOT_EDIT.awayFromStart);
+      this.notify.refusal('edit.away-from-start', CANNOT_EDIT.awayFromStart);
       this.cMenuItems = [];
       //Close the MatContextMenu
       // console.log(this.contextMenu);
@@ -1760,7 +1770,7 @@ export class NewGridComponent implements OnDestroy {
 
     const source = this.activeObjService.selectedJoint;
     if (refused?.refusal) {
-      this.refuseDrop(source.id, MERGE_REFUSAL_MESSAGES[refused.refusal]);
+      this.refuseDrop(source.id, refused.refusal);
       return false;
     }
     if (!target) {
@@ -1776,7 +1786,7 @@ export class NewGridComponent implements OnDestroy {
     const wasWelded = source.isWelded || target.isWelded;
     const refusal = this.mechanismSrv.mergeJoints(source, target);
     if (refusal) {
-      this.refuseDrop(source.id, MERGE_REFUSAL_MESSAGES[refusal]);
+      this.refuseDrop(source.id, refusal);
       return false;
     }
 
@@ -1784,9 +1794,12 @@ export class NewGridComponent implements OnDestroy {
     // slider-carrying survivor cannot be welded at all. Losing the weld
     // silently would leave the user with a linkage they did not ask for. A
     // merge that goes exactly as asked says nothing: the pop is the receipt.
+    // A warning, not a refusal: the merge happened, and the linkage the reader
+    // now has is not quite the one they drew. It waits to be dismissed.
     if (wasWelded && !target.isWelded) {
-      this.sendNotification(
-        `Merged joint ${source.id} into ${target.id}, but ${target.id} cannot be welded`
+      this.notify.warning(
+        'merge.weld-lost',
+        `Merged ${source.id} into ${target.id}. The weld did not carry over — ${target.id} cannot be welded.`
       );
     }
     this.popJoint(target.id);
@@ -1998,7 +2011,10 @@ export class NewGridComponent implements OnDestroy {
                 if (commonLinkCheck) {
                   this.dragState.finishCreating();
                   this.linkCreateStart = undefined;
-                  this.sendNotification('Those two joints are already on one link.');
+                  this.notify.refusal(
+                    'link.already-joined',
+                    'Those two joints are already on one link.'
+                  );
                   return;
                 }
                 this.activeObjService.prevSelectedJoint.connectedJoints.push(joint2);
@@ -2062,8 +2078,9 @@ export class NewGridComponent implements OnDestroy {
             break;
           case 'Link':
             if (this.dragState.isCreatingLink) {
-              this.sendNotification(
-                'Cannot link to a bar. Please create and select a tracer point on the link.'
+              this.notify.refusal(
+                'link.needs-a-joint',
+                'A link joins two joints. Add a tracer point to that bar, then draw to it.'
               );
               this.dragState.cancel();
               this.linkCreateStart = undefined;
@@ -2107,27 +2124,6 @@ export class NewGridComponent implements OnDestroy {
         this.cylinderCreateStart = undefined;
         this.linkCreateStart = undefined;
         break;
-    }
-  }
-
-  static sendNotification(text: string, rateLimitMS?: number) {
-    // Services reach the snackbar through here, and they are also exercised in
-    // tests with no component standing. A missing canvas means nobody is
-    // looking, not that the caller did something wrong.
-    NewGridComponent.instance?.sendNotification(text, rateLimitMS);
-  }
-
-  sendNotification(text: string, rateLimitMS?: number) {
-    rateLimitMS = rateLimitMS || 1000; //Default to 1 second
-    //If there is more than one notification in the last seccond, ingore all but the first
-    if (this.lastNotificationTime + rateLimitMS < Date.now()) {
-      this.lastNotificationTime = Date.now();
-      this.snackBar.open(text, '', {
-        panelClass: 'my-custom-snackbar',
-        horizontalPosition: 'center',
-        verticalPosition: 'top',
-        duration: 4000,
-      });
     }
   }
 
@@ -3030,24 +3026,47 @@ export class NewGridComponent implements OnDestroy {
     this.activeObjService.updateSelectedObj(this.activeObjService.selectedJoint);
   }
 
+  /** Whether the keystroke was aimed at somewhere text is being entered. */
+  private typingInAField($event: KeyboardEvent): boolean {
+    const target = $event.target as HTMLElement | null;
+    if (!target) return false;
+    const tag = target.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable;
+  }
+
   // Angular keys host listeners by event name, so this component gets exactly
   // one window:keydown. Anything that needs the key down hangs off here.
   @HostListener('window:keydown', ['$event'])
   onKeyPress($event: KeyboardEvent) {
     this.reconsiderDrop($event, true);
 
-    if (($event.ctrlKey || $event.metaKey) && $event.keyCode == 90) {
-      //Ctrl + Z
-      NewGridComponent.sendNotification(
-        'You attempted to undo. What were you trying to undo? Please let us know through the report button in the help section.'
-      );
+    // A key pressed into a text field belongs to that field. Undo there means
+    // undo the typing, and Delete means delete a character -- not the joint
+    // whose name is being typed.
+    if (this.typingInAField($event)) {
+      return;
+    }
+
+    // Ctrl/Cmd+Z, and Shift or Y for the other direction. This used to ask the
+    // reader what they had been trying to undo, as a question for a study that
+    // has since ended, while undo itself sat in the top strip working fine.
+    const held = $event.ctrlKey || $event.metaKey;
+    const key = $event.key.toLowerCase();
+    if (held && (key === 'z' || key === 'y')) {
+      $event.preventDefault();
+      // Hidden in the analysis modes for the same reason the buttons are: there
+      // is nothing there to undo.
+      if (this.tabService.isAnalysisMode()) return;
+      if (key === 'y' || $event.shiftKey) {
+        this.saveHistoryService.redo();
+      } else {
+        this.saveHistoryService.undo();
+      }
+      return;
     }
 
     if ($event.keyCode == 27) {
       //Escape Key
-      // NewGridComponent.sendNotification(
-      //   'You pressed the "Escape" key. What were you trying to do and in what context? (This is an Easter Egg. Please talk about in the final question of the survey.)'
-      // );
       this.activeObjService.updateSelectedObj(undefined);
     }
 
@@ -3056,7 +3075,8 @@ export class NewGridComponent implements OnDestroy {
       if (true) {
         //TODO: Sorry jacob you need to fix this it used to say: if(GridComponent.canDelete)
         if (this.activeObjService.objType === 'Grid') {
-          NewGridComponent.sendNotification(
+          this.notify.refusal(
+            'delete.nothing-selected',
             'Select something first — Delete removes whatever is selected.'
           );
           return;

--- a/src/app/component/notification/notification.component.html
+++ b/src/app/component/notification/notification.component.html
@@ -1,0 +1,7 @@
+<mat-icon class="notificationIcon">{{ icon }}</mat-icon>
+<span class="notificationText">{{ data.text }}</span>
+<!-- On every kind, not only the ones that wait. A message that has been read is
+     in the way, and four seconds is long enough to be in the way. -->
+<button class="notificationClose" type="button" (click)="data.dismiss()" aria-label="Dismiss">
+  <mat-icon>close</mat-icon>
+</button>

--- a/src/app/component/notification/notification.component.html
+++ b/src/app/component/notification/notification.component.html
@@ -8,11 +8,11 @@
     >
       <mat-icon class="notificationIcon">{{ iconFor(one) }}</mat-icon>
       <span class="notificationText">{{ one.text }}</span>
-      <!-- Where there is one obvious thing to do about it, the message does it,
+      <!-- Where there is an obvious thing to do about it, the message does it,
            rather than naming a control elsewhere for the reader to go and find. -->
-      @if (one.action) {
-        <button class="notificationAction" type="button" (click)="notifications.act(one)">
-          {{ one.action.label }}
+      @for (action of one.actions; track action.label) {
+        <button class="notificationAction" type="button" (click)="notifications.act(one, action)">
+          {{ action.label }}
         </button>
       }
       <!-- On every kind, not only the ones that wait. A message that has been

--- a/src/app/component/notification/notification.component.html
+++ b/src/app/component/notification/notification.component.html
@@ -1,7 +1,30 @@
-<mat-icon class="notificationIcon">{{ icon }}</mat-icon>
-<span class="notificationText">{{ data.text }}</span>
-<!-- On every kind, not only the ones that wait. A message that has been read is
-     in the way, and four seconds is long enough to be in the way. -->
-<button class="notificationClose" type="button" (click)="data.dismiss()" aria-label="Dismiss">
-  <mat-icon>close</mat-icon>
-</button>
+<div class="notificationStack">
+  @for (one of notifications.live; track one.key) {
+    <div
+      class="notification notification--{{ one.kind }}"
+      [@card]
+      role="status"
+      [attr.aria-live]="politenessFor(one)"
+    >
+      <mat-icon class="notificationIcon">{{ iconFor(one) }}</mat-icon>
+      <span class="notificationText">{{ one.text }}</span>
+      <!-- Where there is one obvious thing to do about it, the message does it,
+           rather than naming a control elsewhere for the reader to go and find. -->
+      @if (one.action) {
+        <button class="notificationAction" type="button" (click)="notifications.act(one)">
+          {{ one.action.label }}
+        </button>
+      }
+      <!-- On every kind, not only the ones that wait. A message that has been
+           read is in the way, and four seconds is long enough to be in the way. -->
+      <button
+        class="notificationClose"
+        type="button"
+        (click)="notifications.dismiss(one.key)"
+        aria-label="Dismiss"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
+  }
+</div>

--- a/src/app/component/notification/notification.component.scss
+++ b/src/app/component/notification/notification.component.scss
@@ -1,0 +1,127 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use 'src/app/component/left-tabs/left-tabs.vars.scss' as vars;
+
+@mixin css($theme) {
+  // Which colour each kind is written in. Only the icon and the edge are
+  // coloured -- the sentence stays the app's text colour, because a red
+  // sentence is harder to read and the glyph has already said which of the
+  // four this is.
+  $kinds: (
+    'success': #2e7d32,
+    'refusal': #455a64,
+    'warning': #ef6c00,
+    'failure': #c62828,
+  );
+
+  // The snackbar renders in an overlay, outside the component tree, so these
+  // rules are global by necessity -- the same reason every other component's
+  // styles in this app are pulled into `mytheme.scss` rather than scoped.
+  .pmksNotification {
+    // Below the top strip rather than over it. It used to be pushed down by a
+    // bare 50px, which was neither the strip's height nor a gap from anything.
+    margin-top: vars.$top-strip-bottom + vars.$card-inset !important;
+
+    // Material's own surface is the wrong shape for this app: a dark slab with
+    // white text. The card underneath is what everything else that floats over
+    // the grid looks like.
+    //
+    // Set through Material's own custom properties rather than by out-shouting
+    // its rules. Its surface selector has the same specificity as anything
+    // written here, so which one wins comes down to the order the two
+    // stylesheets happen to be concatenated in -- which is not something to
+    // rest a colour on.
+    --mat-snack-bar-container-color: var(--card-surface);
+    --mat-snack-bar-supporting-text-color: #2c2c2c;
+
+    // Both spellings: the class was renamed between Material versions and the
+    // element carries the old one as well as the new.
+    .mat-mdc-snackbar-surface,
+    .mdc-snackbar__surface {
+      min-width: 0;
+      max-width: min(640px, 90vw);
+      padding: 0;
+      border-radius: var(--card-radius);
+      box-shadow: var(--card-shadow);
+    }
+
+    .mat-mdc-snack-bar-label,
+    .mdc-snackbar__label {
+      padding: 0;
+    }
+
+    app-notification {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      // The colour bar is the whole left edge, so the padding starts after it.
+      padding: 12px 8px 12px 14px;
+      border-left: 4px solid transparent;
+      border-radius: var(--card-radius);
+      // A message can run to two or three lines; the icon stays on the first.
+      color: #2c2c2c;
+    }
+  }
+
+  .notificationIcon {
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
+    font-size: 20px;
+    line-height: 1;
+    // Material gives mat-icon a 24px box whatever the glyph is, so a 20px
+    // glyph would otherwise sit high in it against a 20px line of text.
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 1px;
+  }
+
+  .notificationText {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: 0.15px;
+  }
+
+  // Small and grey: it is the way out of a message, not part of what the
+  // message says.
+  .notificationClose {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    margin: -2px 0 0;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.06);
+      color: rgba(0, 0, 0, 0.7);
+    }
+
+    .mat-icon {
+      width: 18px;
+      height: 18px;
+      font-size: 18px;
+      line-height: 1;
+    }
+  }
+
+  @each $kind, $color in $kinds {
+    .pmksNotification--#{$kind} app-notification {
+      border-left-color: $color;
+    }
+
+    .pmksNotification--#{$kind} .notificationIcon {
+      color: $color;
+    }
+  }
+}

--- a/src/app/component/notification/notification.component.scss
+++ b/src/app/component/notification/notification.component.scss
@@ -33,9 +33,13 @@ $accent: 5px;
     pointer-events: none;
   }
 
+  // Everything on one centre line. The glyph, the sentence, the buttons and the
+  // close were each aligned by a different rule -- flex-start plus a 1px nudge,
+  // align-self: center, and a -2px margin -- so no two of them agreed on where
+  // the middle was. One rule for the row, and nothing overriding it.
   .notification {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 10px;
     padding: 11px 8px 11px 13px;
     background: var(--card-surface);
@@ -53,18 +57,18 @@ $accent: 5px;
     border-radius: $accent;
   }
 
+  // Material gives mat-icon a 24px box whatever the glyph inside it is, so the
+  // glyph has to be centred in the box the box actually is, not left to sit at
+  // the top of it.
   .notificationIcon {
     flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 20px;
     height: 20px;
     font-size: 20px;
     line-height: 1;
-    // Material gives mat-icon a 24px box whatever the glyph is, so a 20px
-    // glyph would otherwise sit high in it against a 20px line of text.
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 1px;
   }
 
   .notificationText {
@@ -75,12 +79,22 @@ $accent: 5px;
     letter-spacing: 0.15px;
   }
 
+  // A second action sits next to the first rather than a full gap away: the two
+  // are one choice, and the sentence is what they are both about.
+  .notificationAction + .notificationAction,
+  .notificationAction + .notificationClose {
+    margin-left: -6px;
+  }
+
   // Reads as the message's own verb, so it takes the message's own colour.
   .notificationAction {
     flex: 0 0 auto;
-    align-self: center;
-    margin: -4px 0;
-    padding: 4px 8px;
+    display: flex;
+    align-items: center;
+    // The same height as the close button beside it, so a row of one button and
+    // a row of two sit at the same height and their hover fills line up.
+    height: 24px;
+    padding: 0 8px;
     border: none;
     border-radius: 4px;
     background: transparent;
@@ -104,7 +118,6 @@ $accent: 5px;
     justify-content: center;
     width: 24px;
     height: 24px;
-    margin: -2px 0 0;
     padding: 0;
     border: none;
     border-radius: 4px;

--- a/src/app/component/notification/notification.component.scss
+++ b/src/app/component/notification/notification.component.scss
@@ -2,8 +2,11 @@
 @use '@angular/material' as mat;
 @use 'src/app/component/left-tabs/left-tabs.vars.scss' as vars;
 
+/** Width of the accent, and therefore the corner radius. See below. */
+$accent: 5px;
+
 @mixin css($theme) {
-  // Which colour each kind is written in. Only the icon and the edge are
+  // Which colour each kind is written in. Only the accent and the glyph are
   // coloured -- the sentence stays the app's text colour, because a red
   // sentence is harder to read and the glyph has already said which of the
   // four this is.
@@ -14,53 +17,40 @@
     'failure': #c62828,
   );
 
-  // The snackbar renders in an overlay, outside the component tree, so these
-  // rules are global by necessity -- the same reason every other component's
-  // styles in this app are pulled into `mytheme.scss` rather than scoped.
-  .pmksNotification {
-    // Below the top strip rather than over it. It used to be pushed down by a
-    // bare 50px, which was neither the strip's height nor a gap from anything.
-    margin-top: vars.$top-strip-bottom + vars.$card-inset !important;
+  // Below the top strip rather than over it, and out of the way of the pointer:
+  // the canvas underneath is still being worked on while a message sits here.
+  .notificationStack {
+    position: fixed;
+    top: vars.$top-strip-bottom + vars.$card-inset;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: max-content;
+    max-width: min(640px, 90vw);
+    pointer-events: none;
+  }
 
-    // Material's own surface is the wrong shape for this app: a dark slab with
-    // white text. The card underneath is what everything else that floats over
-    // the grid looks like.
-    //
-    // Set through Material's own custom properties rather than by out-shouting
-    // its rules. Its surface selector has the same specificity as anything
-    // written here, so which one wins comes down to the order the two
-    // stylesheets happen to be concatenated in -- which is not something to
-    // rest a colour on.
-    --mat-snack-bar-container-color: var(--card-surface);
-    --mat-snack-bar-supporting-text-color: #2c2c2c;
+  .notification {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 11px 8px 11px 13px;
+    background: var(--card-surface);
+    color: #2c2c2c;
+    box-shadow: var(--card-shadow);
+    pointer-events: auto;
 
-    // Both spellings: the class was renamed between Material versions and the
-    // element carries the old one as well as the new.
-    .mat-mdc-snackbar-surface,
-    .mdc-snackbar__surface {
-      min-width: 0;
-      max-width: min(640px, 90vw);
-      padding: 0;
-      border-radius: var(--card-radius);
-      box-shadow: var(--card-shadow);
-    }
-
-    .mat-mdc-snack-bar-label,
-    .mdc-snackbar__label {
-      padding: 0;
-    }
-
-    app-notification {
-      display: flex;
-      align-items: flex-start;
-      gap: 10px;
-      // The colour bar is the whole left edge, so the padding starts after it.
-      padding: 12px 8px 12px 14px;
-      border-left: 4px solid transparent;
-      border-radius: var(--card-radius);
-      // A message can run to two or three lines; the icon stays on the first.
-      color: #2c2c2c;
-    }
+    // The same trick the help panel uses for its top bar: a border's *inner*
+    // edge is rounded by the radius minus the border width, so a radius equal
+    // to the bar leaves that edge straight while the card's own corners stay
+    // round. At the floating chrome's 10px against a 4px bar the accent curved
+    // away from the card on both ends and read as a separate rounded pill
+    // sitting behind it.
+    border-left: $accent solid transparent;
+    border-radius: $accent;
   }
 
   .notificationIcon {
@@ -83,6 +73,26 @@
     font-size: 14px;
     line-height: 20px;
     letter-spacing: 0.15px;
+  }
+
+  // Reads as the message's own verb, so it takes the message's own colour.
+  .notificationAction {
+    flex: 0 0 auto;
+    align-self: center;
+    margin: -4px 0;
+    padding: 4px 8px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.06);
+    }
   }
 
   // Small and grey: it is the way out of a message, not part of what the
@@ -116,12 +126,13 @@
   }
 
   @each $kind, $color in $kinds {
-    .pmksNotification--#{$kind} app-notification {
+    .notification--#{$kind} {
       border-left-color: $color;
-    }
 
-    .pmksNotification--#{$kind} .notificationIcon {
-      color: $color;
+      .notificationIcon,
+      .notificationAction {
+        color: $color;
+      }
     }
   }
 }

--- a/src/app/component/notification/notification.component.ts
+++ b/src/app/component/notification/notification.component.ts
@@ -1,6 +1,10 @@
-import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
-import { MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
-import { NotificationData, NotificationKind } from '../../services/notification.service';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { animate, style, transition, trigger } from '@angular/animations';
+import {
+  LiveNotification,
+  NotificationKind,
+  NotificationService,
+} from '../../services/notification.service';
 
 /**
  * The glyph that says which of the four this is before the sentence is read.
@@ -16,23 +20,50 @@ const ICONS: Record<NotificationKind, string> = {
 };
 
 /**
- * The body of a notification.
+ * What the app is saying right now, stacked newest last.
  *
- * Every message used to be the same white bar for the same four seconds, so
- * "Message sent. Thank you for your feedback!" and "A cylinder cannot fold
- * onto itself" were the same object until you had read them both.
+ * Every message used to be the same white bar for the same four seconds, one
+ * at a time — so "Message sent. Thank you for your feedback!" and "A cylinder
+ * cannot fold onto itself" were the same object until you had read them both,
+ * and a refusal arriving took away a warning nobody had read yet.
  */
 @Component({
-  selector: 'app-notification',
+  selector: 'app-notification-stack',
+  animations: [
+    // In from above, out by collapsing so the ones below close the gap rather
+    // than jumping up into it.
+    trigger('card', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'translateY(-8px)' }),
+        animate('160ms cubic-bezier(0.4, 0, 0.2, 1)', style({ opacity: 1, transform: 'none' })),
+      ]),
+      transition(':leave', [
+        animate(
+          '140ms cubic-bezier(0.4, 0, 0.2, 1)',
+          style({ opacity: 0, transform: 'translateY(-6px)' })
+        ),
+      ]),
+    ]),
+  ],
   templateUrl: './notification.component.html',
   styleUrls: ['./notification.component.scss'],
   changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 export class NotificationComponent {
-  constructor(@Inject(MAT_SNACK_BAR_DATA) public data: NotificationData) {}
+  constructor(public notifications: NotificationService) {}
 
-  get icon(): string {
-    return ICONS[this.data.kind];
+  iconFor(one: LiveNotification): string {
+    return ICONS[one.kind];
+  }
+
+  /**
+   * How a screen reader is told.
+   *
+   * A failure interrupts; the rest wait for a pause. Both are announced, which
+   * is the point of the region existing at all.
+   */
+  politenessFor(one: LiveNotification): string {
+    return one.kind === 'failure' ? 'assertive' : 'polite';
   }
 }

--- a/src/app/component/notification/notification.component.ts
+++ b/src/app/component/notification/notification.component.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+import { NotificationData, NotificationKind } from '../../services/notification.service';
+
+/**
+ * The glyph that says which of the four this is before the sentence is read.
+ *
+ * `block` rather than an exclamation for a refusal: the app is declining, not
+ * reporting damage, and the reader has done nothing wrong by asking.
+ */
+const ICONS: Record<NotificationKind, string> = {
+  success: 'check_circle',
+  refusal: 'block',
+  warning: 'warning',
+  failure: 'error',
+};
+
+/**
+ * The body of a notification.
+ *
+ * Every message used to be the same white bar for the same four seconds, so
+ * "Message sent. Thank you for your feedback!" and "A cylinder cannot fold
+ * onto itself" were the same object until you had read them both.
+ */
+@Component({
+  selector: 'app-notification',
+  templateUrl: './notification.component.html',
+  styleUrls: ['./notification.component.scss'],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  standalone: false,
+})
+export class NotificationComponent {
+  constructor(@Inject(MAT_SNACK_BAR_DATA) public data: NotificationData) {}
+
+  get icon(): string {
+    return ICONS[this.data.kind];
+  }
+}

--- a/src/app/component/right-panel/right-panel.component.ts
+++ b/src/app/component/right-panel/right-panel.component.ts
@@ -30,6 +30,7 @@ import { Coord } from '../../model/coord';
 import { SvgGridService } from '../../services/svg-grid.service';
 import introJs from 'intro.js';
 import { UrlGenerationService } from 'src/app/services/url-generation.service';
+import { NotificationService } from '../../services/notification.service';
 
 @Component({
   selector: 'app-right-panel',
@@ -116,7 +117,8 @@ export class RightPanelComponent implements DoCheck {
     public settingsService: SettingsService,
     public svgService: SvgGridService,
     public urlGenerationService: UrlGenerationService,
-    private fb: FormBuilder
+    private fb: FormBuilder,
+    private notify: NotificationService
   ) {}
 
   /**
@@ -369,7 +371,6 @@ export class RightPanelComponent implements DoCheck {
 
   sendNotReady() {
     introJs().start();
-    // NewGridComponent.sendNotification('Sorry, the tutorial is not ready yet.');
     // this.analytics.logEvent('tutorial_not_ready');
   }
 
@@ -417,7 +418,7 @@ export class RightPanelComponent implements DoCheck {
   async sendCommentEmail() {
     this.sendingEmail = true;
     if (this.commentForm.invalid) {
-      NewGridComponent.sendNotification('Please fill out the form correctly.');
+      this.notify.refusal('feedback.incomplete', 'Fill in the form before sending it.');
       this.sendingEmail = false;
       return;
     } else {
@@ -429,7 +430,8 @@ export class RightPanelComponent implements DoCheck {
         emailJSKey = res.apiKey;
       } catch (err) {
         console.log(err);
-        NewGridComponent.sendNotification(
+        this.notify.failure(
+          'feedback.no-key',
           'It looks like you are in a development environment. If this is not the case, please try again later or contact us directly at: gr-pmksplus@wpi.edu'
         );
         this.sendingEmail = false;
@@ -473,13 +475,14 @@ export class RightPanelComponent implements DoCheck {
       emailjs
         .send('service_pg2k647', 'template_kfwdx5c', params)
         .then(() => {
-          NewGridComponent.sendNotification('Message sent. Thank you for your feedback!');
+          this.notify.success('feedback.sent', 'Message sent. Thank you for your feedback!');
           this.sendingEmail = false;
           this.commentForm.reset();
         })
         .catch((error: any) => {
           console.log(error);
-          NewGridComponent.sendNotification(
+          this.notify.failure(
+            'feedback.send-failed',
             'Message failed to send. Please try again later or contact us directly at: gr-pmksplus@wpi.edu'
           );
           this.sendingEmail = false;

--- a/src/app/component/synthesis-panel/synthesis-panel.component.ts
+++ b/src/app/component/synthesis-panel/synthesis-panel.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
-import { NewGridComponent } from '../new-grid/new-grid.component';
 import { Pose } from '../../model/pose';
 import { Coord } from '../../model/coord';
 import { Joint, RealJoint, RevJoint } from '../../model/joint';
@@ -200,39 +199,6 @@ export class SynthesisPanelComponent implements OnInit {
     position3Match: [''],
   });
 
-  handleButton() {
-    //Send notification to grid for now
-    NewGridComponent.sendNotification(
-      'Call your backend function with these values! A0: (' +
-        this.synthesisForm.value.a0x! +
-        ',' +
-        this.synthesisForm.value.a0y! +
-        ') B0: (' +
-        this.synthesisForm.value.b0x! +
-        ',' +
-        this.synthesisForm.value.b0y! +
-        ') A1: (' +
-        this.synthesisForm.value.a1x! +
-        ',' +
-        this.synthesisForm.value.a1y! +
-        ') B1: (' +
-        this.synthesisForm.value.b1x! +
-        ',' +
-        this.synthesisForm.value.b1y! +
-        ') A2: (' +
-        this.synthesisForm.value.a2x! +
-        ',' +
-        this.synthesisForm.value.a2y! +
-        ') B2: (' +
-        this.synthesisForm.value.b2x! +
-        ',' +
-        this.synthesisForm.value.b2y! +
-        ')'
-    );
-    //If you need the values as a number instead of a string, use this:
-    console.log(Number(this.synthesisForm.value.a0x!));
-  }
-
   // for html to get current pose as a number
   getCurrentPose(): number {
     return this.synthesisBuilder.selectedPose;
@@ -307,8 +273,6 @@ export class SynthesisPanelComponent implements OnInit {
     let pose3_coord2 = this.synthesisBuilder.poses[3].posFront;
 
     let qualityfromUser = Number(this.synthesisForm.value.quality);
-
-    //   NewGridComponent.sendNotification(qualityfromUser + ';');
 
     //find first itnersection point
 
@@ -389,17 +353,10 @@ export class SynthesisPanelComponent implements OnInit {
 
     //  let trialCoord = new Coord(this.mechanismSrv.mechanisms[0].joints[0][0].x, this.mechanismSrv.mechanisms[0].joints[0][0].y);
 
-    // NewGridComponent.sendNotification(firstPoint.x + ',' + firstPoint.y + ',' + fourthPoint.x + ',' + fourthPoint.y);
-
-    //  NewGridComponent.sendNotification(trialCoord.x+','+trialCoord.y);
-
-    //  NewGridComponent.sendNotification(quality[0]+';');
-
     //now check if there is 999 in the quality. Count 999 and say which position matches
 
     let whichPositionMatches = this.checkQuality(quality);
 
-    // NewGridComponent.sendNotification(
     //   'Position Matches:' +
     //     whichPositionMatches[0] +
     //     ',' +
@@ -468,10 +425,6 @@ export class SynthesisPanelComponent implements OnInit {
           Math.pow(jointValues[val][1].y - posCoords[4].y, 2)
       );
 
-      //  NewGridComponent.sendNotification('JointCoord;' + jointValues[val][1].x + ';');
-      //  NewGridComponent.sendNotification('PosCoord;' + posCoords[0].x + ';');
-      //   NewGridComponent.sendNotification('val:' + val);
-
       let pos1Value_c = Math.sqrt(
         Math.pow(jointValues[val][2].x - posCoords[1].x, 2) +
           Math.pow(jointValues[val][2].y - posCoords[1].y, 2)
@@ -523,8 +476,6 @@ export class SynthesisPanelComponent implements OnInit {
           let jointC_x = (jointValues[val][2].x + jointValues[index - 2][2].x) / 2;
           let jointC_y = (jointValues[val][2].y + jointValues[index - 2][2].y) / 2;
 
-          //    NewGridComponent.sendNotification("Midpoint;" + val+';'+index);
-
           let pos1Value_b = Math.sqrt(
             Math.pow(jointB_x - posCoords[0].x, 2) + Math.pow(jointB_y - posCoords[0].y, 2)
           );
@@ -534,10 +485,6 @@ export class SynthesisPanelComponent implements OnInit {
           let pos3Value_b = Math.sqrt(
             Math.pow(jointB_x - posCoords[4].x, 2) + Math.pow(jointB_y - posCoords[4].y, 2)
           );
-
-          //  NewGridComponent.sendNotification('JointCoord;' + jointValues[val][1].x + ';');
-          //  NewGridComponent.sendNotification('PosCoord;' + posCoords[0].x + ';');
-          //   NewGridComponent.sendNotification('val:' + val);
 
           let pos1Value_c = Math.sqrt(
             Math.pow(jointC_x - posCoords[1].x, 2) + Math.pow(jointC_y - posCoords[1].y, 2)
@@ -566,10 +513,7 @@ export class SynthesisPanelComponent implements OnInit {
       }
 
       index = index + 1;
-
-      //  NewGridComponent.sendNotification('index:' + index);
     }
-    //    NewGridComponent.sendNotification('quality3c:' + quality3_c);
 
     //now compile quality array and then pass it back
 
@@ -586,8 +530,6 @@ export class SynthesisPanelComponent implements OnInit {
       quality3_c,
       pos3TimeStep,
     ];
-
-    // NewGridComponent.sendNotification(";" + qualityCompilation);
 
     return qualityCompilation;
   }

--- a/src/app/component/top-bar/top-bar.component.ts
+++ b/src/app/component/top-bar/top-bar.component.ts
@@ -19,10 +19,10 @@ import { SaveHistoryService } from '../../services/save-history.service';
 import { AnalyticsService } from '../../services/analytics.service';
 import { UrlGenerationService } from '../../services/url-generation.service';
 import { UrlProcessorService } from '../../services/url-processor.service';
-import { NewGridComponent } from '../new-grid/new-grid.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
 import { TemplatesComponent } from '../MODALS/templates/templates.component';
 import { AnalysisExportService } from '../../services/analysis-export.service';
+import { NotificationService } from '../../services/notification.service';
 
 /** A mode's chip: whether that analysis can be entered, and what is missing. */
 interface TabStatus {
@@ -120,7 +120,8 @@ export class TopBarComponent implements AfterViewInit, AfterViewChecked, OnDestr
     private dialog: MatDialog,
     private zone: NgZone,
     private changes: ChangeDetectorRef,
-    private exports: AnalysisExportService
+    private exports: AnalysisExportService,
+    private notify: NotificationService
   ) {}
 
   isDevMode(): boolean {
@@ -423,13 +424,15 @@ export class TopBarComponent implements AfterViewInit, AfterViewChecked, OnDestr
     this.analytics.logEvent('upload_file');
     this.closeMenu();
     const input = $event.target as HTMLInputElement;
+    // Silently. This fires when the picker is dismissed, and cancelling a
+    // dialogue is not a thing that went wrong -- the reader closed it knowing
+    // full well that they had chosen nothing.
     if (!input.files || input.files.length !== 1) {
-      NewGridComponent.sendNotification('No file selected');
       return;
     }
     const reader = new FileReader();
     reader.onload = () => {
-      NewGridComponent.sendNotification('Loaded Mechanism from File');
+      this.notify.success('file.loaded', 'Mechanism loaded.');
       this.urlProcessor.updateFromURL(reader.result as string);
       // Reset the input so the same file can be opened again.
       input.value = '';
@@ -465,8 +468,6 @@ export class TopBarComponent implements AfterViewInit, AfterViewChecked, OnDestr
     scratch.select();
     document.execCommand('copy');
     document.body.removeChild(scratch);
-    NewGridComponent.sendNotification(
-      'Mechanism URL copied. If you make additional changes, copy the URL again.'
-    );
+    this.notify.success('share.copied', 'Link copied. Copy again after your next change.');
   }
 }

--- a/src/app/model/mechanism/drive-profile.spec.ts
+++ b/src/app/model/mechanism/drive-profile.spec.ts
@@ -12,6 +12,7 @@ import { SynthesisBuilderService } from '../../services/synthesis/synthesis-buil
 import { MechanismBuilder } from '../../services/transcoding/mechanism-builder';
 import { StringTranscoder } from '../../services/transcoding/string-transcoder';
 import { TemplateID, TEMPLATE_LINKAGES } from '../../component/MODALS/templates/template-linkages';
+import { silentNotifications } from '../../../test-utils/notification-stub';
 
 /** The solved first mechanism of a template, and what its input does. */
 function profileOf(template: TemplateID): DriveProfile {
@@ -21,7 +22,12 @@ function profileOf(template: TemplateID): DriveProfile {
   let service!: MechanismService;
   const grid = new GridUtilsService(
     new SynthesisBuilderService(parser, settings),
-    new SvgGridService(settings, new DragStateService(), {} as unknown as Injector),
+    new SvgGridService(
+      settings,
+      new DragStateService(),
+      {} as unknown as Injector,
+      silentNotifications()
+    ),
     { get: () => service } as unknown as Injector
   );
   const active = new ActiveObjService();
@@ -30,7 +36,8 @@ function profileOf(template: TemplateID): DriveProfile {
     active,
     { get: () => ({ save: () => undefined }) } as unknown as Injector,
     settings,
-    parser
+    parser,
+    silentNotifications()
   );
 
   const decoder = new StringTranscoder();

--- a/src/app/services/grid-utils.service.spec.ts
+++ b/src/app/services/grid-utils.service.spec.ts
@@ -13,6 +13,7 @@ import { SettingsService } from './settings.service';
 import { SvgGridService } from './svg-grid.service';
 import { DragStateService } from './drag-state.service';
 import { SynthesisBuilderService } from './synthesis/synthesis-builder.service';
+import { silentNotifications } from '../../test-utils/notification-stub';
 
 function createHarness() {
   if (!ColorService.instance) new ColorService();
@@ -23,13 +24,18 @@ function createHarness() {
   let service!: MechanismService;
   const grid = new GridUtilsService(
     new SynthesisBuilderService(parser, settings),
-    new SvgGridService(settings, new DragStateService(), {} as unknown as Injector),
+    new SvgGridService(
+      settings,
+      new DragStateService(),
+      {} as unknown as Injector,
+      silentNotifications()
+    ),
     { get: () => service } as unknown as Injector
   );
   const active = new ActiveObjService();
   let saves = 0;
   const injector = { get: () => ({ save: () => saves++ }) } as unknown as Injector;
-  service = new MechanismService(grid, active, injector, settings, parser);
+  service = new MechanismService(grid, active, injector, settings, parser, silentNotifications());
   return { service, grid, active, settings, saveCount: () => saves };
 }
 

--- a/src/app/services/mechanism.service.spec.ts
+++ b/src/app/services/mechanism.service.spec.ts
@@ -18,6 +18,8 @@ import { MechanismBuilder } from './transcoding/mechanism-builder';
 import { StringTranscoder } from './transcoding/string-transcoder';
 import { SynthesisBuilderService } from './synthesis/synthesis-builder.service';
 import { NewGridComponent } from '../component/new-grid/new-grid.component';
+import { NotificationService } from './notification.service';
+import { silentNotifications } from '../../test-utils/notification-stub';
 
 interface Harness {
   service: MechanismService;
@@ -31,7 +33,12 @@ function createHarness(): Harness {
   if (!ColorService.instance) new ColorService();
   const settings = new SettingsService();
   const parser = new NumberUnitParserService();
-  const svg = new SvgGridService(settings, new DragStateService(), {} as unknown as Injector);
+  const svg = new SvgGridService(
+    settings,
+    new DragStateService(),
+    {} as unknown as Injector,
+    silentNotifications()
+  );
   const synthesis = new SynthesisBuilderService(parser, settings);
   // GridUtilsService resolves MechanismService at call time, so it has to be
   // handed an injector that reads the binding below rather than a finished one.
@@ -42,7 +49,7 @@ function createHarness(): Harness {
   const active = new ActiveObjService();
   let saves = 0;
   const injector = { get: () => ({ save: () => saves++ }) } as unknown as Injector;
-  service = new MechanismService(grid, active, injector, settings, parser);
+  service = new MechanismService(grid, active, injector, settings, parser, silentNotifications());
   return { service, active, settings, grid, saveCount: () => saves };
 }
 
@@ -603,12 +610,13 @@ describe('MechanismService declining a weld that pins a pair twice', () => {
 
   it('names the pair it just pinned twice', () => {
     const scene = triangle();
-    const notify = vi.spyOn(NewGridComponent, 'sendNotification').mockImplementation(() => {});
+    const notify = vi.spyOn(NotificationService.prototype, 'warning').mockImplementation(() => {});
 
     scene.service.weldJoint(scene.b);
 
     expect(notify).toHaveBeenCalledTimes(1);
-    expect(notify.mock.calls[0][0]).toMatch(/\bA and C\b/);
+    // The id is first now, the sentence second.
+    expect(notify.mock.calls[0][1]).toMatch(/\bA and C\b/);
     notify.mockRestore();
   });
 
@@ -636,7 +644,7 @@ describe('MechanismService declining a weld that pins a pair twice', () => {
       wire('XY', [x, y]),
       wire('YZ', [y, z]),
     ];
-    const notify = vi.spyOn(NewGridComponent, 'sendNotification').mockImplementation(() => {});
+    const notify = vi.spyOn(NotificationService.prototype, 'warning').mockImplementation(() => {});
 
     harness.service.weldJoint(y);
 

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -2392,7 +2392,12 @@ export class MechanismService {
     if (!jointToToggleInput.input) {
       const refusal = describeActuator(jointToToggleInput);
       if (typeof refusal === 'string') {
-        this.notify.refusal('input.cannot-drive', refusal);
+        // Silently: this is unreachable from either surface. Both the menu item
+        // and the panel's button are disabled on `canToggleInput`, which is
+        // `input || canDrive` -- and `canDrive` is exactly "describeActuator
+        // did not refuse", asked of this same joint. Checked across all 25
+        // templates: 147 presses of every enabled control, no refusal. Kept as
+        // a guard so a third caller cannot drive what the model will not.
         return;
       }
       // One input per mechanism, so the joint taking the job displaces the old

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -1247,7 +1247,12 @@ export class MechanismService {
     this.slotStashes.clear();
   }
 
-  deleteJoint() {
+  /**
+   * @param save mints the undo entry. Only a caller that deletes several joints
+   * as one gesture passes `false`, and it owes a `finishStructuralEdit(true)`
+   * of its own once the last one is gone — see `deleteMechanism`.
+   */
+  deleteJoint(save: boolean = true) {
     // Deleting a mount (or, defensively, any member joint) of a sealed cylinder
     // takes the whole assembly with it (§ cylinder 5) — and then goes on to
     // delete the joint itself.
@@ -1266,7 +1271,7 @@ export class MechanismService {
       // removed as orphaned, and there is nothing left to delete.
       if (!this.joints.some((joint) => joint.id === doomed.id)) {
         this.activeObjService.updateSelectedObj(undefined);
-        this.finishStructuralEdit(true);
+        this.finishStructuralEdit(save);
         return;
       }
     }
@@ -1650,7 +1655,12 @@ export class MechanismService {
     // Through the shared path, so a slot whose defining joint was just deleted
     // gets reconciled. Deleting a joint by itself is the one way to strand a
     // slot that does not go through mergeJoints or deleteLink.
-    this.finishStructuralEdit(false);
+    //
+    // Saving here is what makes the deletion undoable. This read `false` for as
+    // long as the tail read `updateMechanism()`, whose save flag defaults off —
+    // so a joint deleted on its own left no history at all, while the very same
+    // deletion routed through the cylinder branch above did.
+    this.finishStructuralEdit(save);
     setTimeout(() => {
       this.onMechUpdateState.next(3);
     });

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -55,6 +55,7 @@ import { GridUtilsService } from './grid-utils.service';
 import { ActiveObjService } from './active-obj.service';
 import { NewGridComponent } from '../component/new-grid/new-grid.component';
 import { canDrive, describeActuator } from '../model/actuator';
+import { NotificationService } from './notification.service';
 import { SettingsService } from './settings.service';
 import { slotHalfLength } from '../model/joint-marks';
 import { DragStateService } from './drag-state.service';
@@ -180,7 +181,8 @@ export class MechanismService {
     public activeObjService: ActiveObjService,
     private injector: Injector,
     private settingsService: SettingsService,
-    private nup: NumberUnitParserService
+    private nup: NumberUnitParserService,
+    private notify: NotificationService
   ) {}
 
   /**
@@ -2155,7 +2157,8 @@ export class MechanismService {
     // the item out; this is the same rule where the edit actually happens, so
     // no other caller can get round it.
     if (mountAt?.isWelded) {
-      NewGridComponent.sendNotification(
+      this.notify.refusal(
+        'cylinder.welded-mount',
         'This joint is welded, so a cylinder mounted on it would be a third body inside one rigid one. Unweld it, or attach the cylinder to the link instead.'
       );
       return;
@@ -2379,7 +2382,7 @@ export class MechanismService {
     if (!jointToToggleInput.input) {
       const refusal = describeActuator(jointToToggleInput);
       if (typeof refusal === 'string') {
-        NewGridComponent.sendNotification(refusal);
+        this.notify.refusal('input.cannot-drive', refusal);
         return;
       }
       // One input per mechanism, so the joint taking the job displaces the old
@@ -2578,7 +2581,8 @@ export class MechanismService {
     // the cylinder (§ cylinder 4). The panel and menu grey the control on the
     // mounts; this is the rule they are both fronting.
     if (this.cylinderAt(this.activeObjService.selectedJoint)) {
-      NewGridComponent.sendNotification(
+      this.notify.refusal(
+        'cylinder.sealed-slider',
         'A cylinder is one sealed part — delete the cylinder instead of editing its slider.'
       );
       return;
@@ -3687,7 +3691,8 @@ export class MechanismService {
 
     if (!this.weldTopology(joint)) return;
     if (created) {
-      NewGridComponent.sendNotification(
+      this.notify.warning(
+        'weld.pinned-twice',
         `${created[0]} and ${created[1]} are now pinned together twice. The linkage still ` +
           'moves, but its forces have no unique solution.'
       );

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -1,6 +1,4 @@
 import { Injectable } from '@angular/core';
-import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
-import { NotificationComponent } from '../component/notification/notification.component';
 
 /**
  * How much the reader is meant to care.
@@ -14,11 +12,32 @@ import { NotificationComponent } from '../component/notification/notification.co
  */
 export type NotificationKind = 'success' | 'refusal' | 'warning' | 'failure';
 
-/** What the snackbar body is handed. */
-export interface NotificationData {
+/**
+ * The thing to do about it, when there is one obvious thing.
+ *
+ * A message that says "set the object scale in Settings" is asking the reader
+ * to go and find a control in order to carry out an instruction the app could
+ * simply follow. Where the fix is unambiguous, it goes on the message.
+ */
+export interface NotificationAction {
+  label: string;
+  run: () => void;
+}
+
+export interface NotificationOptions {
+  /** How long this message stays quiet after saying itself, in ms. */
+  cooldownMs?: number;
+  action?: NotificationAction;
+}
+
+/** One message, while it is on screen. */
+export interface LiveNotification {
+  /** Distinct per appearance, so a message said twice animates twice. */
+  key: number;
+  id: string;
   kind: NotificationKind;
   text: string;
-  dismiss: () => void;
+  action?: NotificationAction;
 }
 
 /** How long each kind stays, in ms. `undefined` means until it is dismissed. */
@@ -35,6 +54,16 @@ const DURATION: Record<NotificationKind, number | undefined> = {
 const DEFAULT_COOLDOWN = 800;
 
 /**
+ * How many may be on screen at once.
+ *
+ * More than three is a wall of text over the drawing, and the fourth is worth
+ * less than the view it covers. The oldest that was going to leave by itself
+ * makes room; one waiting to be dismissed is not pushed out from under the
+ * reader.
+ */
+const MAX_STACK = 3;
+
+/**
  * Everything the app says out loud, said in one place.
  *
  * Replaces `NewGridComponent.sendNotification`, which had two faults that were
@@ -47,67 +76,95 @@ const DEFAULT_COOLDOWN = 800;
  * a session, which is when zooming happens.
  *
  * The cooldown here is per message id, and starts unarmed.
+ *
+ * This keeps its own stack rather than driving `MatSnackBar`, which shows one
+ * message at a time and takes the previous one away to do it — so a refusal
+ * could silently swallow a warning the reader had not read yet.
  */
 @Injectable({ providedIn: 'root' })
 export class NotificationService {
-  private lastSaid = new Map<string, number>();
-  private showing?: { id: string; ref: MatSnackBarRef<NotificationComponent> };
+  /** What is on screen, oldest first. Read by the stack component. */
+  readonly live: LiveNotification[] = [];
 
-  constructor(private snackBar: MatSnackBar) {}
+  private lastSaid = new Map<string, number>();
+  private timers = new Map<number, ReturnType<typeof setTimeout>>();
+  private nextKey = 1;
 
   /** Something the reader asked for, happened. */
-  success(id: string, text: string, cooldownMs?: number): void {
-    this.say('success', id, text, cooldownMs);
+  success(id: string, text: string, options?: NotificationOptions): void {
+    this.say('success', id, text, options);
   }
 
   /** Something the reader asked for, did not happen, and why. */
-  refusal(id: string, text: string, cooldownMs?: number): void {
-    this.say('refusal', id, text, cooldownMs);
+  refusal(id: string, text: string, options?: NotificationOptions): void {
+    this.say('refusal', id, text, options);
   }
 
   /** It happened, but the drawing is now in a state worth knowing about. */
-  warning(id: string, text: string, cooldownMs?: number): void {
-    this.say('warning', id, text, cooldownMs);
+  warning(id: string, text: string, options?: NotificationOptions): void {
+    this.say('warning', id, text, options);
   }
 
   /** Something outside the reader's control went wrong. */
-  failure(id: string, text: string, cooldownMs?: number): void {
-    this.say('failure', id, text, cooldownMs);
+  failure(id: string, text: string, options?: NotificationOptions): void {
+    this.say('failure', id, text, options);
   }
 
-  /** Take down whatever is showing. */
-  dismiss(): void {
-    this.showing?.ref.dismiss();
-    this.showing = undefined;
+  dismiss(key: number): void {
+    const at = this.live.findIndex((one) => one.key === key);
+    if (at === -1) return;
+    this.live.splice(at, 1);
+    const timer = this.timers.get(key);
+    if (timer !== undefined) clearTimeout(timer);
+    this.timers.delete(key);
+  }
+
+  dismissAll(): void {
+    [...this.live].forEach((one) => this.dismiss(one.key));
+  }
+
+  /** Do what the message offers, and take the message away. */
+  act(one: LiveNotification): void {
+    one.action?.run();
+    this.dismiss(one.key);
   }
 
   private say(
     kind: NotificationKind,
     id: string,
     text: string,
-    cooldownMs = DEFAULT_COOLDOWN
+    { cooldownMs = DEFAULT_COOLDOWN, action }: NotificationOptions = {}
   ): void {
-    // Already on screen. Reopening would restart the animation and read as a
-    // second, identical event -- which is exactly what a reader holding a key
-    // down or dragging against a rule would see.
-    if (this.showing?.id === id) return;
+    // Already on screen. Saying it again would stack the same sentence twice --
+    // which is exactly what a reader holding a key down or dragging against a
+    // rule would produce.
+    if (this.live.some((one) => one.id === id)) return;
 
     const last = this.lastSaid.get(id);
     if (last !== undefined && last + cooldownMs > Date.now()) return;
     this.lastSaid.set(id, Date.now());
 
-    const ref = this.snackBar.openFromComponent(NotificationComponent, {
-      data: { kind, text, dismiss: () => ref.dismiss() } as NotificationData,
-      panelClass: ['pmksNotification', `pmksNotification--${kind}`],
-      horizontalPosition: 'center',
-      verticalPosition: 'top',
-      duration: DURATION[kind],
-      politeness: kind === 'failure' ? 'assertive' : 'polite',
-    });
+    const one: LiveNotification = { key: this.nextKey++, id, kind, text, action };
+    this.live.push(one);
+    this.makeRoom();
 
-    this.showing = { id, ref };
-    ref.afterDismissed().subscribe(() => {
-      if (this.showing?.ref === ref) this.showing = undefined;
-    });
+    const duration = DURATION[kind];
+    if (duration !== undefined) {
+      this.timers.set(
+        one.key,
+        setTimeout(() => this.dismiss(one.key), duration)
+      );
+    }
+  }
+
+  /** Drop the oldest message that was leaving anyway, until the stack fits. */
+  private makeRoom(): void {
+    while (this.live.length > MAX_STACK) {
+      const leaving = this.live.find((one) => DURATION[one.kind] !== undefined);
+      // Nothing but messages waiting to be dismissed. The newest is the one the
+      // reader has a chance of connecting to what they just did, so the oldest
+      // still goes -- but it has at least been on screen the longest.
+      this.dismiss((leaving ?? this.live[0]).key);
+    }
   }
 }

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBar, MatSnackBarRef } from '@angular/material/snack-bar';
+import { NotificationComponent } from '../component/notification/notification.component';
+
+/**
+ * How much the reader is meant to care.
+ *
+ * The distinction that matters is not severity but *who acted*. A refusal is
+ * the app declining something the reader just tried: they are already looking
+ * at the place it happened, they know what they asked for, and the message is
+ * over as soon as it is read. A warning is the opposite — it reports a state
+ * the drawing is now in, which nobody asked for and which is still true after
+ * the message goes away. That is the one that has to wait to be dismissed.
+ */
+export type NotificationKind = 'success' | 'refusal' | 'warning' | 'failure';
+
+/** What the snackbar body is handed. */
+export interface NotificationData {
+  kind: NotificationKind;
+  text: string;
+  dismiss: () => void;
+}
+
+/** How long each kind stays, in ms. `undefined` means until it is dismissed. */
+const DURATION: Record<NotificationKind, number | undefined> = {
+  // Confirmation of something the reader already watched happen. It is there to
+  // be caught out of the corner of an eye, not read.
+  success: 2500,
+  refusal: 4000,
+  warning: undefined,
+  failure: undefined,
+};
+
+/** How long the same message stays quiet after saying itself, in ms. */
+const DEFAULT_COOLDOWN = 800;
+
+/**
+ * Everything the app says out loud, said in one place.
+ *
+ * Replaces `NewGridComponent.sendNotification`, which had two faults that were
+ * not about wording. It kept a single `lastNotificationTime` for the whole
+ * app, so an unrelated message a moment earlier silenced the next one — two
+ * different refusals in the same second showed only the first. And it
+ * initialised that timestamp to the moment the canvas was constructed, so any
+ * message asking for a long quiet period was muted for that period *from page
+ * load*: the two zoom warnings could not appear in the first twenty seconds of
+ * a session, which is when zooming happens.
+ *
+ * The cooldown here is per message id, and starts unarmed.
+ */
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  private lastSaid = new Map<string, number>();
+  private showing?: { id: string; ref: MatSnackBarRef<NotificationComponent> };
+
+  constructor(private snackBar: MatSnackBar) {}
+
+  /** Something the reader asked for, happened. */
+  success(id: string, text: string, cooldownMs?: number): void {
+    this.say('success', id, text, cooldownMs);
+  }
+
+  /** Something the reader asked for, did not happen, and why. */
+  refusal(id: string, text: string, cooldownMs?: number): void {
+    this.say('refusal', id, text, cooldownMs);
+  }
+
+  /** It happened, but the drawing is now in a state worth knowing about. */
+  warning(id: string, text: string, cooldownMs?: number): void {
+    this.say('warning', id, text, cooldownMs);
+  }
+
+  /** Something outside the reader's control went wrong. */
+  failure(id: string, text: string, cooldownMs?: number): void {
+    this.say('failure', id, text, cooldownMs);
+  }
+
+  /** Take down whatever is showing. */
+  dismiss(): void {
+    this.showing?.ref.dismiss();
+    this.showing = undefined;
+  }
+
+  private say(
+    kind: NotificationKind,
+    id: string,
+    text: string,
+    cooldownMs = DEFAULT_COOLDOWN
+  ): void {
+    // Already on screen. Reopening would restart the animation and read as a
+    // second, identical event -- which is exactly what a reader holding a key
+    // down or dragging against a rule would see.
+    if (this.showing?.id === id) return;
+
+    const last = this.lastSaid.get(id);
+    if (last !== undefined && last + cooldownMs > Date.now()) return;
+    this.lastSaid.set(id, Date.now());
+
+    const ref = this.snackBar.openFromComponent(NotificationComponent, {
+      data: { kind, text, dismiss: () => ref.dismiss() } as NotificationData,
+      panelClass: ['pmksNotification', `pmksNotification--${kind}`],
+      horizontalPosition: 'center',
+      verticalPosition: 'top',
+      duration: DURATION[kind],
+      politeness: kind === 'failure' ? 'assertive' : 'polite',
+    });
+
+    this.showing = { id, ref };
+    ref.afterDismissed().subscribe(() => {
+      if (this.showing?.ref === ref) this.showing = undefined;
+    });
+  }
+}

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -13,11 +13,17 @@ import { Injectable } from '@angular/core';
 export type NotificationKind = 'success' | 'refusal' | 'warning' | 'failure';
 
 /**
- * The thing to do about it, when there is one obvious thing.
+ * Something to do about it, offered on the message itself.
  *
  * A message that says "set the object scale in Settings" is asking the reader
  * to go and find a control in order to carry out an instruction the app could
  * simply follow. Where the fix is unambiguous, it goes on the message.
+ *
+ * More than one is allowed, because "unambiguous" is not the same as "single":
+ * a drawing at the wrong size can be fixed by resizing the drawing or by
+ * moving the view, and which of those somebody wants depends on what they were
+ * doing. Two is the sensible limit — a third is a menu, and a menu on a message
+ * that may take itself away in four seconds is a trap.
  */
 export interface NotificationAction {
   label: string;
@@ -27,7 +33,7 @@ export interface NotificationAction {
 export interface NotificationOptions {
   /** How long this message stays quiet after saying itself, in ms. */
   cooldownMs?: number;
-  action?: NotificationAction;
+  actions?: NotificationAction[];
 }
 
 /** One message, while it is on screen. */
@@ -37,7 +43,7 @@ export interface LiveNotification {
   id: string;
   kind: NotificationKind;
   text: string;
-  action?: NotificationAction;
+  actions: NotificationAction[];
 }
 
 /** How long each kind stays, in ms. `undefined` means until it is dismissed. */
@@ -124,8 +130,8 @@ export class NotificationService {
   }
 
   /** Do what the message offers, and take the message away. */
-  act(one: LiveNotification): void {
-    one.action?.run();
+  act(one: LiveNotification, action: NotificationAction): void {
+    action.run();
     this.dismiss(one.key);
   }
 
@@ -133,7 +139,7 @@ export class NotificationService {
     kind: NotificationKind,
     id: string,
     text: string,
-    { cooldownMs = DEFAULT_COOLDOWN, action }: NotificationOptions = {}
+    { cooldownMs = DEFAULT_COOLDOWN, actions = [] }: NotificationOptions = {}
   ): void {
     // Already on screen. Saying it again would stack the same sentence twice --
     // which is exactly what a reader holding a key down or dragging against a
@@ -144,7 +150,7 @@ export class NotificationService {
     if (last !== undefined && last + cooldownMs > Date.now()) return;
     this.lastSaid.set(id, Date.now());
 
-    const one: LiveNotification = { key: this.nextKey++, id, kind, text, action };
+    const one: LiveNotification = { key: this.nextKey++, id, kind, text, actions };
     this.live.push(one);
     this.makeRoom();
 

--- a/src/app/services/svg-grid.service.ts
+++ b/src/app/services/svg-grid.service.ts
@@ -6,6 +6,7 @@ import { Coord } from '../model/coord';
 import { NewGridComponent } from '../component/new-grid/new-grid.component';
 import { SettingsService } from './settings.service';
 import { DragStateService } from './drag-state.service';
+import { NotificationService } from './notification.service';
 import Hammer from 'hammerjs';
 import { MODEL_SCALE } from '../model/render-scale';
 
@@ -66,7 +67,8 @@ export class SvgGridService {
   constructor(
     private settingsService: SettingsService,
     private dragState: DragStateService,
-    private injector: Injector
+    private injector: Injector,
+    private notify: NotificationService
   ) {}
 
   setNewElement(root: HTMLElement) {
@@ -379,16 +381,24 @@ export class SvgGridService {
     // console.log(this.getZoom());
     this.cellSize = this.cellSizeFor(this.getZoom());
     this.handlePan();
-    if (this.getZoom() * this.settingsService.objectScale < 5) {
-      NewGridComponent.sendNotification(
-        'The visual size of the links might be too small. Try using the "Update Object Scale" button in the settings menu or use the "Reset View" button on the bottom right.',
-        20000
+    // Zooming is continuous, so these have a much longer quiet period than
+    // anything else -- but their own, now. They used to share one timer with
+    // every other message in the app, which meant they were silent for the
+    // first twenty seconds of a session and for twenty seconds after any
+    // unrelated message: the whole of the time somebody is finding their zoom.
+    const drawnAt = this.getZoom() * this.settingsService.objectScale;
+    if (drawnAt < 5) {
+      this.notify.warning(
+        'zoom.links-tiny',
+        'The links are drawn far smaller than the grid. Reset the view, or set the object scale in Settings.',
+        60000
       );
     }
-    if (this.getZoom() * this.settingsService.objectScale > 200) {
-      NewGridComponent.sendNotification(
-        'The visual size of the links might be too large. Try using the "Update Object Scale" button in the settings menu.',
-        20000
+    if (drawnAt > 200) {
+      this.notify.warning(
+        'zoom.links-huge',
+        'The links are drawn far larger than the grid. Reset the view, or set the object scale in Settings.',
+        60000
       );
     }
   }

--- a/src/app/services/svg-grid.service.ts
+++ b/src/app/services/svg-grid.service.ts
@@ -387,18 +387,25 @@ export class SvgGridService {
     // first twenty seconds of a session and for twenty seconds after any
     // unrelated message: the whole of the time somebody is finding their zoom.
     const drawnAt = this.getZoom() * this.settingsService.objectScale;
+    // The fix is one number, and this service is holding it. Sending the reader
+    // to Settings to press a button that does exactly this was asking them to
+    // carry out an instruction the app could simply follow.
+    const fixIt = {
+      label: 'Fit to zoom',
+      run: () => this.updateObjectScale(),
+    };
     if (drawnAt < 5) {
       this.notify.warning(
         'zoom.links-tiny',
-        'The links are drawn far smaller than the grid. Reset the view, or set the object scale in Settings.',
-        60000
+        'The links are drawn far smaller than the grid at this zoom.',
+        { cooldownMs: 60000, action: fixIt }
       );
     }
     if (drawnAt > 200) {
       this.notify.warning(
         'zoom.links-huge',
-        'The links are drawn far larger than the grid. Reset the view, or set the object scale in Settings.',
-        60000
+        'The links are drawn far larger than the grid at this zoom.',
+        { cooldownMs: 60000, action: fixIt }
       );
     }
   }

--- a/src/app/services/svg-grid.service.ts
+++ b/src/app/services/svg-grid.service.ts
@@ -387,25 +387,27 @@ export class SvgGridService {
     // first twenty seconds of a session and for twenty seconds after any
     // unrelated message: the whole of the time somebody is finding their zoom.
     const drawnAt = this.getZoom() * this.settingsService.objectScale;
-    // The fix is one number, and this service is holding it. Sending the reader
-    // to Settings to press a button that does exactly this was asking them to
-    // carry out an instruction the app could simply follow.
-    const fixIt = {
-      label: 'Fit to zoom',
-      run: () => this.updateObjectScale(),
-    };
+    // Both fixes are in this service, and the message used to name neither of
+    // the buttons that hold them without offering either. Which one somebody
+    // wants depends on which they think is wrong: "Fit to zoom" keeps the view
+    // and resizes the drawing to suit it; "Reset view" keeps the drawing and
+    // moves the view back to it.
+    const fixes = [
+      { label: 'Fit to zoom', run: () => this.updateObjectScale() },
+      { label: 'Reset view', run: () => this.scaleToFitLinkage() },
+    ];
     if (drawnAt < 5) {
       this.notify.warning(
         'zoom.links-tiny',
         'The links are drawn far smaller than the grid at this zoom.',
-        { cooldownMs: 60000, action: fixIt }
+        { cooldownMs: 60000, actions: fixes }
       );
     }
     if (drawnAt > 200) {
       this.notify.warning(
         'zoom.links-huge',
         'The links are drawn far larger than the grid at this zoom.',
-        { cooldownMs: 60000, action: fixIt }
+        { cooldownMs: 60000, actions: fixes }
       );
     }
   }

--- a/src/app/services/url-processor.service.ts
+++ b/src/app/services/url-processor.service.ts
@@ -10,7 +10,7 @@ import { SettingsService } from './settings.service';
 import { MechanismBuilder } from './transcoding/mechanism-builder';
 import { SvgGridService } from './svg-grid.service';
 import { ActiveObjService } from './active-obj.service';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { NotificationService } from './notification.service';
 import { SelectedTabService, TabID } from '../selected-tab.service';
 
 @Injectable({
@@ -22,7 +22,7 @@ export class UrlProcessorService {
     private settingsSrv: SettingsService,
     private svgGrid: SvgGridService,
     private activeObj: ActiveObjService,
-    private snackBar: MatSnackBar
+    private notify: NotificationService
   ) {
     // the content part of the url (the part after the ?)
     const url = this.getURLContent();
@@ -114,12 +114,16 @@ export class UrlProcessorService {
         builder.build(updateSettings);
       } catch (error) {
         console.error('Unable to load mechanism URL', error);
+        // Deferred because this can run inside the service's own constructor,
+        // before there is an overlay to open into. A failure, and it waits to
+        // be dismissed: the reader followed a link that did not work, and the
+        // grid they are looking at instead is not an obvious clue that it
+        // didn't.
         setTimeout(() => {
-          this.snackBar.open('Unable to load the shared mechanism URL.', '', {
-            duration: 4000,
-            horizontalPosition: 'center',
-            verticalPosition: 'top',
-          });
+          this.notify.failure(
+            'url.undecodable',
+            'That shared link could not be opened — it may be from an older version of PMKS+.'
+          );
         });
       } finally {
         // Invalid data must not remain in the address bar or be retried on refresh.

--- a/src/app/ui-text.ts
+++ b/src/app/ui-text.ts
@@ -46,6 +46,3 @@ export const NOT_A = {
   force: 'That is not a force. Type a number.',
   name: 'A name has to be letters or numbers, and cannot be one already in use.',
 } as const;
-
-/** Features that exist as a button and nothing else yet. */
-export const NOT_BUILT_YET = 'Not built yet.';

--- a/src/app/ui-text.ts
+++ b/src/app/ui-text.ts
@@ -13,36 +13,23 @@
  */
 
 /**
- * Why an edit cannot happen right now.
- *
- * One situation, one sentence, wherever it is reached from — the same refusal
- * used to have three wordings depending on whether it came from a drag, a
- * context menu or a panel, and one of them called the animation a "simulation".
- *
- * Mode-first where the mode is the reason. Edit and Analyze are becoming more
- * distinctly separate, so a user stopped by one of them should be told which
- * room they are in rather than which button to press.
- */
-export const CANNOT_EDIT = {
-  analyzeMode: 'Switch to Edit mode to change the mechanism.',
-  synthesizeMode: 'Switch to Edit mode to change the mechanism.',
-  animating: 'Cannot edit while the animation is running.',
-  awayFromStart: 'Step back to the start to edit.',
-} as const;
-
-/**
  * What to say when a typed value will not parse.
  *
  * By the *kind* of value, not by the field. There were eleven of these, one per
  * cell of the linkage table, and they differed only in naming a field that is
  * already on screen, highlighted, under the cursor — while saying nothing about
  * what would have been accepted.
+ *
+ * Each one names the units its field will take. Every numeric field in the app
+ * accepts "2 cm" and "0.75 in" as readily as "2", and nothing on screen says
+ * so; a rejected value is the moment somebody is most willing to be told.
  */
 export const NOT_A = {
   length: 'That is not a length. Type a number, with or without a unit — 2, 2 cm, 0.75 in.',
-  angle: 'That is not an angle. Type a number of degrees.',
-  mass: 'That is not a mass. Type a number.',
-  momentOfInertia: 'That is not a moment of inertia. Type a number.',
-  force: 'That is not a force. Type a number.',
+  angle: 'That is not an angle. Type a number, with or without a unit — 90, 90 deg, 1.5 rad.',
+  mass: 'That is not a mass. Type a number, with or without a unit — 5, 5 g, 0.2 lb.',
+  momentOfInertia:
+    'That is not a moment of inertia. Type a number, with or without a unit — 4, 4 kg·cm².',
+  force: 'That is not a force. Type a number, with or without a unit — 10, 10 N, 2.5 lb.',
   name: 'A name has to be letters or numbers, and cannot be one already in use.',
 } as const;

--- a/src/mytheme.scss
+++ b/src/mytheme.scss
@@ -35,6 +35,7 @@
 @use 'src/app/component/MODALS/templates/templates.component.scss' as templates;
 @use 'src/app/component/not-ready-warning/not-ready-warning.component.scss' as not-ready-warning;
 @use 'src/app/component/bottombar/bottombar.component.scss' as bottombar;
+@use 'src/app/component/notification/notification.component.scss' as notification;
 
 @include mat.elevation-classes();
 @include mat.app-background();
@@ -99,6 +100,7 @@ $my-theme: mat.m2-define-light-theme(
 @include equation-panel.css($my-theme);
 @include not-ready-warning.css($my-theme);
 @include bottombar.css($my-theme);
+@include notification.css($my-theme);
 
 @include blocks-common.css($my-theme);
 @include panel-section.css($my-theme);

--- a/src/test-utils/mechanism-harness.ts
+++ b/src/test-utils/mechanism-harness.ts
@@ -9,6 +9,7 @@ import { NumberUnitParserService } from '../app/services/number-unit-parser.serv
 import { SettingsService } from '../app/services/settings.service';
 import { SvgGridService } from '../app/services/svg-grid.service';
 import { SynthesisBuilderService } from '../app/services/synthesis/synthesis-builder.service';
+import { silentNotifications } from './notification-stub';
 
 /**
  * A real `MechanismService` with its dependencies stubbed just enough to run
@@ -35,7 +36,12 @@ export function createMechanismHarness(): MechanismHarness {
   if (!ColorService.instance) new ColorService();
   const settings = new SettingsService();
   const parser = new NumberUnitParserService();
-  const svg = new SvgGridService(settings, new DragStateService(), {} as unknown as Injector);
+  const svg = new SvgGridService(
+    settings,
+    new DragStateService(),
+    {} as unknown as Injector,
+    silentNotifications()
+  );
   const synthesis = new SynthesisBuilderService(parser, settings);
   let service!: MechanismService;
   const grid = new GridUtilsService(synthesis, svg, {
@@ -56,7 +62,7 @@ export function createMechanismHarness(): MechanismHarness {
   const injector = {
     get: (token: unknown) => (token === DragStateService ? dragState : history),
   } as unknown as Injector;
-  service = new MechanismService(grid, active, injector, settings, parser);
+  service = new MechanismService(grid, active, injector, settings, parser, silentNotifications());
   return { service, active, saveCount: () => saves };
 }
 

--- a/src/test-utils/notification-stub.ts
+++ b/src/test-utils/notification-stub.ts
@@ -1,20 +1,13 @@
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { NotificationService } from '../app/services/notification.service';
 
 /**
- * A `NotificationService` that opens nothing.
+ * A `NotificationService` for specs that build their services by hand.
  *
- * The specs that build services by hand have no overlay to open into, and none
- * of them is about what the app said -- they are about what it did. A spec that
- * *is* about the message spies on the service's own methods instead, which is
- * why this stubs the snackbar underneath rather than the service itself.
+ * It is the real thing — the service owns its own stack and needs nothing from
+ * the DOM — so a spec that wants to know what was said can read `live`, and one
+ * that does not can ignore it. A spec asserting on a *particular* message spies
+ * on the service's own methods instead, which reads better than matching text.
  */
 export function silentNotifications(): NotificationService {
-  const snackBar = {
-    openFromComponent: () => ({
-      dismiss: () => {},
-      afterDismissed: () => ({ subscribe: () => {} }),
-    }),
-  } as unknown as MatSnackBar;
-  return new NotificationService(snackBar);
+  return new NotificationService();
 }

--- a/src/test-utils/notification-stub.ts
+++ b/src/test-utils/notification-stub.ts
@@ -1,0 +1,20 @@
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { NotificationService } from '../app/services/notification.service';
+
+/**
+ * A `NotificationService` that opens nothing.
+ *
+ * The specs that build services by hand have no overlay to open into, and none
+ * of them is about what the app said -- they are about what it did. A spec that
+ * *is* about the message spies on the service's own methods instead, which is
+ * why this stubs the snackbar underneath rather than the service itself.
+ */
+export function silentNotifications(): NotificationService {
+  const snackBar = {
+    openFromComponent: () => ({
+      dismiss: () => {},
+      afterDismissed: () => ({ subscribe: () => {} }),
+    }),
+  } as unknown as MatSnackBar;
+  return new NotificationService(snackBar);
+}

--- a/src/tests/verification/assembly-mode.spec.ts
+++ b/src/tests/verification/assembly-mode.spec.ts
@@ -14,6 +14,7 @@ import { SynthesisBuilderService } from '../../app/services/synthesis/synthesis-
 import { MechanismBuilder } from '../../app/services/transcoding/mechanism-builder';
 import { StringTranscoder } from '../../app/services/transcoding/string-transcoder';
 import { MODEL_SCALE } from '../../app/model/render-scale';
+import { silentNotifications } from '../../test-utils/notification-stub';
 
 // The linkage from issue #199. An exact parallelogram four-bar: A->B and D->C are
 // the same vector, so every revolution the crank lines up with the ground link and
@@ -39,12 +40,17 @@ function loadMechanism(payload: string) {
   let service!: MechanismService;
   const grid = new GridUtilsService(
     new SynthesisBuilderService(parser, settings),
-    new SvgGridService(settings, new DragStateService(), {} as unknown as Injector),
+    new SvgGridService(
+      settings,
+      new DragStateService(),
+      {} as unknown as Injector,
+      silentNotifications()
+    ),
     { get: () => service } as unknown as Injector
   );
   const active = new ActiveObjService();
   const injector = { get: () => ({ save: () => {} }) } as unknown as Injector;
-  service = new MechanismService(grid, active, injector, settings, parser);
+  service = new MechanismService(grid, active, injector, settings, parser, silentNotifications());
 
   const decoder = new StringTranscoder();
   decoder.decodeURL(payload);

--- a/src/tests/verification/edit-invariants.spec.ts
+++ b/src/tests/verification/edit-invariants.spec.ts
@@ -11,6 +11,7 @@ import { Coord } from '../../app/model/coord';
 import { RevJoint, RealJoint } from '../../app/model/joint';
 import { RealLink } from '../../app/model/link';
 import { createMechanismHarness, wireGraph } from '../../test-utils/mechanism-harness';
+import { LEGACY_FORCE_MECHANISM } from '../fixtures/mechanism-fixtures';
 
 /**
  * A mechanism built to be awkward: four welded compounds, two cylinders, a
@@ -203,5 +204,62 @@ describe('undo', () => {
     expect(active.selectedJoint.id, 'still looking at the joint that was edited').toBe('B');
     // And the object selected is the live one, not the copy the undo replaced.
     expect(mechanism.joints.some((joint) => joint === active.selectedJoint)).toBe(true);
+  });
+
+  it('puts back a joint that was deleted', () => {
+    // Deleting a joint wrote no history at all: the joint went, Undo stayed
+    // greyed out, and Ctrl+Z did nothing. The tail of `deleteJoint` had asked
+    // not to save since back when it read `updateMechanism()`, whose save flag
+    // is off by default — so the flag was never a decision, just the default
+    // carried forward through a refactor that made it explicit.
+    //
+    // It was invisible for as long as it was, because the same deletion routed
+    // through the cylinder branch *did* save, as does `deleteLink`.
+    TestBed.configureTestingModule({ imports: [AppModule] });
+    const mechanism = TestBed.inject(MechanismService);
+    const active = TestBed.inject(ActiveObjService);
+    const history = TestBed.inject(SaveHistoryService);
+    TestBed.inject(UrlProcessorService).updateFromURL(LEGACY_FORCE_MECHANISM, false, true, false);
+    // Loading does not write the loaded state — the one entry standing behind
+    // it is the empty grid — so the four-bar has to be saved to be landed on.
+    mechanism.save();
+
+    const b = mechanism.joints.find((joint) => joint.id === 'b') as RealJoint;
+    active.updateSelectedObj(b);
+    mechanism.deleteJoint();
+    expect(mechanism.joints.some((joint) => joint.id === 'b')).toBe(false);
+
+    expect(history.canUndo(), 'a deletion is an edit, so it earns an entry').toBe(true);
+
+    history.undo();
+
+    // The whole four-bar, not just `b`: if the delete had written nothing, this
+    // undo would step past it onto the empty grid the load sat on top of.
+    expect(mechanism.joints.map((joint) => joint.id).sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('spends one entry on a delete, or none when the caller owns the gesture', () => {
+    // `deleteMechanism` deletes every joint of a partition in a loop. Saving
+    // per joint would make restoring it cost one Ctrl+Z per joint it happened
+    // to have, so that caller opts out and mints the single entry itself.
+    const harness = createMechanismHarness();
+    const a = new RevJoint('A', 0, 0);
+    const b = new RevJoint('B', 4, 0);
+    const c = new RevJoint('C', 4, 3);
+    harness.service.joints.push(a, b, c);
+    harness.service.links.push(
+      new RealLink('AB', [a, b], 1, 1, new Coord(2, 0)),
+      new RealLink('BC', [b, c], 1, 1, new Coord(4, 1.5))
+    );
+    wireGraph(harness.service);
+    const before = harness.saveCount();
+
+    harness.active.updateSelectedObj(c);
+    harness.service.deleteJoint();
+    expect(harness.saveCount() - before).toBe(1);
+
+    harness.active.updateSelectedObj(b);
+    harness.service.deleteJoint(false);
+    expect(harness.saveCount() - before, 'the caller saves for this one').toBe(1);
   });
 });

--- a/src/tests/verification/time-based-playback.spec.ts
+++ b/src/tests/verification/time-based-playback.spec.ts
@@ -12,6 +12,7 @@ import { MechanismBuilder } from '../../app/services/transcoding/mechanism-build
 import { StringTranscoder } from '../../app/services/transcoding/string-transcoder';
 import { TEMPLATE_LINKAGES } from '../../app/component/MODALS/templates/template-linkages';
 import { LEGACY_FORCE_MECHANISM } from '../fixtures/mechanism-fixtures';
+import { silentNotifications } from '../../test-utils/notification-stub';
 
 /** A real MechanismService (not a stub) loaded with the fully rotating four-bar template. */
 function createLoadedService(payload: string = TEMPLATE_LINKAGES['4-Bar']) {
@@ -25,12 +26,17 @@ function createLoadedService(payload: string = TEMPLATE_LINKAGES['4-Bar']) {
     new SynthesisBuilderService(parser, settings),
     // The injector is only reached when something asks the canvas to re-frame
     // itself, which nothing here does — there is no canvas in this test.
-    new SvgGridService(settings, new DragStateService(), {} as unknown as Injector),
+    new SvgGridService(
+      settings,
+      new DragStateService(),
+      {} as unknown as Injector,
+      silentNotifications()
+    ),
     { get: () => service } as unknown as Injector
   );
   const active = new ActiveObjService();
   const injector = { get: () => ({ save: () => {} }) } as unknown as Injector;
-  service = new MechanismService(grid, active, injector, settings, parser);
+  service = new MechanismService(grid, active, injector, settings, parser, silentNotifications());
 
   const decoder = new StringTranscoder();
   decoder.decodeURL(payload);


### PR DESCRIPTION
Forty-seven messages shared one white bar, one four-second life, and one timestamp. This sorts them, cuts the ones that were saying what the window already says, and rebuilds what is left.

`docs/notification-inventory.md` is the record: every reachable message, what it was sorted as, and what became of it.

## The timestamp was the real fault

Not the wording. `NewGridComponent.sendNotification` kept a single `lastNotificationTime` for the whole app, initialised to the moment the canvas was constructed. Two consequences, both invisible until you go looking:

- **A message a moment earlier silenced the next one.** Drag against one rule, then another, and only the first was said.
- **Anything asking for a long quiet period was mute for that period *from page load*.** The two zoom warnings pass `20000`, so they could not appear in the first twenty seconds of a session — which is exactly when somebody is finding their zoom. I could not make them appear by any means until I waited the window out, at which point they fired instantly.

Cooldowns are per message id now, and start unarmed.

## Four kinds

| | colour | leaves | why |
| --- | --- | --- | --- |
| success | green | 2.5s | you watched it happen; this is a glance, not a read |
| refusal | slate | 4s | a rule, explained at the place you hit it |
| warning | amber | **waits** | a state nobody asked for, still true after the message would have gone |
| failure | red | **waits** | outside your control |

The glyph and the accent carry the colour; the sentence stays the app's text colour, because a red sentence is harder to read and the glyph has already said which of the four it is.

## Stacking, and why `MatSnackBar` had to go

It shows one message and takes the previous one away to do it — so a refusal could silently swallow a warning nobody had read. The service keeps its own stack of three. A fourth displaces the oldest message that was **leaving anyway**, never one still waiting to be dismissed.

Owning the markup also ended the fight with MDC's dark slab, and made room for actions.

## Messages that carry their own fix

The zoom warnings named a button in Settings and offered nothing. They now offer both real answers, because "this looks wrong" means two different things: **Fit to zoom** holds the view and resizes the drawing; **Reset view** holds the drawing and moves the view. Both were already sitting in the service that raises the warning. Capped at two — a third is a menu, and a menu on something that may leave in four seconds is a trap.

## Ctrl+Z undoes

It used to ask *"What were you trying to undo? Please let us know through the report button"* — a question for a study that ended — while undo itself sat in the top strip working fine. Shift or Y redoes. A keystroke aimed at a text field is left to that field, which also stops Delete from removing a joint while its name is being typed.

That exposed a second bug, fixed here in its own commit: **deleting a joint wrote no history at all**, so Undo could not bring it back. `deleteJoint` ended in `finishStructuralEdit(false)`; the flag had been carried across from a refactor and read like a decision that was never made.

## Cut

- **The four mode and timing refusals** — "Switch to Edit mode to change the mechanism", "Cannot edit while the animation is running", "Step back to the start to edit". Every guard stays; none of them narrates. Which mode you are in is written across the top strip and down the side of the window.
- **The four driven-joint refusals**, which turned out to be unreachable. Both surfaces disable the control on `canToggleInput = input || canDrive`, and `canDrive` is *exactly* "`describeActuator` did not refuse", asked of the same joint `adjustInput` re-tests. Checked empirically as well: 147 presses of every enabled control across all 25 templates, zero refusals. The guard stays, silent; the four sentences stay in `actuator.ts`, where the setup panel's blocker list actually reads them.
- **"No file selected"**, which fired when the file picker was dismissed. Cancelling a dialogue is not a thing that went wrong.
- Dead code: `synthesis-panel.handleButton` (no template bound it), the unused `NOT_BUILT_YET`, ~20 commented-out debug calls, the Escape easter egg.

## Added, for discoverability

The six "that is not a length" messages only ever fired inside the **Debug tab**, while the Edit panel put the old value back without a word. They now fire from all thirteen of its numeric fields, and each one names the units its field takes:

> That is not a length. Type a number, with or without a unit — 2, 2 cm, 0.75 in.

Every numeric field in the app accepts `2 cm` and `0.75 in` as readily as `2`, and nothing on screen said so. A rejected value is the moment somebody is most willing to be told. Examples were checked against the parsers before being written down — `90 deg`, `1.5 rad`, `10 N`, `2.5 lb`, `4 kg·cm²` are all real.

## Visual

The accent follows the help panel's trick: a corner radius **equal to the border width** leaves the bar's inner edge straight while the card's corners stay round. At 10px against a 4px bar it curved away at both ends and read as a separate rounded pill behind the card.

The row had been aligned four different ways — `flex-start` on the container, a 1px nudge on the glyph, `align-self: center` on the button, a −2px margin on the close — so no two agreed where the middle was. One rule now. Measured rather than eyeballed: on one line and on two, every element's centre falls on the card's, to 0.0px.

## Verification

- **992 unit tests**, 114 files.
- **`e2e/notifications.mjs`** — 25 browser checks: the four kinds are told apart on screen; who waits and who leaves; per-id cooldowns (two different refusals in a second both speak, the same one twice speaks once, a long cooldown can still speak at once); three stack and a fourth displaces the right one; both zoom actions do their own distinct thing; Ctrl+Z / Ctrl+Shift+Z; and Ctrl+Z in a text field leaves the mechanism alone.

One thing worth keeping from the debugging: **`scaleToFitLinkage()` finishes inside an `afterNextRender`**, so calling it without a change-detection pass behind it leaves the fit pending forever. The Reset View button works; the same call from a console does nothing. It cost me a false failure before I spotted it.

## Left open

- **The eleven drop refusals** still speak, on top of the canvas refusal marker and the joint shake — kept deliberately, to be judged now the new system is visible.
- **`awayFromStart` is now the only fully silent refusal** where the window does not otherwise explain itself: you are in Edit mode, scrubbed forward, and dragging simply does nothing. Removed as asked; easy to bring back alone.
- **The linkage table** those six messages came from is still reachable only through the Debug tab. Whether it should exist at all is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
