### PR TITLE
Force analysis for cylinders and welded slides, and setup help that names the fix

### DIFF
--- a/docs/phase-3-slide-spec.md
+++ b/docs/phase-3-slide-spec.md
@@ -555,6 +555,15 @@ message that names the joint, and §9 carries it.
 
 ## 9. Follow-up: statics for welded assemblies
 
+**Landed.** The couple column exists (`GuideCouple` in `force-solver.ts`), the refusal in 3.8 is
+retired, and the verification is the shape this section asked for: hand statics swept over the
+loaded Scotch yoke (`slide-forces.spec.ts`), the two-force-member property of a sealed cylinder
+(`cylinder-forces.spec.ts`), and a virtual-work audit across every topology class
+(`force-power-balance.spec.ts`). One deviation from the sketch below: rider and block stay
+separate bodies — the block is zero-length, so the couple passes through it untouched and no
+merged mass/CoM/parallel-axis bookkeeping is needed. The section is kept as written for the
+reasoning.
+
 Deliberately **not** in Phase 3, and to be specified on its own rather than left as optional work
 inside this one. Recorded here so its scope is visible rather than implied — it is wider than the
 equilibrium change that makes it sound small:

--- a/e2e/force-status-survey.mjs
+++ b/e2e/force-status-survey.mjs
@@ -1,0 +1,54 @@
+/**
+ * What force analysis actually says in the running app, per template.
+ * Investigation script — reads statuses through ng.getComponent.
+ *
+ *   PMKS_BASE_URL=<origin> node e2e/force-status-survey.mjs
+ */
+import { readFileSync } from 'node:fs';
+
+const { chromium } = await import(
+  (process.env.PMKS_PLAYWRIGHT_DIR ?? '/tmp/pmks-playwright') + '/node_modules/playwright/index.mjs'
+);
+import { waitForReady } from './app-ready.mjs';
+
+const BASE = process.env.PMKS_BASE_URL ?? 'http://localhost:4200';
+const source = readFileSync('src/app/component/MODALS/templates/template-linkages.ts', 'utf8');
+const payloads = Object.fromEntries(
+  [...source.matchAll(/^ {2}'?([\w-]+)'?:\n {4}'([^']+)',$/gm)].map(([, id, p]) => [id, p])
+);
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1500, height: 950 } });
+const errors = [];
+page.on('pageerror', (error) => errors.push(String(error)));
+
+console.log('templates found:', Object.keys(payloads).join(', '));
+
+for (const [name, payload] of Object.entries(payloads)) {
+  await page.goto(`${BASE}/?${payload}`, { waitUntil: 'domcontentloaded' });
+  await waitForReady(page).catch(() => undefined);
+  await page.waitForTimeout(600);
+  const report = await page.evaluate(() => {
+    const srv = ng.getComponent(document.querySelector('app-new-grid')).mechanismSrv;
+    return srv.mechanisms.map((mech) => {
+      const out = { valid: mech.isMechanismValid() };
+      if (!out.valid) return out;
+      for (const mode of ['static', 'dynamic']) {
+        const series = mech.getForceAnalysis(mode);
+        const first = series.frames[0];
+        out[mode] = {
+          ok: `${series.successfulFrames}/${series.frames.length}`,
+          status: first?.status,
+          message: first?.message,
+          diagnostic: series.diagnostic,
+        };
+      }
+      return out;
+    });
+  });
+  console.log(`\n### ${name}`);
+  for (const mech of report) console.log(JSON.stringify(mech, null, 1));
+}
+
+if (errors.length) console.log('\nPAGE ERRORS:', errors.slice(0, 5));
+await browser.close();

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -962,8 +962,14 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
       const hasFiniteData = [datum_X, datum_Y, datum_Z].some((values) =>
         values.some(Number.isFinite)
       );
+      // A hole in an otherwise good series is worth a sentence of its own: a
+      // silent gap at a toggle position reads as a plotting bug, when it is
+      // the most physical thing on the chart.
+      const failed = result.frames.length - result.successfulFrames;
       this.analysisDiagnostic = hasFiniteData
-        ? null
+        ? failed > 0
+          ? `${failed} of ${result.frames.length} positions have no solution — the chart has a gap there. Those are toggle positions: reactions grow without bound as the mechanism approaches them.`
+          : null
         : (result.diagnostic ??
           (mechProp === 'Joint Forces'
             ? 'This point is internal to one welded body and has no independent joint reaction.'

--- a/src/app/component/analysis-setup/analysis-setup.component.html
+++ b/src/app/component/analysis-setup/analysis-setup.component.html
@@ -47,7 +47,13 @@
       <button class="sectionHeader" (click)="forceOpen = !forceOpen">
         <span class="sectionName">
           Force analysis
-          <span class="chip warning">{{ forceOutstanding }} to set</span>
+          @if (forceOutstanding > 0) {
+            <span class="chip warning">{{ forceOutstanding }} to set</span>
+          } @else if (forceWarnings > 0) {
+            <span class="chip">{{ forceWarnings }} worth a look</span>
+          } @else {
+            <span class="chip ready">Ready</span>
+          }
         </span>
         <mat-icon>{{ forceOpen ? 'expand_less' : 'expand_more' }}</mat-icon>
       </button>
@@ -57,7 +63,9 @@
           @for (requirement of forceRequirements; track requirement.title) {
             @if (!requirement.met) {
               <div class="check">
-                <mat-icon class="checkIcon warning">radio_button_unchecked</mat-icon>
+                <mat-icon class="checkIcon warning">{{
+                  requirement.warning ? 'warning_amber' : 'radio_button_unchecked'
+                }}</mat-icon>
                 <div class="checkBody">
                   <div class="checkTitle">{{ requirement.title }}</div>
                   <p class="checkText">{{ requirement.body }}</p>

--- a/src/app/component/analysis-setup/analysis-setup.component.ts
+++ b/src/app/component/analysis-setup/analysis-setup.component.ts
@@ -69,7 +69,13 @@ export class AnalysisSetupComponent {
   }
 
   get forceOutstanding(): number {
-    return this.forceRequirements.filter((requirement) => !requirement.met).length;
+    return this.forceRequirements.filter((requirement) => !requirement.met && !requirement.warning)
+      .length;
+  }
+
+  get forceWarnings(): number {
+    return this.forceRequirements.filter((requirement) => !requirement.met && requirement.warning)
+      .length;
   }
 
   /**
@@ -84,9 +90,13 @@ export class AnalysisSetupComponent {
   get summary(): string {
     if (this.mode === 'force') {
       const outstanding = this.forceOutstanding;
-      return outstanding === 0
-        ? 'Force analysis is ready to run.'
-        : `${outstanding} ${outstanding === 1 ? 'thing has' : 'things have'} to be set before forces can be solved.`;
+      if (outstanding > 0) {
+        return `${outstanding} ${outstanding === 1 ? 'thing has' : 'things have'} to be set before forces can be solved.`;
+      }
+      const warnings = this.forceWarnings;
+      return warnings > 0
+        ? `Force analysis runs. ${warnings === 1 ? 'One thing below is' : `${warnings} things below are`} worth a look before trusting the numbers.`
+        : 'Force analysis is ready to run.';
     }
     const all = this.readiness;
     if (all.length === 0) {

--- a/src/app/component/new-grid/new-grid.component.html
+++ b/src/app/component/new-grid/new-grid.component.html
@@ -1148,7 +1148,7 @@
   @if (settings.isShowCOM.value || settings.previewCoMLinkId) {
     <g id="comTagHolder" style="transform: scaleY(-1); pointer-events: none">
       @for (link of mechanismSrv.getLinks(); track link) {
-        @if (settings.isShowCOM.value || settings.previewCoMLinkId === link.id) {
+        @if (showsCoM(link)) {
           <svg style="overflow: visible">
             <!-- The standard mark, drawn to be read over whatever is beneath it.
                  Two of the four quarters are filled and the other two are not
@@ -1210,7 +1210,7 @@
               [attr.fill]="tag.ink"
               [attr.fill-opacity]="tag.opacity"
               [attr.transform]="tag.angle ? 'rotate(' + tag.angle + ')' : null"
-              [attr.dy]="settings.isShowCOM.value ? -settings.objectScale * 0.13 : 0"
+              [attr.dy]="showsCoM(link) ? -settings.objectScale * 0.13 : 0"
               [style.font-size.px]="tagFontSize"
               style="text-anchor: middle"
             >

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -2711,6 +2711,20 @@ export class NewGridComponent implements OnDestroy {
   }
 
   /**
+   * Whether this link's centre-of-mass mark is on screen right now.
+   *
+   * The view toggle governs it, but a massless link is excused: mass starts at
+   * zero until someone chooses one, and a centre-of-mass mark on a link with no
+   * mass points at a property the link does not have. The preview (hovering
+   * the analysis panel's centre-of-mass heading) still shows it, because there
+   * the reader is asking about exactly that property.
+   */
+  showsCoM(link: Link): boolean {
+    if (this.settings.previewCoMLinkId === link.id) return true;
+    return this.settings.isShowCOM.value && link.mass > 0;
+  }
+
+  /**
    * Where a link's name goes, and in what ink.
    *
    * The anchor is the average of the joints the link is made of, which is

--- a/src/app/component/settings-panel/settings-panel.component.html
+++ b/src/app/component/settings-panel/settings-panel.component.html
@@ -22,6 +22,13 @@
         [disabled]="!unitsEditable()"
         >Angle Units
       </radio-block>
+      <toggle-block
+        [formGroup]="this.settingsForm"
+        _formControl="gravity"
+        tooltip="Weight loads every link that has mass. Turn off to analyze forces without gravity. Stored in the URL, so a shared analysis keeps it."
+      >
+        Gravity
+      </toggle-block>
       <!-- Input direction and speed belong to the input joint, so they live in that
            joint's Input Settings section in the Edit panel rather than here. -->
     </collapsible-subseciton>

--- a/src/app/component/settings-panel/settings-panel.component.ts
+++ b/src/app/component/settings-panel/settings-panel.component.ts
@@ -58,6 +58,7 @@ export class SettingsPanelComponent implements OnDestroy {
       showMinorGrid: this.settingsService.isShowMinorGrid.value,
       snapToGrid: this.settingsService.isSnapToGrid.value,
       snapToAlignment: this.settingsService.isSnapToAlignment.value,
+      gravity: this.settingsService.isGravity.value,
     });
 
     this.settingsSubscriptions.add(
@@ -184,6 +185,14 @@ export class SettingsPanelComponent implements OnDestroy {
       this.settingsService.isShowMinorGrid.next(Boolean(val));
       this.mechanismSrv.updateMechanism();
     });
+    // Gravity changes what the force analysis means, so it is an edit: the
+    // mechanisms are rebuilt with the new flag and the change is undoable.
+    this.settingsForm.controls['gravity'].valueChanges.subscribe((val) => {
+      const on = val === true;
+      if (on === this.settingsService.isGravity.value) return;
+      this.settingsService.isGravity.next(on);
+      this.mechanismSrv.updateMechanism(true);
+    });
     // this.settingsForm.controls['torqueunit'].valueChanges.subscribe(() => {
     //   this.settingsService.inputTorque.next(this.currentTorqueUnit);
     // });
@@ -259,6 +268,7 @@ export class SettingsPanelComponent implements OnDestroy {
       showMajorGrid: [true, { updateOn: 'change' }],
       snapToGrid: [false, { updateOn: 'change' }],
       snapToAlignment: [true, { updateOn: 'change' }],
+      gravity: [true, { updateOn: 'change' }],
     },
     { updateOn: 'blur' }
   );

--- a/src/app/component/settings-panel/settings-panel.component.ts
+++ b/src/app/component/settings-panel/settings-panel.component.ts
@@ -97,7 +97,8 @@ export class SettingsPanelComponent implements OnDestroy {
         this.settingsService.globalUnit,
         this.settingsService.isShowMajorGrid,
         this.settingsService.isShowMinorGrid,
-      ]).subscribe(([length, angle, force, global, showMajorGrid, showMinorGrid]) => {
+        this.settingsService.isGravity,
+      ]).subscribe(([length, angle, force, global, showMajorGrid, showMinorGrid, gravity]) => {
         this.currentLengthUnit = length;
         this.currentAngleUnit = angle;
         this.currentForceUnit = force;
@@ -109,6 +110,7 @@ export class SettingsPanelComponent implements OnDestroy {
             globalunit: (global - 30).toString(),
             showMajorGrid,
             showMinorGrid,
+            gravity,
           },
           { emitEvent: false }
         );
@@ -192,6 +194,9 @@ export class SettingsPanelComponent implements OnDestroy {
       if (on === this.settingsService.isGravity.value) return;
       this.settingsService.isGravity.next(on);
       this.mechanismSrv.updateMechanism(true);
+      // An open force graph is plotting the old gravity; ask for a redraw the
+      // same way a unit change does.
+      this.mechanismSrv.onMechUpdateState.next(2);
     });
     // this.settingsForm.controls['torqueunit'].valueChanges.subscribe(() => {
     //   this.settingsService.inputTorque.next(this.currentTorqueUnit);

--- a/src/app/component/top-bar/top-bar.component.ts
+++ b/src/app/component/top-bar/top-bar.component.ts
@@ -315,7 +315,10 @@ export class TopBarComponent implements AfterViewInit, AfterViewChecked, OnDestr
 
   statusOf(tab: TabID): TabStatus {
     if (tab === TabID.FORCE) {
-      const missing = this.mechanism.forceAnalysisRequirements().filter((r) => !r.met).length;
+      // Warnings do not count: they do not stop the analysis running.
+      const missing = this.mechanism
+        .forceAnalysisRequirements()
+        .filter((r) => !r.met && !r.warning).length;
       return missing === 0
         ? { text: 'Ready', ready: true }
         : { text: `${missing} to set`, ready: false };

--- a/src/app/component/view-controls/view-controls.component.ts
+++ b/src/app/component/view-controls/view-controls.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MechanismService } from '../../services/mechanism.service';
-import { SettingsService } from '../../services/settings.service';
+import { SettingsService, writeStoredFlag } from '../../services/settings.service';
 import { SvgGridService } from '../../services/svg-grid.service';
 
 /**
@@ -45,7 +45,11 @@ export class ViewControlsComponent {
   }
 
   showCenterOfMass(): void {
-    this.settingsService.isShowCOM.next(!this.settingsService.isShowCOM.value);
+    const on = !this.settingsService.isShowCOM.value;
+    this.settingsService.isShowCOM.next(on);
+    // A display preference, remembered on this machine rather than in the URL
+    // (see SettingsService.isShowCOM).
+    writeStoredFlag('showCoM', on);
   }
 
   comIconName(): string {

--- a/src/app/model/link.ts
+++ b/src/app/model/link.ts
@@ -162,8 +162,12 @@ export class RealLink extends Link {
     //   //TODO: Unsubsribe from this when link gets deleted
     // });
     // console.log('new subscription');
-    // this._mass = mass !== undefined ? mass : 1;
-    this._massMoI = massMoI !== undefined ? massMoI : 1;
+    // Zero, like the mass above it: a link that arrives with a moment of
+    // inertia of 1 resists angular acceleration in every dynamic analysis of a
+    // drawing whose author never chose a number — and it made "massless links
+    // are skipped by inertia" a lie. URLs carry each link's stored value, so
+    // only freshly drawn links land here.
+    this._massMoI = massMoI !== undefined ? massMoI : 0;
     // this._shape = shape !== undefined ? shape : Shape.line;
     // this._fill = '#' + (0x1000000 + Math.random() * 0xffffff).toString(16).substr(1, 6);
     // this._fill = RealLink.colorOptions[Math.floor(Math.random() * RealLink.colorOptions.length)];

--- a/src/app/model/mechanism/force-solver.ts
+++ b/src/app/model/mechanism/force-solver.ts
@@ -279,7 +279,8 @@ export class ForceSolver {
     });
 
     if (bodies.length === 0) return empty('unsupported-topology');
-    if (!this.propertiesAreValid(bodies, units)) return empty('invalid-properties');
+    const badProperty = this.invalidProperty(bodies, units);
+    if (badProperty) return empty('invalid-properties', badProperty);
     if (mode === 'dynamic' && !this.kinematicsAreComplete(bodies, kinematics)) {
       return empty('missing-kinematics');
     }
@@ -350,9 +351,15 @@ export class ForceSolver {
 
     const unknownCount = reactions.length + couples.length + (inputBody && inputKind ? 1 : 0);
     if (unknownCount !== rowCount) {
+      // Cause first, arithmetic second: "10 equations, 9 unknowns" is the
+      // solver talking to itself. What a reader can act on is which way the
+      // count is off — too many supports, or a body with none.
+      const counts = `(${rowCount} equilibrium equations, ${unknownCount} unknowns)`;
       return empty(
         'unsupported-topology',
-        `Force equilibrium has ${rowCount} equations and ${unknownCount} unknowns.`
+        unknownCount > rowCount
+          ? `This linkage has more supports than equilibrium can determine — a redundant support, link, or weld leaves the load's split between them ambiguous. Remove one ${counts}.`
+          : `A body here has nothing to react against, so its equilibrium cannot be written. Check for a part carrying load with no support ${counts}.`
       );
     }
 
@@ -682,22 +689,37 @@ export class ForceSolver {
     return ordered;
   }
 
-  private static propertiesAreValid(bodies: Link[], units: UnitFactors): boolean {
-    if (!Object.values(units).every(Number.isFinite)) return false;
-    return bodies.every((body) => {
-      if (!Number.isFinite(body.mass) || body.mass < 0) return false;
-      if (body instanceof RealLink) {
-        if (!Number.isFinite(body.massMoI) || body.massMoI < 0) return false;
-        return body.forces.every(
-          (force) =>
-            Number.isFinite(force.mag) &&
-            Number.isFinite(force.angleRad) &&
-            Number.isFinite(force.startCoord.x) &&
-            Number.isFinite(force.startCoord.y)
-        );
+  /**
+   * The first invalid mass, inertia, or force property, described by name —
+   * or undefined when everything is a usable number. The panel shows this
+   * sentence verbatim, so it has to say which part to go and fix.
+   */
+  private static invalidProperty(bodies: Link[], units: UnitFactors): string | undefined {
+    if (!Object.values(units).every(Number.isFinite)) {
+      return 'The unit conversion is invalid — reselect the global units.';
+    }
+    const nameOf = (body: Link): string => ('name' in body && body.name) || body.id;
+    for (const body of bodies) {
+      if (!Number.isFinite(body.mass) || body.mass < 0) {
+        return `Link ${nameOf(body)} has a mass that is not a usable number. Set Link Mass in Mass Settings.`;
       }
-      return true;
-    });
+      if (body instanceof RealLink) {
+        if (!Number.isFinite(body.massMoI) || body.massMoI < 0) {
+          return `Link ${nameOf(body)} has a moment of inertia that is not a usable number. Set it in Mass Settings.`;
+        }
+        for (const force of body.forces) {
+          if (
+            !Number.isFinite(force.mag) ||
+            !Number.isFinite(force.angleRad) ||
+            !Number.isFinite(force.startCoord.x) ||
+            !Number.isFinite(force.startCoord.y)
+          ) {
+            return `The force on link ${nameOf(body)} has an invalid magnitude or position. Select it and re-enter its values.`;
+          }
+        }
+      }
+    }
+    return undefined;
   }
 
   private static kinematicsAreComplete(

--- a/src/app/model/mechanism/force-solver.ts
+++ b/src/app/model/mechanism/force-solver.ts
@@ -27,6 +27,12 @@ export interface ForceAnalysisFrame {
   jointReactionsByLink: Map<string, Map<string, ForceVector>>;
   /** Compatibility/default view: the resultant on the joint's first root body. */
   jointReactions: Map<string, ForceVector>;
+  /**
+   * The couple each welded guide applies to its rider, keyed by the sliding
+   * joint's id. N·m, counterclockwise-positive on the rider. Only welded
+   * prismatic pairs carry one; a free-turning block cannot transmit a moment.
+   */
+  guideCouples: Map<string, number>;
   inputEffort?: ForceAnalysisEffort;
   rank: number;
   residual: number;
@@ -83,6 +89,25 @@ interface ReactionUnknown {
   positiveBody: Link;
   negativeBody?: Link;
   direction: ForceVector;
+  column: number;
+}
+
+/**
+ * The couple a welded guide transmits (docs/phase-3-slide-spec.md §3.8, §9).
+ *
+ * A free-turning block exchanges only a normal force with its slot. Welding a
+ * rider to the block stops the pair rotating, so the guide must also supply a
+ * moment — the unknown the count guard used to come up one short by. The block
+ * is zero-length and has no moment equation, so the couple passes through it
+ * untouched and can couple the rider to the guide directly.
+ */
+interface GuideCouple {
+  /** The sliding joint whose guide supplies the couple. */
+  slider: PrisJoint;
+  /** The root body the weld holds rigid with the block; +1 in its moment row. */
+  rider: RealLink;
+  /** The slot's carrier when it is cut into a moving body; −1 in its moment row. */
+  carrier?: Link;
   column: number;
 }
 
@@ -212,9 +237,12 @@ export class ForceSolver {
       frames,
       successfulFrames,
       reactionIndex: this.buildReactionIndex(mechanism.joints[0] ?? [], mechanism.links[0] ?? []),
+      // The frame's own message first: it names the joint or the count, where
+      // the status alone can only say "topology".
       diagnostic:
         successfulFrames === 0
-          ? this.statusMessage(frames[0]?.status ?? 'unsupported-topology')
+          ? (frames[0]?.message ??
+            this.statusMessage(frames[0]?.status ?? 'unsupported-topology'))
           : undefined,
     };
   }
@@ -244,26 +272,13 @@ export class ForceSolver {
       timeSeconds,
       jointReactionsByLink: new Map(),
       jointReactions: new Map(),
+      guideCouples: new Map(),
       rank,
       residual,
       message,
     });
 
     if (bodies.length === 0) return empty('unsupported-topology');
-    // A welded slide assembly is refused by name rather than by arithmetic
-    // (docs/phase-3-slide-spec.md §3.8). The equation count catches it too --
-    // it comes out one unknown short, because a prismatic pair welded to a body
-    // with a moment equation transmits a couple the model has no column for --
-    // but a count that happens to be wrong is not a reason, and it would go
-    // quiet the moment some other change made the numbers balance.
-    const welded = slideAssemblies(joints);
-    if (welded.length > 0) {
-      return empty(
-        'unsupported-topology',
-        `Joint ${welded[0].weldJoint.id} welds ${welded[0].riders[0].id} rigidly to its slider. ` +
-          'A prismatic pair carrying a moment has no force solution here yet.'
-      );
-    }
     if (!this.propertiesAreValid(bodies, units)) return empty('invalid-properties');
     if (mode === 'dynamic' && !this.kinematicsAreComplete(bodies, kinematics)) {
       return empty('missing-kinematics');
@@ -278,6 +293,36 @@ export class ForceSolver {
     }
 
     const { reactions, incidentByJoint } = this.enumerateReactions(joints, bodies);
+
+    // One couple unknown per welded slide (docs/phase-3-slide-spec.md §9).
+    // Shapes the couple cannot be written for are refused by name rather than
+    // left to the count guard, which would only catch them by coincidence.
+    const couples: GuideCouple[] = [];
+    for (const assembly of slideAssemblies(joints)) {
+      // A dangling guide exerts nothing, so it owes no couple either.
+      if (!assembly.slider.ground && !assembly.slider.isFloating) continue;
+      const rider = this.rootBody(bodies, assembly.riders[0]);
+      const carrier = assembly.slider.isFloating
+        ? this.rootBody(bodies, assembly.slider.carrier)
+        : undefined;
+      if (
+        !(rider instanceof RealLink) ||
+        rider === carrier ||
+        (carrier !== undefined && !(carrier instanceof RealLink))
+      ) {
+        return empty(
+          'unsupported-topology',
+          `Joint ${assembly.weldJoint.id} welds ${assembly.riders[0]?.id ?? 'a link'} rigidly ` +
+            'to its slider, and that shape has no force model.'
+        );
+      }
+      couples.push({
+        slider: assembly.slider,
+        rider,
+        carrier,
+        column: reactions.length + couples.length,
+      });
+    }
 
     const inputJoint = joints.find(
       (joint): joint is RealJoint => joint instanceof RealJoint && joint.input
@@ -299,7 +344,7 @@ export class ForceSolver {
       }
     }
 
-    const unknownCount = reactions.length + (inputBody && inputKind ? 1 : 0);
+    const unknownCount = reactions.length + couples.length + (inputBody && inputKind ? 1 : 0);
     if (unknownCount !== rowCount) {
       return empty(
         'unsupported-topology',
@@ -346,7 +391,15 @@ export class ForceSolver {
       }
     }
 
-    const inputColumn = reactions.length;
+    // A couple has no force resultant: it enters moment rows alone.
+    for (const couple of couples) {
+      A[bodyRows.get(couple.rider.id)!.start + 2][couple.column] += 1;
+      if (couple.carrier) {
+        A[bodyRows.get(couple.carrier.id)!.start + 2][couple.column] -= 1;
+      }
+    }
+
+    const inputColumn = reactions.length + couples.length;
     if (inputBody && inputKind) {
       const rows = bodyRows.get(inputBody.id)!;
       if (inputKind === 'torque' && inputBody instanceof RealLink) {
@@ -354,6 +407,17 @@ export class ForceSolver {
       } else if (inputKind === 'force') {
         A[rows.start][inputColumn] = inputDirection[0];
         A[rows.start + 1][inputColumn] = inputDirection[1];
+        // An actuator pushes against something. On a grounded guide that is
+        // the world; in a sealed cylinder it is the barrel, and leaving the
+        // reaction off turns the drive into an outside hand pushing the block
+        // through space — which breaks the oldest property a cylinder has, of
+        // being a two-force member between its mounts.
+        if (inputJoint instanceof PrisJoint && inputJoint.isFloating) {
+          const carrier = this.rootBody(bodies, inputJoint.carrier);
+          if (carrier) {
+            addForceCoefficient(carrier, inputJoint, inputDirection, inputColumn, -1);
+          }
+        }
       }
     }
 
@@ -427,6 +491,11 @@ export class ForceSolver {
       if (value) jointReactions.set(jointId, value);
     }
 
+    const guideCouples = new Map<string, number>();
+    for (const couple of couples) {
+      guideCouples.set(couple.slider.id, solution.values[couple.column]);
+    }
+
     const inputEffort =
       inputJoint && inputKind
         ? {
@@ -442,10 +511,26 @@ export class ForceSolver {
       timeSeconds,
       jointReactionsByLink,
       jointReactions,
+      guideCouples,
       inputEffort,
       rank: solution.rank,
       residual: solution.residual,
     };
+  }
+
+  /**
+   * The root body in `bodies` that `leaf` belongs to.
+   *
+   * A weld fuses links into a compound whose members survive as `subset`
+   * leaves, so the link a slide assembly names is not always the body the
+   * equilibrium rows are written for.
+   */
+  private static rootBody(bodies: Link[], leaf: Link | undefined): Link | undefined {
+    if (!leaf) return undefined;
+    const contains = (link: Link): boolean =>
+      link.id === leaf.id ||
+      (link instanceof RealLink && link.subset.some((member) => contains(member)));
+    return bodies.find(contains);
   }
 
   static statusMessage(status: ForceAnalysisStatus): string {

--- a/src/app/model/mechanism/force-solver.ts
+++ b/src/app/model/mechanism/force-solver.ts
@@ -301,7 +301,11 @@ export class ForceSolver {
     for (const assembly of slideAssemblies(joints)) {
       // A dangling guide exerts nothing, so it owes no couple either.
       if (!assembly.slider.ground && !assembly.slider.isFloating) continue;
-      const rider = this.rootBody(bodies, assembly.riders[0]);
+      // A settled weld has fused every rider into one compound. Mid-edit, the
+      // riders can still be several distinct bodies, and one couple cannot
+      // speak for all of them — refuse rather than pick a favourite.
+      const riderRoots = new Set(assembly.riders.map((leaf) => this.rootBody(bodies, leaf)));
+      const rider = riderRoots.size === 1 ? [...riderRoots][0] : undefined;
       const carrier = assembly.slider.isFloating
         ? this.rootBody(bodies, assembly.slider.carrier)
         : undefined;
@@ -578,9 +582,10 @@ export class ForceSolver {
         // A grounded slot pushes against the world, which needs no equation of
         // its own. A floating one pushes against the carrier, and that reaction
         // has to appear in the carrier's equilibrium as well or the slot
-        // transmits force out of nowhere.
+        // transmits force out of nowhere. Resolved through compounds: a weld
+        // may have folded the carrier into a root whose id is not its own.
         const carrier = candidate.isFloating
-          ? bodies.find((body) => body.id === candidate.carrier?.id)
+          ? this.rootBody(bodies, candidate.carrier)
           : undefined;
         if (piston && (candidate.ground || carrier)) {
           reactions.push({
@@ -672,7 +677,7 @@ export class ForceSolver {
     // `joints`, so without this the body on the far side of the slot is simply
     // missing from the joint's incidence.
     if (joint instanceof PrisJoint && joint.isFloating) {
-      add(bodies.find((body) => body.id === joint.carrier?.id));
+      add(this.rootBody(bodies, joint.carrier));
     }
     return ordered;
   }

--- a/src/app/model/mechanism/mechanism.ts
+++ b/src/app/model/mechanism/mechanism.ts
@@ -12,6 +12,7 @@ import { KinematicsSolver } from './kinematic-solver';
 import { ForceAnalysisMode, ForceAnalysisSeries, ForceSolver } from './force-solver';
 import { roundNumber } from '../utils';
 import { LBF_IN_PER_NEWTON_METER, LBF_PER_NEWTON } from '../unit-conversions';
+import { MODEL_SCALE } from '../render-scale';
 
 /**
  * Why a mechanism will not run. One of these, not a boolean, because the ways a
@@ -29,6 +30,14 @@ export type MechanismFailure =
 export class Mechanism {
   private _failure: MechanismFailure | undefined;
   private _unusableCylinder: string | undefined;
+  /** Joints the position ordering never reached, captured at the failure. */
+  private _unreachableJoints: string[] = [];
+  /**
+   * How near the cycle came to closing before the solver gave up, in user
+   * units. Captured at the failure so the panel can say whether the loop only
+   * just misses or wanders wide.
+   */
+  private _cycleGap: number | undefined;
   private _joints: Joint[][] = [[]];
   private _links: Link[][] = [[]];
   private _forces: Force[][] = [[]];
@@ -399,6 +408,7 @@ export class Mechanism {
       // move. Returning quietly left it *reporting itself valid* with a single
       // frame: the play button enabled, nothing happening, and the panel with
       // nothing to say about why.
+      this._unreachableJoints = [...PositionSolver.unsolvableJoints];
       this.setMechanismInvalid('nothing-can-move');
       return;
     }
@@ -590,6 +600,19 @@ export class Mechanism {
         startingPositionY - roundNumber(this._joints[currentTimeStamp][desiredJointIndex].y, 2)
       );
       if (currentTimeStamp === 750) {
+        // How close it ever came to its starting pose, skipping the first few
+        // frames where it is trivially still there. setMechanismInvalid wipes
+        // the frames, so this is the last chance to measure.
+        let nearest = Infinity;
+        for (let frame = 30; frame < this._joints.length; frame++) {
+          const joint = this._joints[frame]?.[desiredJointIndex];
+          if (!joint) continue;
+          nearest = Math.min(
+            nearest,
+            Math.hypot(joint.x - startingPositionX, joint.y - startingPositionY)
+          );
+        }
+        this._cycleGap = Number.isFinite(nearest) ? nearest / MODEL_SCALE : undefined;
         this.setMechanismInvalid('cycle-never-closes');
         return;
       }
@@ -653,6 +676,16 @@ export class Mechanism {
    */
   get unusableCylinder(): string | undefined {
     return this._unusableCylinder;
+  }
+
+  /** Joints the position ordering never reached, when nothing-can-move. */
+  get unreachableJoints(): string[] {
+    return this._unreachableJoints;
+  }
+
+  /** Nearest return to the starting pose in user units, when the cycle never closes. */
+  get cycleGap(): number | undefined {
+    return this._cycleGap;
   }
 
   get internalTriangleSimLinkMap(): Map<string, number[]> {

--- a/src/app/model/mechanism/readiness.ts
+++ b/src/app/model/mechanism/readiness.ts
@@ -93,13 +93,16 @@ export function readinessOf(
         });
       } else if (dof > 1) {
         // Point at the loose ends when there are any: a joint on one link with
-        // no ground is a freedom the reader can see.
+        // no ground is a freedom the reader can see. Only on a *binary* link,
+        // though — a third joint riding a link that already has two is a tracer
+        // point, and a tracer adds no freedom worth sending anyone to.
         const freeEnds = partition.ownJoints.filter(
           (joint) =>
             joint instanceof RealJoint &&
             !(joint instanceof PrisJoint) &&
             !joint.ground &&
-            joint.links.length === 1
+            joint.links.length === 1 &&
+            joint.links[0].joints.length <= 2
         );
         add({
           state: 'blocker',

--- a/src/app/model/mechanism/readiness.ts
+++ b/src/app/model/mechanism/readiness.ts
@@ -92,16 +92,40 @@ export function readinessOf(
           body: 'It has no ground, so every part of it is free to drift. Ground a joint, or ground a slider’s guide.',
         });
       } else if (dof > 1) {
+        // Point at the loose ends when there are any: a joint on one link with
+        // no ground is a freedom the reader can see.
+        const freeEnds = partition.ownJoints.filter(
+          (joint) =>
+            joint instanceof RealJoint &&
+            !(joint instanceof PrisJoint) &&
+            !joint.ground &&
+            joint.links.length === 1
+        );
         add({
           state: 'blocker',
           title: `This mechanism has ${dof} degrees of freedom`,
-          body: `One input can drive only one degree of freedom. Ground another joint, or connect a free joint to a second link, until this reads 1.`,
+          body:
+            `One input can drive only one degree of freedom. Ground another joint, or connect a free joint to a second link, until this reads 1.` +
+            (freeEnds.length > 0
+              ? ` ${freeEnds.length === 1 ? 'Joint' : 'Joints'} ${names(freeEnds)} ${
+                  freeEnds.length === 1 ? 'hangs' : 'hang'
+                } on only one link — free ends like that are where extra freedom usually lives.`
+              : ''),
+          at: freeEnds[0],
+          action: freeEnds.length > 0 ? 'Go To Joint' : undefined,
         });
       } else {
+        const welded = partition.ownJoints.some(
+          (joint) => joint instanceof RealJoint && joint.isWelded
+        );
         add({
           state: 'blocker',
           title: `This mechanism has ${dof} degrees of freedom`,
-          body: 'It is over-constrained, so nothing can move at all. Remove a link, or unground a joint, until this reads 1.',
+          body:
+            'It is over-constrained, so nothing can move at all. Remove a link, or unground a joint, until this reads 1.' +
+            (welded
+              ? ' A weld also removes freedom — unwelding a joint is another way out.'
+              : ''),
         });
       }
       break;
@@ -144,21 +168,44 @@ export function readinessOf(
       });
       break;
 
-    case 'cycle-never-closes':
+    case 'cycle-never-closes': {
+      const gap = mechanism.cycleGap;
       add({
         state: 'blocker',
         title: 'The motion never repeats',
-        body: 'This mechanism never comes back to the pose it started in, so there is no cycle to animate. Check the link lengths — a loop that only just closes can wander instead of repeating.',
+        body:
+          'This mechanism never comes back to the pose it started in, so there is no cycle to animate.' +
+          (gap !== undefined && Number.isFinite(gap)
+            ? gap < 0.5
+              ? ` The closest it comes is ${gap.toFixed(2)} units away — a loop that only just fails to close usually has a link length slightly off.`
+              : ` The closest it comes is ${gap.toFixed(1)} units away — the motion wanders rather than repeating. Check the link lengths.`
+            : ' Check the link lengths — a loop that only just closes can wander instead of repeating.'),
       });
       break;
+    }
 
-    case 'nothing-can-move':
+    case 'nothing-can-move': {
+      const unreachable = partition.ownJoints.filter((joint) =>
+        mechanism.unreachableJoints.includes(joint.id)
+      );
       add({
         state: 'blocker',
         title: 'Nothing moves when the input turns',
-        body: 'The driven joint cannot reach the rest of the mechanism, so no other joint has a position to solve for. Check that it is connected through links to the parts you expect it to move.',
+        body:
+          unreachable.length > 0
+            ? `The solver never finds a position for ${
+                unreachable.length === 1 ? 'joint' : 'joints'
+              } ${names(unreachable)} — the driven joint cannot reach ${
+                unreachable.length === 1 ? 'it' : 'them'
+              } through the links. Check the connections between the input and ${
+                unreachable.length === 1 ? 'that joint' : 'those joints'
+              }.`
+            : 'The driven joint cannot reach the rest of the mechanism, so no other joint has a position to solve for. Check that it is connected through links to the parts you expect it to move.',
+        at: unreachable[0],
+        action: unreachable.length > 0 ? 'Go To Joint' : undefined,
       });
       break;
+    }
   }
 
   // Asked even of a mechanism the solver accepted: the toggle refuses a joint
@@ -239,6 +286,12 @@ function reciprocates(mechanism: Mechanism): boolean {
 /** One condition force analysis needs, and whether the drawing meets it. */
 export interface ForceRequirement {
   met: boolean;
+  /**
+   * Unmet-but-not-blocking: the analysis runs anyway, and the row is worth
+   * reading before trusting the numbers. Warnings do not gate readiness and
+   * are not counted by the "N to set" chips.
+   */
+  warning?: boolean;
   /** A short sentence-case phrase naming the condition. */
   title: string;
   /** Met: what is true. Unmet: what is missing, and how to supply it. */

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -1928,8 +1928,15 @@ export class MechanismService {
     // Demanding a drawn arrow on top of that refused analyses that meant
     // something.
     const loads = this.forces.filter((force) => analysable.has(force.link?.id));
+    // Any body's mass, not only a RealLink's: the solver hangs a slider block's
+    // weight from gravity too, so a drawing whose only massive body is a block
+    // is genuinely loaded. (The massless *warning* above stays about links --
+    // every block starts massless and naming them all would be noise.)
     const weighted = this.links.some(
-      (link) => link instanceof RealLink && analysable.has(link.id) && link.mass > 0
+      (link) =>
+        (link instanceof RealLink || link instanceof SliderBlock) &&
+        analysable.has(link.id) &&
+        link.mass > 0
     );
     const gravityLoads = this.settingsService.isGravity.value && weighted;
     requirements.push({

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -300,7 +300,7 @@ export class MechanismService {
           partition.links,
           partition.forces,
           this.ics,
-          true,
+          this.settingsService.isGravity.value,
           unitStr,
           this.inputVelocityFor(partition)
         )
@@ -1903,12 +1903,16 @@ export class MechanismService {
         .filter((_, index) => this.mechanisms[index]?.isMechanismValid())
         .flatMap((partition) => partition.links.map((link) => link.id))
     );
+    // A massless link is a legitimate idealization -- the solver simply skips
+    // its weight and inertia -- so this is a warning, not a gate. It is worth
+    // one, because zero is the mass nobody chose: every link starts there.
     const massless = this.links.filter(
       (link) => link instanceof RealLink && analysable.has(link.id) && !(link.mass > 0)
     ) as RealLink[];
     requirements.push({
       met: massless.length === 0,
-      title: 'Mass on every link',
+      warning: true,
+      title: 'Massless links',
       body:
         massless.length === 0
           ? 'Every link has a mass and a moment of inertia.'
@@ -1916,19 +1920,29 @@ export class MechanismService {
               .map((link) => link.name || link.id)
               .join(
                 ', '
-              )} still ${massless.length === 1 ? 'weighs' : 'weigh'} nothing. A massless link contributes no inertia, so a dynamic answer will not account for it. Set Link Mass in Mass Settings.`,
+              )} ${massless.length === 1 ? 'weighs' : 'weigh'} nothing, so gravity and inertia pass ${massless.length === 1 ? 'it' : 'them'} by. Fine for an idealized bar — set Link Mass in Mass Settings to include ${massless.length === 1 ? 'it' : 'them'}.`,
     });
 
-    // And a force has to be on one of them: a load attached to a linkage that
-    // cannot run says nothing about the one that can.
+    // Something has to load the linkage, but weight counts: with gravity on,
+    // a link with mass hangs from it, and that is a complete static problem.
+    // Demanding a drawn arrow on top of that refused analyses that meant
+    // something.
     const loads = this.forces.filter((force) => analysable.has(force.link?.id));
+    const weighted = this.links.some(
+      (link) => link instanceof RealLink && analysable.has(link.id) && link.mass > 0
+    );
+    const gravityLoads = this.settingsService.isGravity.value && weighted;
     requirements.push({
-      met: loads.length > 0,
+      met: loads.length > 0 || gravityLoads,
       title: 'A load to react against',
       body:
         loads.length > 0
           ? `${loads.length} ${loads.length === 1 ? 'force is' : 'forces are'} applied.`
-          : 'Without an applied force the only load is the drive itself, so every reaction comes from it. Right-click a link and choose Attach Force to add one.',
+          : gravityLoads
+            ? 'Gravity loads the links that have mass.'
+            : this.settingsService.isGravity.value
+              ? 'Nothing loads this mechanism yet: no force is applied and every link is massless. Right-click a link and choose Attach Force, or give a link mass — gravity is on, so weight alone is a load.'
+              : 'Nothing loads this mechanism: gravity is off and no force is applied. Right-click a link and choose Attach Force, or turn gravity on in Settings and give a link mass.',
     });
 
     return requirements;
@@ -1936,7 +1950,9 @@ export class MechanismService {
 
   /** Can the Force tab show anything worth reading? */
   forceAnalysisReady(): boolean {
-    return this.forceAnalysisRequirements().every((requirement) => requirement.met);
+    return this.forceAnalysisRequirements().every(
+      (requirement) => requirement.met || requirement.warning === true
+    );
   }
 
   /** What to say about geometry that is in no mechanism. */

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -90,7 +90,21 @@ export class SettingsService {
   isSnapToAlignment = new BehaviorSubject(readStoredFlag('snapToAlignment', true));
 
   isShowID = new BehaviorSubject(false);
-  isShowCOM = new BehaviorSubject(false);
+  /**
+   * On by default, and remembered on this machine rather than in the URL: the
+   * mark only appears on links that have been given mass — a massless link has
+   * no centre of mass worth pointing at — so a fresh drawing shows nothing
+   * extra, and a link given weight announces it. Nearly every circulating URL
+   * carries the *old* default (off) in its stored bit, which is why the bit is
+   * no longer read: a display preference should not travel with the drawing.
+   */
+  isShowCOM = new BehaviorSubject(readStoredFlag('showCoM', true));
+  /**
+   * Whether weight loads the mechanism. On by default — every link with mass
+   * hangs from it — and recorded in the URL when turned off, so a shared
+   * analysis means the same thing on arrival.
+   */
+  isGravity = new BehaviorSubject(true);
   /**
    * A link whose centre of mass to draw while the reader is asking about it.
    *

--- a/src/app/services/transcoding/mechanism-builder.ts
+++ b/src/app/services/transcoding/mechanism-builder.ts
@@ -324,7 +324,10 @@ export class MechanismBuilder {
         this.transcoder.getBoolSetting(BoolSetting.IS_SHOW_MINOR_GRID)
       );
       this.settings.isShowID.next(this.transcoder.getBoolSetting(BoolSetting.IS_SHOW_ID));
-      this.settings.isShowCOM.next(this.transcoder.getBoolSetting(BoolSetting.IS_SHOW_COM));
+      // IS_SHOW_COM is deliberately not read any more: it is a display
+      // preference, kept on this machine, and nearly every circulating URL
+      // carries the old default in that bit (settings.service.ts).
+      this.settings.isGravity.next(!this.transcoder.getBoolSetting(BoolSetting.GRAVITY_OFF));
       // The URL stores the user-unit object scale; the internal one is
       // MODEL_SCALE times larger, like every other length.
       SettingsService._objectScale.next(

--- a/src/app/services/transcoding/stored-settings.ts
+++ b/src/app/services/transcoding/stored-settings.ts
@@ -28,6 +28,12 @@ export enum DecimalSetting {
 
 export enum BoolSetting {
   IS_INPUT_CW,
+  /**
+   * Dead slot. Written in an early era, then ignored once gravity was
+   * hardcoded on, so the bit in circulating URLs carries whatever that era
+   * wrote. Gravity lives in GRAVITY_OFF below — do not revive this slot, and
+   * do not reorder it away: the flags are packed by position.
+   */
   IS_GRAVITY,
   ANIMATING,
   IS_SHOW_MAJOR_GRID,
@@ -35,4 +41,11 @@ export enum BoolSetting {
   IS_SHOW_ID,
   IS_SHOW_COM,
   IS_FORCES,
+  /**
+   * Appended, and inverted on purpose: every URL written before this flag
+   * existed unpacks it as false, and false has to keep meaning what those URLs
+   * have always meant — gravity on. Turning gravity *off* is the choice worth
+   * recording.
+   */
+  GRAVITY_OFF,
 }

--- a/src/app/services/url-generation.service.ts
+++ b/src/app/services/url-generation.service.ts
@@ -196,7 +196,9 @@ export class UrlGenerationService {
       );
       encoder.addEnumSetting(EnumSetting.GLOBAL_UNIT, GlobalUnit, normalizedGlobal);
       encoder.addBoolSetting(BoolSetting.IS_INPUT_CW, this.settings.isInputCW.getValue());
-      //encoder.addBoolSetting(BoolSetting.IS_GRAVITY, this.settings.isGravity.getValue());
+      // Inverted on purpose: false is what every pre-flag URL unpacks, and
+      // false has to keep meaning gravity on (see stored-settings.ts).
+      encoder.addBoolSetting(BoolSetting.GRAVITY_OFF, !this.settings.isGravity.getValue());
       encoder.addIntSetting(IntSetting.INPUT_SPEED, this.settings.inputSpeed.getValue());
       encoder.addDecimalSetting(
         DecimalSetting.LINEAR_INPUT_SPEED,
@@ -211,7 +213,10 @@ export class UrlGenerationService {
         this.settings.isShowMinorGrid.getValue()
       );
       encoder.addBoolSetting(BoolSetting.IS_SHOW_ID, this.settings.isShowID.getValue());
-      encoder.addBoolSetting(BoolSetting.IS_SHOW_COM, this.settings.isShowCOM.getValue());
+      // Frozen at the old default: the CoM toggle is a machine-local display
+      // preference now and the decoder no longer reads this bit. Writing the
+      // live value would churn every generated URL for a bit nobody consumes.
+      encoder.addBoolSetting(BoolSetting.IS_SHOW_COM, false);
       encoder.addDecimalSetting(DecimalSetting.SCALE, this.settings.objectScale / MODEL_SCALE);
 
       encoder.addIntSetting(IntSetting.TIMESTEP, cachedAnimationFrame);

--- a/src/test-utils/mechanism-harness.ts
+++ b/src/test-utils/mechanism-harness.ts
@@ -21,6 +21,8 @@ import { SynthesisBuilderService } from '../app/services/synthesis/synthesis-bui
 export interface MechanismHarness {
   service: MechanismService;
   active: ActiveObjService;
+  /** The service's own settings, for specs that flip gravity or units. */
+  settings: SettingsService;
   /**
    * How many undo entries the service has asked for.
    *
@@ -57,7 +59,7 @@ export function createMechanismHarness(): MechanismHarness {
     get: (token: unknown) => (token === DragStateService ? dragState : history),
   } as unknown as Injector;
   service = new MechanismService(grid, active, injector, settings, parser);
-  return { service, active, saveCount: () => saves };
+  return { service, active, settings, saveCount: () => saves };
 }
 
 /**

--- a/src/test-utils/verification/force-fixtures.ts
+++ b/src/test-utils/verification/force-fixtures.ts
@@ -57,8 +57,9 @@ export function punchPressFixture(): MechanismFixture {
  * held by a *tie bar* is what a crane looks like in a drawing and is a
  * structure, not a mechanism — two bars and the ground make a triangle, and a
  * triangle has nothing to analyse. Luffing it with a **ram** moves, but the
- * force analysis reports an unsupported topology for a sealed cylinder, and a
- * force demonstration whose force panel is empty is not one.
+ * force analysis of the day reported an unsupported topology for a sealed
+ * cylinder (it solves one now — see cylinder-forces.spec.ts), and a force
+ * demonstration whose force panel is empty is not one.
  *
  * So it luffs on a crank and a link, which is how a derrick actually raises its
  * boom, and every joint in it is a pin. The point on a force panel is the size

--- a/src/tests/verification/cylinder-forces.spec.ts
+++ b/src/tests/verification/cylinder-forces.spec.ts
@@ -1,0 +1,69 @@
+import '../../app/model/joint';
+import { MODEL_SCALE } from '../../app/model/render-scale';
+import { buildMechanismAtScale } from '../../test-utils/verification/fixture';
+import { cylinderBoomFixture } from '../../test-utils/verification/slot-fixtures';
+
+// Force analysis of a sealed cylinder, checked against the oldest result in
+// statics: the two-force member.
+//
+// The cylinder assembly — barrel, rod, block — touches the rest of the world at
+// exactly two pins, its mounts, and (with gravity off) carries no load of its
+// own. Every statics text solves machines like this boom by replacing the
+// cylinder with a force along the line between its mounts; if the matrix
+// solver is right, that property has to fall out of it rather than be put in.
+// It exercises the floating-carrier side of the guide couple too, since a
+// sealed cylinder's slot is cut into the moving barrel.
+
+describe('force analysis of a sealed cylinder', () => {
+  const build = () => {
+    // At the drawing scale the driven-cylinder kinematics suite pins: a
+    // cylinder's stroke is measured against objectScale, and at the wrong one
+    // the ram has no travel and the mechanism never runs at all.
+    const fixture = cylinderBoomFixture(MODEL_SCALE);
+    // A weight hung on the boom tip. The cylinder itself stays unloaded, which
+    // is what makes it a two-force member.
+    fixture.load = { onLink: 'OC', at: [0, 4 * MODEL_SCALE], vector: [0, -300] };
+    return buildMechanismAtScale(fixture, 1 * MODEL_SCALE).mechanism;
+  };
+
+  it('solves every frame of the loaded cylinder-driven boom', () => {
+    const series = build().getForceAnalysis('static');
+    expect(series.diagnostic).toBeUndefined();
+    expect(series.successfulFrames).toBe(series.frames.length);
+    expect(series.frames.length).toBeGreaterThan(100);
+  });
+
+  it('acts as a two-force member: mount reactions along the mount line', () => {
+    const mechanism = build();
+    const series = mechanism.getForceAnalysis('static');
+
+    series.frames.forEach((frame, t) => {
+      const at = (id: string) => mechanism.joints[t].find((joint) => joint.id === id)!;
+      const g = at('G');
+      const c = at('C');
+      const span = Math.hypot(c.x - g.x, c.y - g.y);
+      const along = [(c.x - g.x) / span, (c.y - g.y) / span];
+
+      // The world pushing on the barrel at its mount, and the boom pushing on
+      // the rod at the other: the only two external forces on the assembly.
+      const onBarrel = frame.jointReactionsByLink.get('G')!.get('GN')!;
+      const onRod = frame.jointReactionsByLink.get('C')!.get('PC')!;
+
+      expect(onBarrel[0] + onRod[0]).toBeCloseTo(0, 6);
+      expect(onBarrel[1] + onRod[1]).toBeCloseTo(0, 6);
+      const magnitude = Math.hypot(onBarrel[0], onBarrel[1]);
+      expect(magnitude).toBeGreaterThan(0);
+      const cross = onBarrel[0] * along[1] - onBarrel[1] * along[0];
+      expect(Math.abs(cross) / magnitude).toBeLessThan(1e-8);
+    });
+  });
+
+  it('obeys the third law where the rod meets the boom', () => {
+    const frame = build().getForceAnalysis('static').frames[30];
+    const atMount = frame.jointReactionsByLink.get('C')!;
+    const onRod = atMount.get('PC')!;
+    const onBoom = atMount.get('OC')!;
+    expect(onRod[0] + onBoom[0]).toBeCloseTo(0, 8);
+    expect(onRod[1] + onBoom[1]).toBeCloseTo(0, 8);
+  });
+});

--- a/src/tests/verification/force-power-balance.spec.ts
+++ b/src/tests/verification/force-power-balance.spec.ts
@@ -1,0 +1,204 @@
+import '../../app/model/joint';
+import { PrisJoint, RealJoint } from '../../app/model/joint';
+import { RealLink, SliderBlock } from '../../app/model/link';
+import { ForceAnalysisMode } from '../../app/model/mechanism/force-solver';
+import { KinematicsSolver } from '../../app/model/mechanism/kinematic-solver';
+import { siUnitFactors } from '../../app/model/unit-conversions';
+import { MODEL_SCALE } from '../../app/model/render-scale';
+import { buildMechanismAtScale, MechanismFixture } from '../../test-utils/verification/fixture';
+import {
+  offsetLoadFourBarFixture,
+  punchPressFixture,
+} from '../../test-utils/verification/force-fixtures';
+import {
+  cylinderBoomFixture,
+  loadedInvertedSliderCrankFixture,
+  scotchYokeFixture,
+  SLOT_RISE,
+  YOKE_CRANK,
+} from '../../test-utils/verification/slot-fixtures';
+
+// Virtual work, as an independent audit of the whole force analysis.
+//
+// The equilibrium solve and this check share no arithmetic: one balances
+// forces and moments body by body, the other multiplies the same answers by
+// velocities — which are the kinematics the MATLAB suites verify — and asks
+// for energy accounting. In statics the input's power must exactly cancel the
+// applied loads'; in dynamics the difference must be the rate of change of
+// kinetic energy. A sign error, a wrong moment arm, or a misplaced unit factor
+// in any reaction path breaks this on nearly every frame of every mechanism,
+// which is what makes it worth running across one specimen of each topology
+// class rather than on a single blessed example.
+
+const GRAVITY = 9.80665;
+
+interface Audit {
+  name: string;
+  fixture: () => MechanismFixture;
+}
+
+const loadedScotchYoke = (): MechanismFixture => {
+  const fixture = scotchYokeFixture();
+  fixture.load = { onLink: 'CD', at: [YOKE_CRANK, SLOT_RISE], vector: [40, 0] };
+  return fixture;
+};
+
+// The cylinder's geometry has to be drawn at the solving objectScale, or the
+// ram has no travel and the mechanism never runs (see driven-cylinder.spec.ts).
+const loadedCylinderBoom = (): MechanismFixture => {
+  const fixture = cylinderBoomFixture(MODEL_SCALE);
+  fixture.load = { onLink: 'OC', at: [0, 4 * MODEL_SCALE], vector: [0, -300] };
+  return fixture;
+};
+
+const AUDITS: Audit[] = [
+  { name: 'pin-jointed four-bar with an offset load', fixture: offsetLoadFourBarFixture },
+  { name: 'slider-crank punch press', fixture: punchPressFixture },
+  { name: 'inverted slider-crank with a floating slot', fixture: loadedInvertedSliderCrankFixture },
+  { name: 'welded Scotch yoke', fixture: loadedScotchYoke },
+  { name: 'sealed cylinder boom', fixture: loadedCylinderBoom },
+];
+
+/**
+ * Worst relative power imbalance across the cycle, and how many frames could
+ * be audited at all (a frame the solver refused, or whose analytic kinematics
+ * are incomplete, proves nothing either way and is not counted).
+ */
+function audit(fixture: MechanismFixture, mode: ForceAnalysisMode) {
+  const { mechanism } = buildMechanismAtScale(fixture, 1 * MODEL_SCALE);
+  const series = mechanism.getForceAnalysis(mode);
+  const units = siUnitFactors(mechanism.unit);
+  KinematicsSolver.resetVariables();
+  KinematicsSolver.requiredLoops = mechanism.requiredLoops;
+
+  let audited = 0;
+  let worst = 0;
+  for (let t = 0; t < series.frames.length; t++) {
+    const frame = series.frames[t];
+    if (frame.status !== 'ok' || !frame.inputEffort) continue;
+    KinematicsSolver.determineKinematics(
+      mechanism.joints[t],
+      mechanism.links[t],
+      mechanism.inputAngularVelocities[t]
+    );
+
+    const terms: number[] = [];
+    let complete = true;
+    const need = (value: number | undefined): number => {
+      if (value === undefined || !Number.isFinite(value)) {
+        complete = false;
+        return 0;
+      }
+      return value;
+    };
+
+    // What the input feeds in. A force drive is an internal pair — it pushes
+    // the block and its carrier apart — so its power is the force times the
+    // *extension* rate, the block's velocity relative to the material point of
+    // the carrier it is passing. Against the world a grounded guide's carrier
+    // term is simply zero.
+    if (frame.inputEffort.kind === 'torque') {
+      terms.push(frame.inputEffort.valueSI * mechanism.inputAngularVelocities[t]);
+    } else {
+      const slider = mechanism.joints[t].find(
+        (joint): joint is PrisJoint => joint instanceof PrisJoint && joint.input
+      )!;
+      const block = mechanism.links[t].find(
+        (link): link is SliderBlock =>
+          link instanceof SliderBlock && link.joints.some((joint) => joint.id === slider.id)
+      )!;
+      const pin = block.joints.find((joint) => !(joint instanceof PrisJoint))!;
+      const velocity = KinematicsSolver.jointVelMap.get(pin.id);
+      let relative = [need(velocity?.[0]), need(velocity?.[1])];
+      const carrier = slider.isFloating
+        ? mechanism.links[t].find((link) => link.id === slider.carrier?.id)
+        : undefined;
+      if (carrier instanceof RealLink) {
+        const carrierVelocity = KinematicsSolver.linkVelMap.get(carrier.id);
+        const omega = need(KinematicsSolver.linkAngVelMap.get(carrier.id));
+        relative = [
+          relative[0] - (need(carrierVelocity?.[0]) - omega * (pin.y - carrier.CoM.y)),
+          relative[1] - (need(carrierVelocity?.[1]) + omega * (pin.x - carrier.CoM.x)),
+        ];
+      }
+      const rate =
+        relative[0] * Math.cos(slider.slotAngle) + relative[1] * Math.sin(slider.slotAngle);
+      terms.push(frame.inputEffort.valueSI * rate * units.distanceToM);
+    }
+
+    // What the loads and gravity feed in, through the moving material points.
+    for (const link of mechanism.links[t]) {
+      if (link instanceof RealLink) {
+        const comVelocity = KinematicsSolver.linkVelMap.get(link.id);
+        const omega = need(KinematicsSolver.linkAngVelMap.get(link.id));
+        for (const force of link.forces) {
+          const fx = force.mag * Math.cos(force.angleRad) * units.forceToN;
+          const fy = force.mag * Math.sin(force.angleRad) * units.forceToN;
+          const vx = need(comVelocity?.[0]) - omega * (force.startCoord.y - link.CoM.y);
+          const vy = need(comVelocity?.[1]) + omega * (force.startCoord.x - link.CoM.x);
+          terms.push((fx * vx + fy * vy) * units.distanceToM);
+        }
+        if (mechanism.gravity) {
+          terms.push(
+            -link.mass * units.massToKg * GRAVITY * need(comVelocity?.[1]) * units.distanceToM
+          );
+        }
+      } else if (link instanceof SliderBlock && mechanism.gravity) {
+        const pin = link.joints.find((joint) => !(joint instanceof PrisJoint));
+        const velocity = pin && KinematicsSolver.jointVelMap.get(pin.id);
+        terms.push(-link.mass * units.massToKg * GRAVITY * need(velocity?.[1]) * units.distanceToM);
+      }
+    }
+
+    // What motion soaks up: the rate of change of kinetic energy.
+    let kineticRate = 0;
+    if (mode === 'dynamic') {
+      for (const link of mechanism.links[t]) {
+        if (link instanceof RealLink) {
+          const velocity = KinematicsSolver.linkVelMap.get(link.id);
+          const acceleration = KinematicsSolver.linkAccMap.get(link.id);
+          kineticRate +=
+            link.mass *
+            units.massToKg *
+            (need(velocity?.[0]) * need(acceleration?.[0]) +
+              need(velocity?.[1]) * need(acceleration?.[1])) *
+            units.distanceToM ** 2;
+          kineticRate +=
+            link.massMoI *
+            units.inertiaToKgM2 *
+            need(KinematicsSolver.linkAngVelMap.get(link.id)) *
+            need(KinematicsSolver.linkAngAccMap.get(link.id));
+        } else if (link instanceof SliderBlock) {
+          const pin = link.joints.find((joint) => !(joint instanceof PrisJoint));
+          const velocity = pin && KinematicsSolver.jointVelMap.get(pin.id);
+          const acceleration = pin && KinematicsSolver.jointAccMap.get(pin.id);
+          kineticRate +=
+            link.mass *
+            units.massToKg *
+            (need(velocity?.[0]) * need(acceleration?.[0]) +
+              need(velocity?.[1]) * need(acceleration?.[1])) *
+            units.distanceToM ** 2;
+        }
+      }
+    }
+
+    if (!complete) continue;
+    audited++;
+    const supplied = terms.reduce((sum, term) => sum + term, 0);
+    const scale = Math.max(1e-9, ...terms.map(Math.abs), Math.abs(kineticRate));
+    worst = Math.max(worst, Math.abs(supplied - kineticRate) / scale);
+  }
+  return { audited, total: series.frames.length, worst };
+}
+
+describe('power balance across every topology class', () => {
+  for (const { name, fixture } of AUDITS) {
+    for (const mode of ['static', 'dynamic'] as ForceAnalysisMode[]) {
+      it(`${name}: ${mode} analysis conserves power`, () => {
+        const result = audit(fixture(), mode);
+        expect(result.audited).toBeGreaterThan(result.total * 0.9);
+        expect(result.worst).toBeLessThan(1e-6);
+      });
+    }
+  }
+});

--- a/src/tests/verification/force-setup-help.spec.ts
+++ b/src/tests/verification/force-setup-help.spec.ts
@@ -1,8 +1,8 @@
 // joint.ts first: the model modules form an import cycle that only
 // initializes cleanly when entered here (see test-utils/verification/fixture.ts).
 import '../../app/model/joint';
-import { RevJoint } from '../../app/model/joint';
-import { RealLink } from '../../app/model/link';
+import { PrisJoint, RevJoint } from '../../app/model/joint';
+import { RealLink, SliderBlock } from '../../app/model/link';
 import { FlagPacker } from '../../app/services/transcoding/flag-packer';
 import { BoolSetting } from '../../app/services/transcoding/stored-settings';
 import { createMechanismHarness, MechanismHarness } from '../../test-utils/mechanism-harness';
@@ -120,6 +120,45 @@ describe('force analysis setup, as a fresh drawing meets it', () => {
     );
     expect(weightOn).toBe(true);
     expect(weightOff).toBe(true);
+  });
+});
+
+describe('mass on a slider block', () => {
+  it('counts as weight, the same as the solver counts it', () => {
+    // A slider-crank whose only mass is the piston itself: the solver hangs
+    // that mass from gravity, so setup has to call the mechanism loaded.
+    const harness = createMechanismHarness();
+    const at: [number, number][] = [
+      [0, 0],
+      [1, 1],
+      [3, 0],
+    ];
+    const joints = at.map(([x, y], i) => new RevJoint('ABC'[i], x, y));
+    joints[0].ground = true;
+    joints[0].input = true;
+    const links = [0, 1].map((i) => {
+      const link = new RealLink(joints[i].id + joints[i + 1].id, [joints[i], joints[i + 1]]);
+      joints[i].links.push(link);
+      joints[i + 1].links.push(link);
+      joints[i].connectedJoints.push(joints[i + 1]);
+      joints[i + 1].connectedJoints.push(joints[i]);
+      return link;
+    });
+    // The block and its grounded guide, wired the way the fixture builder
+    // wires them: pin C rides in a horizontal slot fixed to the world.
+    const pris = new PrisJoint('P', joints[2].x, joints[2].y, false, true);
+    pris.angle_rad = 0;
+    pris.connectedJoints.push(joints[2]);
+    joints[2].connectedJoints.push(pris);
+    const block = new SliderBlock('CP', [joints[2], pris], 3);
+    pris.links.push(block);
+    joints[2].links.push(block);
+    harness.service.joints.push(...joints, pris);
+    harness.service.links.push(...links, block);
+    harness.service.updateMechanism();
+
+    const load = row(harness, 'A load to react against');
+    expect(load.met).toBe(true);
   });
 });
 

--- a/src/tests/verification/force-setup-help.spec.ts
+++ b/src/tests/verification/force-setup-help.spec.ts
@@ -1,0 +1,143 @@
+// joint.ts first: the model modules form an import cycle that only
+// initializes cleanly when entered here (see test-utils/verification/fixture.ts).
+import '../../app/model/joint';
+import { RevJoint } from '../../app/model/joint';
+import { RealLink } from '../../app/model/link';
+import { FlagPacker } from '../../app/services/transcoding/flag-packer';
+import { BoolSetting } from '../../app/services/transcoding/stored-settings';
+import { createMechanismHarness, MechanismHarness } from '../../test-utils/mechanism-harness';
+
+// What the Force tab asks for before it will call itself ready, now that
+// gravity is a load and a massless link is an idealization rather than a sin.
+//
+// The situations here are the ones a fresh drawing actually walks through:
+// every link starts massless, gravity starts on, and no force is drawn. Each
+// step of giving the drawing weight should move exactly one row, and the tab
+// should come ready the moment there is genuinely something to solve.
+
+/** A crank-rocker with every link at the default mass of zero. */
+function fourBar(harness: MechanismHarness): RealLink[] {
+  const at: [number, number][] = [
+    [0, 0],
+    [0, 1],
+    [3, 2],
+    [4, 0],
+  ];
+  const joints = at.map(([x, y], i) => new RevJoint('ABCD'[i], x, y));
+  joints[0].ground = true;
+  joints[3].ground = true;
+  joints[0].input = true;
+  const links = [0, 1, 2].map((i) => {
+    const link = new RealLink(joints[i].id + joints[i + 1].id, [joints[i], joints[i + 1]]);
+    joints[i].links.push(link);
+    joints[i + 1].links.push(link);
+    joints[i].connectedJoints.push(joints[i + 1]);
+    joints[i + 1].connectedJoints.push(joints[i]);
+    return link;
+  });
+  harness.service.joints.push(...joints);
+  harness.service.links.push(...links);
+  harness.service.updateMechanism();
+  return links;
+}
+
+const row = (harness: MechanismHarness, title: string) =>
+  harness.service.forceAnalysisRequirements().find((r) => r.title === title)!;
+
+describe('force analysis setup, as a fresh drawing meets it', () => {
+  it('starts unloaded: massless everywhere, gravity with nothing to pull on', () => {
+    const harness = createMechanismHarness();
+    fourBar(harness);
+
+    const load = row(harness, 'A load to react against');
+    expect(load.met).toBe(false);
+    // Both ways out, in one sentence each: draw a force, or give mass weight.
+    expect(load.body).toContain('Attach Force');
+    expect(load.body).toContain('mass');
+    expect(harness.service.forceAnalysisReady()).toBe(false);
+  });
+
+  it('comes ready the moment one link has mass, because gravity is a load', () => {
+    const harness = createMechanismHarness();
+    const links = fourBar(harness);
+    links[1].mass = 5;
+    harness.service.updateMechanism();
+
+    const load = row(harness, 'A load to react against');
+    expect(load.met).toBe(true);
+    expect(load.body).toContain('Gravity');
+    expect(harness.service.forceAnalysisReady()).toBe(true);
+  });
+
+  it('warns about the links still massless, without standing in the way', () => {
+    const harness = createMechanismHarness();
+    const links = fourBar(harness);
+    links[1].mass = 5;
+    harness.service.updateMechanism();
+
+    const massless = row(harness, 'Massless links');
+    expect(massless.met).toBe(false);
+    expect(massless.warning).toBe(true);
+    // Names the links, and says the idealization is allowed.
+    expect(massless.body).toContain('AB');
+    expect(massless.body).toContain('CD');
+    expect(harness.service.forceAnalysisReady()).toBe(true);
+  });
+
+  it('with gravity off, mass alone is no longer a load, and the message says so', () => {
+    const harness = createMechanismHarness();
+    const links = fourBar(harness);
+    links[1].mass = 5;
+    harness.settings.isGravity.next(false);
+    harness.service.updateMechanism();
+
+    const load = row(harness, 'A load to react against');
+    expect(load.met).toBe(false);
+    expect(load.body).toContain('gravity is off');
+    expect(harness.service.forceAnalysisReady()).toBe(false);
+  });
+
+  it('feeds the gravity setting into the solved mechanism itself', () => {
+    const on = createMechanismHarness();
+    const linksOn = fourBar(on);
+    linksOn.forEach((link) => (link.mass = 2));
+    on.service.updateMechanism();
+    const withGravity = on.service.mechanisms[0].getForceAnalysis('static');
+
+    const off = createMechanismHarness();
+    const linksOff = fourBar(off);
+    linksOff.forEach((link) => (link.mass = 2));
+    off.settings.isGravity.next(false);
+    off.service.updateMechanism();
+    const withoutGravity = off.service.mechanisms[0].getForceAnalysis('static');
+
+    expect(withGravity.successfulFrames).toBeGreaterThan(0);
+    const weightOn = [...withGravity.frames[0].jointReactions.values()].some(
+      ([x, y]) => Math.hypot(x, y) > 1e-6
+    );
+    const weightOff = [...withoutGravity.frames[0].jointReactions.values()].every(
+      ([x, y]) => Math.hypot(x, y) < 1e-9
+    );
+    expect(weightOn).toBe(true);
+    expect(weightOff).toBe(true);
+  });
+});
+
+describe('the GRAVITY_OFF flag against every URL already in circulation', () => {
+  it('unpacks as false — gravity on — from a token written before it existed', () => {
+    // Eight flags was the whole enum when today's URLs were written. Packing
+    // eight and unpacking nine is exactly what decoding an old URL does, and
+    // the ninth has to come back false, because false means what those URLs
+    // have always meant.
+    const oldEra = FlagPacker.pack([true, false, true, true, false, true, false, true]);
+    const decoded = FlagPacker.unpack(oldEra, 9);
+    expect(decoded[BoolSetting.GRAVITY_OFF]).toBe(false);
+    expect(decoded.slice(0, 8)).toEqual([true, false, true, true, false, true, false, true]);
+  });
+
+  it('keeps the token the same length, so no URL field shifts', () => {
+    const eight = FlagPacker.pack([true, false, true, true, false, true, false, true]);
+    const nine = FlagPacker.pack([true, false, true, true, false, true, false, true, false]);
+    expect(nine).toBe(eight);
+  });
+});

--- a/src/tests/verification/force-setup-help.spec.ts
+++ b/src/tests/verification/force-setup-help.spec.ts
@@ -123,6 +123,34 @@ describe('force analysis setup, as a fresh drawing meets it', () => {
   });
 });
 
+describe('what a fresh link weighs', () => {
+  it('starts with no mass and no moment of inertia', () => {
+    // MoI used to default to 1 while mass defaulted to 0, so a "massless" link
+    // still resisted angular acceleration — every dynamic analysis of a fresh
+    // drawing quietly carried unit inertia on every link.
+    const link = new RealLink('AB', [new RevJoint('A', 0, 0), new RevJoint('B', 1, 0)]);
+    expect(link.mass).toBe(0);
+    expect(link.massMoI).toBe(0);
+  });
+
+  it('so a fully massless mechanism takes no torque to drive', () => {
+    // No mass, no inertia, no gravity, no load: the drive has nothing to work
+    // against, and the dynamic input effort has to come out zero everywhere.
+    const harness = createMechanismHarness();
+    fourBar(harness);
+    harness.settings.isGravity.next(false);
+    harness.service.updateMechanism();
+
+    const series = harness.service.mechanisms[0].getForceAnalysis('dynamic');
+    expect(series.successfulFrames).toBeGreaterThan(0);
+    series.frames
+      .filter((frame) => frame.status === 'ok')
+      .forEach((frame) => {
+        expect(Math.abs(frame.inputEffort!.valueSI)).toBeLessThan(1e-9);
+      });
+  });
+});
+
 describe('mass on a slider block', () => {
   it('counts as weight, the same as the solver counts it', () => {
     // A slider-crank whose only mass is the piston itself: the solver hangs

--- a/src/tests/verification/readiness-checks.spec.ts
+++ b/src/tests/verification/readiness-checks.spec.ts
@@ -71,6 +71,26 @@ describe('why a mechanism will not run', () => {
     expect(check.body).toMatch(/Ground another joint, or connect a free joint to a second link/);
   });
 
+  it('points at the free end that carries the extra freedom', () => {
+    // Same loose chain: C hangs on one link, and that is where the second
+    // degree of freedom lives. The message should say so and offer the trip.
+    const readiness = checksFor({
+      joints: [
+        { id: 'A', x: 0, y: 0, ground: true, input: true },
+        { id: 'B', x: 1, y: 0 },
+        { id: 'C', x: 2, y: 0 },
+      ],
+      links: [{ joints: 'AB' }, { joints: 'BC' }],
+      inputAngVel: 1,
+    });
+
+    const [check] = readiness.checks;
+    expect(check.body).toContain('C');
+    expect(check.body).toMatch(/free end/i);
+    expect(check.at?.id).toBe('C');
+    expect(check.action).toBe('Go To Joint');
+  });
+
   it('reports the mobility first when a linkage is both loose and undriven', () => {
     // Both are wrong, and the order matters: giving this an input would not
     // make it run, so sending the reader to add one first wastes the fix.

--- a/src/tests/verification/slide-forces.spec.ts
+++ b/src/tests/verification/slide-forces.spec.ts
@@ -1,60 +1,139 @@
 import '../../app/model/joint';
 import { RealJoint } from '../../app/model/joint';
-import { ForceSolver } from '../../app/model/mechanism/force-solver';
-import { buildMechanism } from '../../test-utils/verification/fixture';
+import { RealLink } from '../../app/model/link';
+import { ForceAnalysisSeries, ForceSolver } from '../../app/model/mechanism/force-solver';
+import { Mechanism } from '../../app/model/mechanism/mechanism';
+import { buildMechanism, MechanismFixture } from '../../test-utils/verification/fixture';
 import {
   loadedInvertedSliderCrankFixture,
   scotchYokeFixture,
+  scotchYokeGuidedAtFarEndFixture,
+  SLOT_RISE,
+  swingingBlockFixture,
+  YOKE_CRANK,
 } from '../../test-utils/verification/slot-fixtures';
 
-// Phase 3 does not solve statics for a welded assembly, and says so rather than
-// producing a number (docs/phase-3-slide-spec.md §3.8, §9).
+// Statics through a welded slide assembly (docs/phase-3-slide-spec.md §9).
 //
-// The physics of why: a prismatic pair transmits a normal force *and* a couple.
-// While the block is a free-turning body with only two equations the couple
-// never appears; welded to a rider that has a moment equation, the guide has to
-// supply one, and there is no column for it.
+// A prismatic pair transmits a normal force *and* a couple. While the block is
+// a free-turning body the couple never appears; welded to a rider, the guide
+// has to supply one, and the solver now carries a column for it. Phase 3's
+// honest refusal is retired by the thing it was holding the door for.
+//
+// The check is against hand statics, not against the solver's own arithmetic.
+// For a yoke under a load (fx, fy) applied to the rider, with the crank pin B
+// riding the vertical slot and the guide pin at G:
+//
+//   - the slot passes the horizontal load through to the crank pin unchanged,
+//     so the crank feels torque      T = fx · y_B;
+//   - the load line misses the pin, and the guide couple closes the gap:
+//                                    τ = fx · (y_L − y_B) − fy · (x_L − x_G),
+//     counterclockwise-positive on the rider.
+//
+// Both are evaluated from the mechanism's own positions at each step — the
+// formulas are hand-derived, the coordinates are whatever the position solver
+// (with its four-decimal rounding) actually produced. τ barely depends on
+// where along the rider the guide sits, which is why the same two formulas
+// cover both yoke variants.
+
+/** Horizontal load on the yoke, newtons. */
+const P = 40;
+
+const loadedYoke = (fixture: MechanismFixture): Mechanism => {
+  fixture.load = { onLink: 'CD', at: [YOKE_CRANK, SLOT_RISE], vector: [P, 0] };
+  return buildMechanism(fixture).mechanism;
+};
+
+const everyFrameOk = (series: ForceAnalysisSeries): void => {
+  expect(series.diagnostic).toBeUndefined();
+  expect(series.successfulFrames).toBe(series.frames.length);
+  expect(series.frames.length).toBeGreaterThan(300);
+};
+
+/** Hand statics evaluated at timestep t's own (rounded) geometry. */
+const handStatics = (mechanism: Mechanism, t: number, guideId: string) => {
+  const at = (id: string) => mechanism.joints[t].find((joint) => joint.id === id)!;
+  const load = (mechanism.links[t].find((link) => link.id === 'CD') as RealLink).forces[0];
+  const fx = load.mag * Math.cos(load.angleRad);
+  const fy = load.mag * Math.sin(load.angleRad);
+  const pinHeight = at('B').y - at('A').y;
+  return {
+    torque: fx * pinHeight,
+    couple: fx * (load.startCoord.y - at('A').y - pinHeight) - fy * (load.startCoord.x - at(guideId).x),
+  };
+};
 
 describe('force analysis of a welded slide assembly', () => {
-  it('refuses, and names the joint responsible', () => {
-    const built = buildMechanism(scotchYokeFixture());
+  it('solves the loaded Scotch yoke, matching hand statics on every frame', () => {
+    const mechanism = loadedYoke(scotchYokeFixture());
+    const series = mechanism.getForceAnalysis('static');
+    everyFrameOk(series);
 
-    const result = ForceSolver.analyzeFrame(built.joints, built.links, 'static', false, 'm');
-
-    expect(result.status).toBe('unsupported-topology');
-    expect(result.message).toContain('C');
-    expect(result.message).toContain('moment');
+    series.frames.forEach((frame, t) => {
+      const expected = handStatics(mechanism, t, 'C');
+      expect(frame.inputEffort!.valueSI).toBeCloseTo(expected.torque, 6);
+      expect(frame.guideCouples.get('F')).toBeCloseTo(expected.couple, 6);
+    });
   });
 
-  it('refuses for a reason, not because the equation count happens to be off', () => {
-    // The count guard catches this too -- eight equations against seven
-    // unknowns -- but a count that happens to be wrong is not a reason, and it
-    // would fall silent the moment anything else made the numbers balance.
-    const built = buildMechanism(scotchYokeFixture());
+  it('reaches the same two numbers with the guide at the far end of the slot', () => {
+    // Kinematically identical, but the loop reaches the welded rider along a
+    // link edge instead of stepping straight onto the block — the same control
+    // the kinematics suite uses, now standing guard over the couple column.
+    const mechanism = loadedYoke(scotchYokeGuidedAtFarEndFixture());
+    const series = mechanism.getForceAnalysis('static');
+    everyFrameOk(series);
 
-    const result = ForceSolver.analyzeFrame(built.joints, built.links, 'static', false, 'm');
-
-    expect(result.message).not.toContain('equations');
+    series.frames.forEach((frame, t) => {
+      const expected = handStatics(mechanism, t, 'D');
+      expect(frame.inputEffort!.valueSI).toBeCloseTo(expected.torque, 6);
+      expect(frame.guideCouples.get('G')).toBeCloseTo(expected.couple, 6);
+    });
   });
 
-  it('refuses because of the weld, and nothing else about the mechanism', () => {
-    // "Not the Slide message" is too weak a control: an unrelated refusal would
-    // satisfy it. This is an A/B on one fixture instead -- Phase 2's loaded
-    // inverted slider-crank, which has a working force solution -- with the
-    // flag as the only difference between the two calls.
-    //
-    // The unwelded Scotch yoke cannot serve as the control: without its weld it
-    // is a DOF 2 linkage and its statics are underconstrained for reasons that
-    // have nothing to do with Phase 3.
-    const built = buildMechanism(loadedInvertedSliderCrankFixture());
-    const before = ForceSolver.analyzeFrame(built.joints, built.links, 'static', true, 'm');
+  it('passes the load across the slot with reactions equal and opposite', () => {
+    const mechanism = loadedYoke(scotchYokeFixture());
+    const frame = mechanism.getForceAnalysis('static').frames[45];
 
-    (built.joints.find((joint) => joint.id === 'B') as RealJoint).isWelded = true;
-    const after = ForceSolver.analyzeFrame(built.joints, built.links, 'static', true, 'm');
+    const acrossSlot = frame.jointReactionsByLink.get('E')!;
+    const onBlock = acrossSlot.get('BE') ?? [...acrossSlot.values()][0];
+    const onCarrier = acrossSlot.get('CD') ?? [...acrossSlot.values()][1];
+    expect(onBlock[0] + onCarrier[0]).toBeCloseTo(0, 8);
+    expect(onBlock[1] + onCarrier[1]).toBeCloseTo(0, 8);
+    // And the carrier-side force is the load, passed through unchanged.
+    expect(Math.hypot(onCarrier[0], onCarrier[1])).toBeCloseTo(P, 3);
+    expect(onCarrier[0]).toBeLessThan(0);
+  });
 
-    expect(before.status, 'solves as a Slot').toBe('ok');
-    expect(before.jointReactions.size).toBeGreaterThan(0);
-    expect(after.status, 'refuses as a Slide').toBe('unsupported-topology');
-    expect(after.message).toContain('B');
+  it('solves a slide whose guide is cut into a moving link', () => {
+    // The swinging-block engine: rider welded to a block sliding in a link
+    // that itself pivots. The couple's reaction lands on that carrier rather
+    // than on the world — the −1 side of the column, which no grounded-guide
+    // yoke can reach. Its kinematics are still refused (spec §4), so this is
+    // the statics of the drawn pose.
+    const fixture = swingingBlockFixture();
+    fixture.load = { onLink: 'BR', at: [YOKE_CRANK, 0], vector: [30, 0] };
+    const built = buildMechanism(fixture);
+
+    const frame = ForceSolver.analyzeFrame(built.joints, built.links, 'static', false, 'm');
+
+    expect(frame.status).toBe('ok');
+    expect(frame.guideCouples.size).toBe(1);
+    expect([...frame.guideCouples.values()].every(Number.isFinite)).toBe(true);
+    expect(frame.residual).toBeLessThanOrEqual(1e-8);
+  });
+
+  it('still refuses a weld that turns the mechanism into a structure', () => {
+    // Welding the inverted slider-crank's pin makes crank and block one rigid
+    // body: DOF 0, a structure. Its statics are indeterminate — an input
+    // effort has nowhere to go — and the honest answer is a refusal, not a
+    // number.
+    const welded = buildMechanism(loadedInvertedSliderCrankFixture());
+    (welded.joints.find((joint) => joint.id === 'B') as RealJoint).isWelded = true;
+
+    const frame = ForceSolver.analyzeFrame(welded.joints, welded.links, 'static', true, 'm');
+
+    expect(frame.status).toBe('unsupported-topology');
+    expect(frame.message).toContain('equations');
   });
 });

--- a/src/tests/verification/slide-forces.spec.ts
+++ b/src/tests/verification/slide-forces.spec.ts
@@ -39,8 +39,12 @@ import {
 /** Horizontal load on the yoke, newtons. */
 const P = 40;
 
-const loadedYoke = (fixture: MechanismFixture): Mechanism => {
-  fixture.load = { onLink: 'CD', at: [YOKE_CRANK, SLOT_RISE], vector: [P, 0] };
+const loadedYoke = (
+  fixture: MechanismFixture,
+  at: [number, number] = [YOKE_CRANK, SLOT_RISE],
+  vector: [number, number] = [P, 0]
+): Mechanism => {
+  fixture.load = { onLink: 'CD', at, vector };
   return buildMechanism(fixture).mechanism;
 };
 
@@ -88,6 +92,22 @@ describe('force analysis of a welded slide assembly', () => {
       const expected = handStatics(mechanism, t, 'D');
       expect(frame.inputEffort!.valueSI).toBeCloseTo(expected.torque, 6);
       expect(frame.guideCouples.get('G')).toBeCloseTo(expected.couple, 6);
+    });
+  });
+
+  it('carries a tilted, offset load: the transverse term reaches the couple', () => {
+    // The first two sweeps have fy = 0 and the load directly above the guide
+    // pin, so the −fy·(x_L − x_G) term of the couple is silently zero and a
+    // solver that dropped it would still pass them. This load is tilted and
+    // hung 0.6 to the side, so both terms carry weight on every frame.
+    const mechanism = loadedYoke(scotchYokeFixture(), [YOKE_CRANK + 0.6, 0.9], [P, -25]);
+    const series = mechanism.getForceAnalysis('static');
+    everyFrameOk(series);
+
+    series.frames.forEach((frame, t) => {
+      const expected = handStatics(mechanism, t, 'C');
+      expect(frame.inputEffort!.valueSI).toBeCloseTo(expected.torque, 6);
+      expect(frame.guideCouples.get('F')).toBeCloseTo(expected.couple, 6);
     });
   });
 


### PR DESCRIPTION
Force analysis for cylinders and welded slides, and setup help that names the fix. Five commits, each reviewed by GPT-5.6 sol with its findings folded back in.

## Cylinders and Scotch yokes now solve (b11d903, a8c47b4)

Every sealed cylinder is a welded slide, so six of the 25 built-in templates refused force analysis with one vague sentence. Three model changes:

- **The guide couple.** A welded prismatic pair transmits a moment the equation set had no column for (the phase-3 §3.8 deferral). One `GuideCouple` unknown per welded slide enters the rider's moment row, and the carrier's when the slot is cut into a moving link. Rider and block stay separate bodies — the block is zero-length, so the couple passes through it untouched and no merged-body bookkeeping is needed. Exposed as `guideCouples` on each frame (N·m, CCW-positive on the rider).
- **The actuator is an internal pair.** A drive force was applied to the block as an external push from the world; a real actuator pushes its own barrel. Without the carrier-side reaction a sealed cylinder was not a two-force member between its mounts.
- **Diagnostics pass through.** `analyzeMechanism` used to reduce every refusal to "this topology does not have a determinate force-equilibrium model"; the frame's specific message (naming the weld joint) now reaches the panel.

**All 25 templates now solve every frame in both modes** (was 19).

Verification is the shape §9 asked for, plus one independent method:
- `slide-forces.spec.ts` — hand-derived torque and guide couple swept over every frame of two loaded Scotch yokes (including a tilted, offset load so the transverse couple term carries weight); the floating-carrier swinging block; and the weld that turns a mechanism into a structure still refuses.
- `cylinder-forces.spec.ts` — the loaded boom's mount reactions are equal, opposite, and collinear with the mounts on every frame: the two-force member falls out of the matrix rather than being put in.
- `force-power-balance.spec.ts` — virtual-work audit across all five topology classes in both modes, priced against the MATLAB-verified kinematics. Input power must cancel load power in statics and equal the kinetic-energy rate in dynamics.

## Setup help for real stuck cases (c9e14e4, 41ae012)

- **Gravity is a setting again**: on by default, toggle in Settings, rebuilds and saves (undoable), and refreshes open force graphs and an open Settings panel after undo. Recorded in the URL as an appended `GRAVITY_OFF` flag, inverted so every circulating URL keeps meaning what it always has (gravity on); the dead `IS_GRAVITY` slot stays dead. Nine flags pack into the same two characters eight did, so generated URLs are byte-identical.
- **Weight counts as a load**: an applied force or (gravity on + any body with mass — slider blocks included) satisfies "A load to react against". A fully unloaded drawing gets a message naming both ways out.
- **Massless links warn instead of blocking**: zero mass is the textbook idealization and the solver never needed the gate. The row still names the links but no longer counts toward "N to set" or holds the Ready chip.
- **CoM marks**: the view toggle defaults on and persists per machine (the URL bit is frozen and ignored — nearly every circulating URL carries the old default); the mark only draws on links that have mass.
- **Culprits by name**: mobility points at the free end carrying the extra freedom (binary links only, so tracer points are never blamed) with a Go To button; the over-constrained case mentions unwelding when a weld exists; nothing-can-move names the joints the ordering never reached; cycle-never-closes reports how near the loop came to closing; the solver names which link's mass or force is invalid; the equation-count refusal explains over- vs under-support instead of matrix dimensions.
- **Chart gaps explained**: a force series with singular frames mid-cycle says how many positions have no solution and why (toggle positions), instead of a silent hole.

## A fresh link starts with no inertia (bc98e6e)

MoI defaulted to 1 while mass defaulted to 0, so every dynamic analysis of a fresh drawing quietly carried unit inertia on every link. Now both default to zero; the URL codec stores MoI per link, so only freshly drawn links are affected. Pinned by a test that a fully massless, unloaded, gravity-free four-bar takes exactly zero torque to drive.

Deliberately **not** in this PR: cylinder mass fields in the Edit Cylinder panel (the mass-setting UI is getting an overhaul later; the model already carries barrel, rod, and head masses separately and the solver handles all three).

## Verification

- Full suite: **1017 tests across 117 files**, green.
- Browser (built app): all 25 templates × static/dynamic report every frame ok via `e2e/force-status-survey.mjs`; the boom's Force tab shows the genuine remaining requirement instead of the topology refusal; CoM marks appear/disappear with mass; the gravity toggle flips analysis and the setup rows live.
- Two independent GPT-5.6 sol reviews; all six of their findings fixed in-branch (stale graphs, stale toggle after undo, block weight, tracer misdirection, untested couple term, multi-rider refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
