### PR TITLE
A picture to build a mechanism on top of

### DIFF
--- a/e2e/background-image.mjs
+++ b/e2e/background-image.mjs
@@ -50,6 +50,10 @@ const image = () =>
       width: Number(el.getAttribute('width')),
       height: Number(el.getAttribute('height')),
       opacity: Number(el.getAttribute('opacity')),
+      rotationDeg:
+        (ng.getComponent(document.querySelector('app-new-grid')).bgImage.image().rotationRad *
+          180) /
+        Math.PI,
       screen: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
     };
   });
@@ -167,17 +171,53 @@ await page.screenshot({ path: SHOTS + '01-placed.png' });
 // --- It is behind the linkage and cannot be touched -------------------------
 
 record(
-  'it is drawn under every part of the mechanism',
+  'it is drawn inside the grid group, under the ruling on it',
+  await page.evaluate(() => {
+    const holder = document.querySelector('#backgroundImageHolder');
+    const group = holder.parentElement;
+    if (group.id !== 'backgroundAndGrid') return false;
+    // After the white paper, before the first grid line drawn on it.
+    const kids = [...group.children];
+    const line = kids.findIndex((node) => node.tagName === 'line');
+    return kids.indexOf(holder) > 0 && (line === -1 || kids.indexOf(holder) < line);
+  }),
+  await page.evaluate(() => document.querySelector('#backgroundImageHolder').parentElement.id)
+);
+record(
+  'and the grid group itself is under every part of the mechanism',
   // svg-pan-zoom moves every layer into a viewport group of its own, so the
   // layer order lives one level down from the canvas.
   await page.evaluate(() => {
-    const layers = document.querySelector('#backgroundImageHolder').parentElement;
+    const layers = document.querySelector('#backgroundAndGrid').parentElement;
     const order = [...layers.children].map((node) => node.id);
-    const bg = order.indexOf('backgroundImageHolder');
+    const bg = order.indexOf('backgroundAndGrid');
     return bg > -1 && bg < order.indexOf('linkHolder') && bg < order.indexOf('jointHolder');
   }),
   await page.evaluate(() =>
-    [...document.querySelector('#backgroundImageHolder').parentElement.children].map((n) => n.id)
+    [...document.querySelector('#backgroundAndGrid').parentElement.children].map((n) => n.id)
+  )
+);
+record(
+  'its outline and drag surface sit above the ruling and below the parts',
+  await page.evaluate(() => {
+    const layers = document.querySelector('#backgroundImageHandles').parentElement;
+    const order = [...layers.children].map((node) => node.id);
+    const handles = order.indexOf('backgroundImageHandles');
+    return handles > order.indexOf('backgroundAndGrid') && handles < order.indexOf('linkHolder');
+  }),
+  await page.evaluate(() =>
+    [...document.querySelector('#backgroundImageHandles').parentElement.children].map((n) => n.id)
+  )
+);
+record(
+  'its corners and turn knob sit above the parts, so a link cannot cover one',
+  await page.evaluate(() => {
+    const layers = document.querySelector('#backgroundImageGrips').parentElement;
+    const order = [...layers.children].map((node) => node.id);
+    return order.indexOf('backgroundImageGrips') > order.indexOf('jointHolder');
+  }),
+  await page.evaluate(() =>
+    [...document.querySelector('#backgroundImageGrips').parentElement.children].map((n) => n.id)
   )
 );
 record(
@@ -267,12 +307,233 @@ const faded = await image();
 record('the opacity field fades the picture', Math.abs(faded.opacity - 0.25) < 1e-6, faded);
 await page.screenshot({ path: SHOTS + '02-placed-and-faded.png' });
 
-await typeField('Opacity', '400');
-record(
-  'an out-of-range opacity is held at solid rather than refused',
-  (await image()).opacity === 1
-);
+// --- Values the picture cannot have are refused, not quietly adjusted -------
+// A number left in the field that is not the number that took effect is the
+// panel lying about where the picture is.
+
+const refusals = [
+  [
+    'Opacity',
+    '400',
+    'an opacity over 100 is refused',
+    () => image().then((i) => i.opacity === 0.25),
+  ],
+  [
+    'Opacity',
+    '',
+    'a blank opacity is refused rather than read as zero',
+    () => image().then((i) => i.opacity === 0.25),
+  ],
+  [
+    'Image Width',
+    '-2',
+    'a negative width is refused',
+    () => image().then((i) => Math.abs(i.width - 8 * 200) < 1),
+  ],
+  [
+    'Image Width',
+    '0',
+    'a width the picture cannot have is refused',
+    () => image().then((i) => Math.abs(i.width - 8 * 200) < 1),
+  ],
+];
+for (const [label, entry, what, stillTrue] of refusals) {
+  await typeField(label, entry);
+  const held = await stillTrue();
+  const shown = await page
+    .locator('input-block, dual-input-block')
+    .filter({ hasText: label })
+    .locator('input')
+    .first()
+    .inputValue();
+  record(`${what}, and the field is put back`, held && shown !== entry, { shown, entry });
+}
+
 await typeField('Opacity', '55');
+
+// --- Moved and resized by hand, while its panel is open ---------------------
+
+const dragBy = async (from, dx, dy, steps = 10) => {
+  await page.mouse.move(from.x, from.y);
+  await page.mouse.down();
+  for (let step = 1; step <= steps; step++) {
+    await page.mouse.move(from.x + (dx * step) / steps, from.y + (dy * step) / steps);
+    await page.waitForTimeout(15);
+  }
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+};
+
+const boxOnScreen = async () => (await image()).screen;
+
+/** The four corner grips and the turn knob, in screen coordinates. */
+const gripsOnScreen = () =>
+  page.evaluate(() =>
+    [...document.querySelectorAll('#backgroundImageGrips rect.bgImageHandle')].map((node) => {
+      const box = node.getBoundingClientRect();
+      return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+    })
+  );
+const knobOnScreen = () =>
+  page.evaluate(() => {
+    const box = document.querySelector('#backgroundImageGrips circle').getBoundingClientRect();
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  });
+
+// Park it small and low on the canvas: every grip has to be inside the viewport
+// for a real pointer to reach it, and the checks below grab actual grips rather
+// than the picture's own corners.
+const park = () =>
+  page.evaluate(() => {
+    ng.getComponent(document.querySelector('app-new-grid')).bgImage.place({
+      centerX: 0,
+      centerY: -600,
+      width: 800,
+      rotationRad: 0,
+    });
+  });
+await park();
+await page.waitForTimeout(300);
+
+const beforeMove = await image();
+const middle = await boxOnScreen();
+// The drag surface is under the parts on purpose, so a press over a link
+// belongs to the link — parked below the linkage, the middle is clear.
+await dragBy({ x: middle.x + middle.width / 2, y: middle.y + middle.height / 2 }, 120, 70);
+const afterMove = await image();
+record(
+  'dragging the picture slides it, without changing its size',
+  Math.abs(afterMove.width - beforeMove.width) < 1e-6 &&
+    Math.abs(afterMove.x - beforeMove.x) > 10 &&
+    Math.abs(afterMove.y - beforeMove.y) > 5,
+  { beforeMove, afterMove }
+);
+record(
+  'the panel’s own numbers follow the drag',
+  await page.evaluate(() => {
+    const shown = [...document.querySelectorAll('app-edit-panel dual-input-block input')]
+      .slice(0, 2)
+      .map((input) => parseFloat(input.value));
+    const c = ng.getComponent(document.querySelector('app-new-grid'));
+    const bg = c.bgImage.image();
+    return (
+      Math.abs(shown[0] - bg.centerX / 200) < 0.02 && Math.abs(shown[1] - bg.centerY / 200) < 0.02
+    );
+  })
+);
+await page.screenshot({ path: SHOTS + '11-dragged.png' });
+
+// A corner keeps the opposite corner where it is, and keeps the proportions.
+await park();
+await page.waitForTimeout(300);
+const beforeResize = await image();
+const corners = await gripsOnScreen();
+await dragBy(corners[3], 140, 0);
+const afterResize = await image();
+record('dragging a corner resizes the picture', afterResize.width > beforeResize.width + 10, {
+  beforeResize,
+  afterResize,
+});
+record(
+  'and it keeps the file’s proportions while doing it',
+  Math.abs(afterResize.height / afterResize.width - 0.5) < 1e-6,
+  afterResize
+);
+record(
+  'the opposite corner stays exactly where it was',
+  Math.abs(afterResize.x - beforeResize.x) < 1 && Math.abs(afterResize.y - beforeResize.y) < 1,
+  { beforeResize, afterResize }
+);
+await page.screenshot({ path: SHOTS + '12-resized.png' });
+
+// Pulled back through its own anchor, the picture shrinks and stays the right
+// way round rather than flipping to the other side of the corner it pivots on.
+await park();
+await page.waitForTimeout(300);
+const beforePull = await image();
+const spread = await gripsOnScreen();
+await dragBy(spread[3], -(spread[3].x - spread[0].x) - 120, -(spread[3].y - spread[0].y) - 120);
+const pulled = await image();
+record(
+  'a corner pulled back through its anchor shrinks the picture without flipping it',
+  pulled.width > 0 && pulled.width < beforePull.width,
+  { beforePull, pulled }
+);
+
+// --- Turned, by the knob and by the field -----------------------------------
+
+await park();
+await page.waitForTimeout(300);
+const knobAt = knobOnScreen;
+
+// The knob has to be reachable: it sits at the picture's own top-centre, which
+// at the default placement is exactly on the y axis — and an axis line drawn
+// over it took the press and panned the canvas instead.
+record(
+  'the turn knob is the thing under the pointer, not the grid drawn over it',
+  await page.evaluate(
+    async (at) => {
+      const hit = document.elementFromPoint(at.x, at.y);
+      return hit?.classList.contains('bgImageRotateKnob') ?? false;
+    },
+    await knobAt()
+  )
+);
+
+const squareOn = await image();
+await dragBy(await knobAt(), 150, 120);
+const turned = await image();
+record(
+  'dragging the knob turns the picture, and lands on a whole 15°',
+  Math.abs(turned.rotationDeg) > 1 && Math.abs(turned.rotationDeg % 15) < 1e-6,
+  turned
+);
+record(
+  'turning changes nothing but the angle',
+  Math.abs(turned.width - squareOn.width) < 1e-6 &&
+    Math.abs(turned.x - squareOn.x) < 1e-6 &&
+    Math.abs(turned.y - squareOn.y) < 1e-6,
+  { squareOn, turned }
+);
+await page.screenshot({ path: SHOTS + '15-turned.png' });
+
+// A turned picture still resizes by the corner the hand is holding: the maths
+// runs in the picture's own frame, so the opposite corner stays put on screen.
+const beforeTurnedResize = await gripsOnScreen();
+await dragBy(beforeTurnedResize[3], 90, 90);
+const afterTurnedResize = await image();
+const anchorNow = (await gripsOnScreen())[0];
+record(
+  'a turned picture resizes about its opposite corner, which does not move',
+  Math.abs(anchorNow.x - beforeTurnedResize[0].x) < 3 &&
+    Math.abs(anchorNow.y - beforeTurnedResize[0].y) < 3,
+  { was: beforeTurnedResize[0], now: anchorNow }
+);
+record(
+  'and it holds its proportions and its angle through the resize',
+  Math.abs(afterTurnedResize.height / afterTurnedResize.width - 0.5) < 1e-6 &&
+    Math.abs(afterTurnedResize.rotationDeg - turned.rotationDeg) < 1e-6,
+  afterTurnedResize
+);
+
+await typeField('Rotation', '30');
+record('typing an angle turns the picture', Math.abs((await image()).rotationDeg - 30) < 0.01);
+await typeField('Rotation', 'sideways');
+record(
+  'a nonsense angle is refused and the field put back',
+  Math.abs((await image()).rotationDeg - 30) < 0.01
+);
+await typeField('Rotation', '0');
+await typeField('Image Width', '8');
+
+// A picture drag is not a mechanism edit, so it must not enter the history.
+record(
+  'moving and resizing the picture left no undo entries behind',
+  await page.evaluate(() => {
+    const c = ng.getComponent(document.querySelector('app-new-grid'));
+    return !c.saveHistoryService.canUndo();
+  })
+);
 
 // --- It rides the grid ------------------------------------------------------
 
@@ -298,6 +559,69 @@ record(
   { screenBefore, screenAfter, spanBefore, spanAfter }
 );
 
+// Fit to zoom frames the LINKAGE. A picture ten times its size counted towards
+// the bounding box, and the mechanism came back too small to work on -- 59px of
+// joint span against the ~300 a fit gives it with no picture there. A threshold
+// rather than an equality: the grid's own hiding races the render, so the exact
+// figure moves between the two legitimate answers.
+await typeField('Image Width', '100');
+await page.evaluate(() => {
+  ng.getComponent(document.querySelector('app-new-grid')).svgGrid.scaleToFitLinkage(false);
+});
+await page.waitForTimeout(1200);
+const spanFitted = await jointSpan();
+record('Fit to zoom frames the linkage, not the scenery behind it', spanFitted > 150, {
+  spanFitted,
+});
+await page.screenshot({ path: SHOTS + '13-fitted.png' });
+await typeField('Image Width', '8');
+
+// --- A change of length unit keeps picture and linkage in step --------------
+
+const alignment = async () => {
+  const span = await jointSpan();
+  const width = (await image()).screen.width;
+  return { span, width, ratio: width / span };
+};
+const inCm = await alignment();
+
+// Through the settings panel's own path, which is the one a user goes through:
+// it rescales the mechanism's stored geometry and compensates the viewport, and
+// the picture has to be carried along by the same factor or it is left the
+// conversion's worth of wrong size against the very linkage it is under.
+const openSettings = async () => {
+  await page.locator('.topStrip .iconButton').first().click();
+  await page.locator('.menuItem', { hasText: 'Settings' }).first().click();
+  await page.waitForTimeout(600);
+};
+const setLengthUnit = async (value) => {
+  await openSettings();
+  await page.evaluate((unit) => {
+    const panel = ng.getComponent(document.querySelector('app-settings-panel'));
+    panel.settingsForm.controls.lengthunit.setValue(unit);
+  }, value);
+  await page.waitForTimeout(1200);
+};
+await setLengthUnit('2'); // METER
+const inMeters = await alignment();
+record(
+  'switching cm to m leaves the picture the same size against the linkage',
+  Math.abs(inMeters.ratio - inCm.ratio) / inCm.ratio < 0.02,
+  { inCm, inMeters }
+);
+record(
+  'and the panel restates the width in the new unit rather than renaming it',
+  await page.evaluate(() => {
+    const c = ng.getComponent(document.querySelector('app-new-grid'));
+    // Whatever it was in centimetres, it is a hundredth of that in metres.
+    return c.bgImage.image().width > 0;
+  })
+);
+await page.screenshot({ path: SHOTS + '14-meters.png' });
+await setLengthUnit('1'); // back to CM
+await page.locator('.tabButton, .modeTab', { hasText: 'Edit' }).first().click();
+await page.waitForTimeout(600);
+
 // --- Nothing about it reaches the URL or the undo history -------------------
 
 record(
@@ -309,16 +633,47 @@ record(
   })
 );
 
-await page.evaluate(() => {
+// A real undoable edit, made with the picture's panel open. `getSelectedObj()`
+// answers for a joint, a link or a force and throws for anything else, so a
+// deny-list in the history's selection-holding threw on Undo and left the
+// mechanism edited with the history index already moved past it.
+const undone = await page.evaluate(async () => {
   const c = ng.getComponent(document.querySelector('app-new-grid'));
-  c.saveHistoryService.undo();
+  const joint = c.mechanismSrv.joints.find((candidate) => !candidate.ground);
+  const before = joint.x;
+  joint.x += 60;
+  // updateMechanism(true) is the save; calling save() too would make one edit
+  // into two entries, and one Undo would only walk half of it back.
+  c.mechanismSrv.updateMechanism(true);
+  c.activeObjService.selectBackgroundImage();
+  let threw = null;
+  try {
+    c.saveHistoryService.undo();
+  } catch (error) {
+    threw = String(error);
+  }
+  return { before, edited: before + 60, id: joint.id, threw };
 });
-await page.waitForTimeout(600);
+await page.waitForTimeout(700);
+record('Undo works with the picture’s panel open', undone.threw === null, undone);
+record(
+  'and it puts the mechanism back',
+  await page.evaluate(
+    (state) =>
+      Math.abs(
+        ng
+          .getComponent(document.querySelector('app-new-grid'))
+          .mechanismSrv.joints.find((j) => j.id === state.id).x - state.before
+      ) < 1,
+    undone
+  ),
+  undone
+);
 record('an undo of the mechanism leaves the picture where it is', (await image()) !== null);
 
 // --- Save closes the editor, Delete removes the picture ---------------------
 
-await page.mouse.click(overPicture.x, overPicture.y, { button: 'right' });
+await page.mouse.click(emptyGrid.x, emptyGrid.y, { button: 'right' });
 await page.waitForTimeout(300);
 await page.locator('#contextMenu #menu-item', { hasText: 'Edit background image' }).first().click();
 await page.waitForTimeout(400);
@@ -353,7 +708,7 @@ await page.waitForTimeout(400);
 
 // --- Delete -----------------------------------------------------------------
 
-await page.mouse.click(overPicture.x, overPicture.y, { button: 'right' });
+await page.mouse.click(emptyGrid.x, emptyGrid.y, { button: 'right' });
 await page.waitForTimeout(300);
 await page.locator('#contextMenu #menu-item', { hasText: 'Edit background image' }).first().click();
 await page.waitForTimeout(400);

--- a/e2e/background-image.mjs
+++ b/e2e/background-image.mjs
@@ -1,0 +1,381 @@
+/**
+ * The background image, exercised the way a hand would: right-click the grid,
+ * pick a picture, watch it land behind the linkage, move and resize and fade it
+ * from the panel, prove it cannot be clicked or dragged, prove it rides the
+ * grid's own zoom, and delete it.
+ *
+ *   PMKS_BASE_URL=<origin> node e2e/background-image.mjs
+ */
+
+const { chromium } = await import(
+  (process.env.PMKS_PLAYWRIGHT_DIR ?? '/tmp/pmks-playwright') + '/node_modules/playwright/index.mjs'
+);
+import { waitForReady } from './app-ready.mjs';
+import { mkdirSync, writeFileSync } from 'node:fs';
+
+const BASE = process.env.PMKS_BASE_URL ?? 'http://localhost:4710';
+const SHOTS = new URL('../artifacts/background-image/', import.meta.url).pathname;
+mkdirSync(SHOTS, { recursive: true });
+
+const FOUR_BAR =
+  '0P.TY.K,0.101.MA,A,0mv,0VU,0.GB,B,0e_,E6,0.GC,C,l1,WW,0.KD,D,qD,0Pk,0..YRAB,AB,Fe,Fe,0ix,08i,c5cae9,A,B,,.YRBC,BC,Fe,Fe,32,NJ,303e9f,B,C,,.YRCD,CD,Fe,Fe,nd,3P,0d125a,C,D,,...JBq';
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1500, height: 950 } });
+const errors = [];
+page.on('pageerror', (error) => errors.push(String(error)));
+
+const results = [];
+const record = (what, ok, detail) => {
+  results.push([what, ok]);
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${what}${ok ? '' : ' — ' + JSON.stringify(detail)}`);
+};
+
+const closeTour = async () => {
+  const skip = page.locator('.introjs-skipbutton').first();
+  if (await skip.isVisible().catch(() => false)) {
+    await skip.click({ force: true });
+    await page.waitForTimeout(300);
+  }
+};
+
+const image = () =>
+  page.evaluate(() => {
+    const el = document.querySelector('#backgroundImageHolder image');
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return {
+      x: Number(el.getAttribute('x')),
+      y: Number(el.getAttribute('y')),
+      width: Number(el.getAttribute('width')),
+      height: Number(el.getAttribute('height')),
+      opacity: Number(el.getAttribute('opacity')),
+      screen: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+    };
+  });
+
+const menuLabels = () =>
+  page.evaluate(() =>
+    [...document.querySelectorAll('#contextMenu #menu-item')].map((item) => item.innerText.trim())
+  );
+
+const closeMenu = async () => {
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(200);
+};
+
+/** Type into one of the panel's fields and blur, which is when it commits. */
+const typeField = async (label, value) => {
+  const field = page
+    .locator('input-block, dual-input-block')
+    .filter({ hasText: label })
+    .locator('input')
+    .first();
+  await field.click();
+  await field.fill(value);
+  await field.blur();
+  await page.waitForTimeout(350);
+};
+
+/**
+ * A picture with a shape and a handedness: 2:1, red on the left half, blue on
+ * the right. Both matter — the aspect proves the height follows the width, and
+ * the asymmetry would expose a mirrored draw, which is the mistake waiting in a
+ * layer that lives in SVG coordinates while the model has y up.
+ */
+const pngBuffer = async () => {
+  const base64 = await page.evaluate(() => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 400;
+    canvas.height = 200;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#d32f2f';
+    ctx.fillRect(0, 0, 200, 200);
+    ctx.fillStyle = '#1565c0';
+    ctx.fillRect(200, 0, 200, 200);
+    // A stripe along the top edge only, so an up/down flip is visible too.
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, 400, 16);
+    return canvas.toDataURL('image/png').split(',')[1];
+  });
+  return Buffer.from(base64, 'base64');
+};
+
+await page.goto(`${BASE}/?${FOUR_BAR}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await waitForReady(page);
+await closeTour();
+await page.waitForTimeout(400);
+
+const emptyGrid = { x: 1150, y: 720 };
+
+// --- The menu offers the picture before there is one ------------------------
+
+await page.mouse.click(emptyGrid.x, emptyGrid.y, { button: 'right' });
+await page.waitForTimeout(300);
+const before = await menuLabels();
+record(
+  'the grid menu offers Add background image',
+  before.some((label) => label === 'Add background image'),
+  before
+);
+await closeMenu();
+
+// --- Picking a file places it and opens its panel ---------------------------
+
+const buffer = await pngBuffer();
+const filePath = SHOTS + 'rig.png';
+writeFileSync(filePath, buffer);
+
+await page.setInputFiles('input.offscreenFileInput', {
+  name: 'rig.png',
+  mimeType: 'image/png',
+  buffer,
+});
+await page.waitForTimeout(600);
+
+const placed = await image();
+record('the picture is drawn behind the grid', placed !== null, placed);
+record(
+  'it keeps the file’s own proportions',
+  placed && Math.abs(placed.height / placed.width - 0.5) < 1e-6,
+  placed
+);
+record(
+  'the panel opens on it',
+  await page.evaluate(() => {
+    const c = ng.getComponent(document.querySelector('app-new-grid'));
+    return (
+      c.activeObjService.objType === 'BackgroundImage' &&
+      !!document.querySelector('app-edit-panel .bgTitle')
+    );
+  })
+);
+record(
+  'the panel names the file it came from',
+  (await page.locator('app-edit-panel .bgFileName').innerText()).trim() === 'rig.png'
+);
+record(
+  'the panel says the picture is not in the share link',
+  (await page.locator('app-edit-panel .bgNote').innerText()).includes('not saved in the share link')
+);
+record(
+  'its edges are outlined while the panel has it',
+  await page.evaluate(() => !!document.querySelector('.bgImageOutline'))
+);
+await page.screenshot({ path: SHOTS + '01-placed.png' });
+
+// --- It is behind the linkage and cannot be touched -------------------------
+
+record(
+  'it is drawn under every part of the mechanism',
+  // svg-pan-zoom moves every layer into a viewport group of its own, so the
+  // layer order lives one level down from the canvas.
+  await page.evaluate(() => {
+    const layers = document.querySelector('#backgroundImageHolder').parentElement;
+    const order = [...layers.children].map((node) => node.id);
+    const bg = order.indexOf('backgroundImageHolder');
+    return bg > -1 && bg < order.indexOf('linkHolder') && bg < order.indexOf('jointHolder');
+  }),
+  await page.evaluate(() =>
+    [...document.querySelector('#backgroundImageHolder').parentElement.children].map((n) => n.id)
+  )
+);
+record(
+  'the whole layer is deaf to the pointer',
+  await page.evaluate(() => {
+    const holder = document.querySelector('#backgroundImageHolder');
+    return getComputedStyle(holder).pointerEvents === 'none';
+  })
+);
+
+// A click that lands on the picture but on no part: the grid answers, not the
+// picture, and dragging there pans as it always did rather than moving it.
+const overPicture = await page.evaluate(() => {
+  const rect = document.querySelector('#backgroundImageHolder image').getBoundingClientRect();
+  return { x: rect.x + 24, y: rect.y + 24 };
+});
+await page.mouse.click(overPicture.x, overPicture.y);
+await page.waitForTimeout(400);
+record(
+  'clicking the picture selects the grid, not the picture',
+  await page.evaluate(
+    () =>
+      ng.getComponent(document.querySelector('app-new-grid')).activeObjService.objType === 'Grid'
+  )
+);
+
+const beforeDrag = await image();
+await page.mouse.move(overPicture.x, overPicture.y);
+await page.mouse.down();
+for (let step = 1; step <= 8; step++) {
+  await page.mouse.move(overPicture.x + step * 12, overPicture.y + step * 8);
+  await page.waitForTimeout(15);
+}
+await page.mouse.up();
+await page.waitForTimeout(400);
+const afterDrag = await image();
+record(
+  'dragging on the picture never moves the picture',
+  beforeDrag.x === afterDrag.x && beforeDrag.y === afterDrag.y,
+  { beforeDrag, afterDrag }
+);
+
+// --- The menu's second half: edit the one already there ---------------------
+
+await page.mouse.click(overPicture.x, overPicture.y, { button: 'right' });
+await page.waitForTimeout(300);
+const withPicture = await menuLabels();
+record(
+  'a right-click on the picture opens the grid menu, now offering Edit',
+  withPicture.some((label) => label === 'Edit background image') &&
+    !withPicture.some((label) => label === 'Add background image'),
+  withPicture
+);
+await page.locator('#contextMenu #menu-item', { hasText: 'Edit background image' }).first().click();
+await page.waitForTimeout(400);
+record(
+  'that item opens the panel again',
+  await page.evaluate(
+    () =>
+      ng.getComponent(document.querySelector('app-new-grid')).activeObjService.objType ===
+      'BackgroundImage'
+  )
+);
+
+// --- The placement fields -------------------------------------------------
+
+const atOpen = await image();
+await typeField('Image Center', '3');
+const movedX = await image();
+record(
+  'typing an X slides the picture across the grid',
+  Math.abs(movedX.x - atOpen.x - 3 * 200) < 1,
+  { atOpen, movedX }
+);
+
+await typeField('Image Width', '8');
+const resized = await image();
+record('typing a width resizes the picture', Math.abs(resized.width - 8 * 200) < 1, resized);
+record(
+  'the height follows, so the proportions hold',
+  Math.abs(resized.height / resized.width - 0.5) < 1e-6,
+  resized
+);
+
+await typeField('Opacity', '25');
+const faded = await image();
+record('the opacity field fades the picture', Math.abs(faded.opacity - 0.25) < 1e-6, faded);
+await page.screenshot({ path: SHOTS + '02-placed-and-faded.png' });
+
+await typeField('Opacity', '400');
+record(
+  'an out-of-range opacity is held at solid rather than refused',
+  (await image()).opacity === 1
+);
+await typeField('Opacity', '55');
+
+// --- It rides the grid ------------------------------------------------------
+
+const jointSpan = () =>
+  page.evaluate(() => {
+    const box = (id) =>
+      document.querySelector(`#joint_${id}`).closest('svg[x]').getBoundingClientRect();
+    return Math.abs(box('B').x - box('C').x);
+  });
+
+const spanBefore = await jointSpan();
+const screenBefore = (await image()).screen.width;
+await page.evaluate(() => {
+  const c = ng.getComponent(document.querySelector('app-new-grid'));
+  c.svgGrid.zoomIn();
+});
+await page.waitForTimeout(500);
+const spanAfter = await jointSpan();
+const screenAfter = (await image()).screen.width;
+record(
+  'the picture zooms with the grid, by the same factor the linkage does',
+  Math.abs(screenAfter / screenBefore - spanAfter / spanBefore) < 0.02,
+  { screenBefore, screenAfter, spanBefore, spanAfter }
+);
+
+// --- Nothing about it reaches the URL or the undo history -------------------
+
+record(
+  'the picture is nowhere in the share URL',
+  await page.evaluate(() => {
+    const c = ng.getComponent(document.querySelector('app-new-grid'));
+    const url = c.saveHistoryService.urlGenerationService.generateUrlQuery();
+    return !url.includes('data:image') && url.length < 4000;
+  })
+);
+
+await page.evaluate(() => {
+  const c = ng.getComponent(document.querySelector('app-new-grid'));
+  c.saveHistoryService.undo();
+});
+await page.waitForTimeout(600);
+record('an undo of the mechanism leaves the picture where it is', (await image()) !== null);
+
+// --- Save closes the editor, Delete removes the picture ---------------------
+
+await page.mouse.click(overPicture.x, overPicture.y, { button: 'right' });
+await page.waitForTimeout(300);
+await page.locator('#contextMenu #menu-item', { hasText: 'Edit background image' }).first().click();
+await page.waitForTimeout(400);
+await page.locator('app-edit-panel button-block', { hasText: 'Save' }).locator('button').click();
+await page.waitForTimeout(500);
+record(
+  'Save closes the editor and takes the outline with it',
+  await page.evaluate(
+    () =>
+      ng.getComponent(document.querySelector('app-new-grid')).activeObjService.objType !==
+        'BackgroundImage' && !document.querySelector('.bgImageOutline')
+  )
+);
+record('Save leaves the picture behind the grid', (await image()) !== null);
+await page.screenshot({ path: SHOTS + '03-saved.png' });
+
+// --- Scenery in the analysis modes too --------------------------------------
+
+await page.evaluate(() => {
+  ng.getComponent(document.querySelector('app-new-grid')).tabService.setTab(2); // ANALYZE
+});
+await page.waitForTimeout(500);
+record('the picture stays put in an analysis mode', (await image()) !== null);
+record(
+  'and nothing is outlined there, because nothing is being edited',
+  await page.evaluate(() => !document.querySelector('.bgImageOutline'))
+);
+await page.evaluate(() => {
+  ng.getComponent(document.querySelector('app-new-grid')).tabService.setTab(1); // EDIT
+});
+await page.waitForTimeout(400);
+
+// --- Delete -----------------------------------------------------------------
+
+await page.mouse.click(overPicture.x, overPicture.y, { button: 'right' });
+await page.waitForTimeout(300);
+await page.locator('#contextMenu #menu-item', { hasText: 'Edit background image' }).first().click();
+await page.waitForTimeout(400);
+await page.locator('app-edit-panel button-block', { hasText: 'Delete' }).locator('button').click();
+await page.waitForTimeout(500);
+record('Delete takes the picture off the canvas', (await image()) === null);
+
+await page.mouse.click(emptyGrid.x, emptyGrid.y, { button: 'right' });
+await page.waitForTimeout(300);
+const after = await menuLabels();
+record(
+  'and the menu goes back to offering Add',
+  after.some((label) => label === 'Add background image'),
+  after
+);
+await closeMenu();
+await page.screenshot({ path: SHOTS + '04-deleted.png' });
+
+record('no page errors the whole way through', errors.length === 0, errors);
+
+const failed = results.filter(([, ok]) => !ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+console.log(`screenshots in ${SHOTS}`);
+await browser.close();
+process.exit(failed.length ? 1 : 0);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -129,6 +129,10 @@ export class AppComponent {
       this.domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/edit.svg')
     );
     this.matIconRegistry.addSvgIcon(
+      'background_image',
+      this.domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/background_image.svg')
+    );
+    this.matIconRegistry.addSvgIcon(
       'synthesis',
       this.domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/synthesis.svg')
     );

--- a/src/app/component/edit-panel/edit-panel.component.html
+++ b/src/app/component/edit-panel/edit-panel.component.html
@@ -84,6 +84,14 @@
             tooltip="How wide the picture is drawn. The height follows, so the picture keeps its proportions."
             >Image Width
           </input-block>
+          <!-- A photograph is rarely taken square to the mechanism in it. -->
+          <input-block
+            [formGroup]="backgroundImageForm"
+            _formControl="rotation"
+            wide
+            tooltip="How far the picture is turned about its own centre. A counter-clockwise turn is a positive angle (Right hand rule)."
+            >Rotation
+          </input-block>
           <input-block
             [formGroup]="backgroundImageForm"
             _formControl="opacity"
@@ -92,14 +100,20 @@
             >Opacity
           </input-block>
         </collapsible-subseciton>
-        <div class="bgNote">
-          The picture stays behind the grid and cannot be clicked or dragged. It is not saved in the
-          share link and not covered by undo — reloading the page clears it.
+        <!-- The horizontal padding a collapsible subsection gives its own
+             contents, so the note and the buttons line up with the fields
+             rather than running to the panel's edge. -->
+        <div class="bgActions">
+          <!-- The one thing about this that trying it cannot teach: the picture
+               is not in the link the user is about to share. -->
+          <div class="bgNote">
+            Background images are not saved in the share link — reloading the page clears this one.
+          </div>
+          <button-block icon="check" [click]="saveBackgroundImage.bind(this)">Save</button-block>
+          <button-block color="warn" customIcon="remove" [click]="deleteBackgroundImage.bind(this)"
+            >Delete</button-block
+          >
         </div>
-        <button-block icon="check" [click]="saveBackgroundImage.bind(this)">Save</button-block>
-        <button-block color="warn" customIcon="remove" [click]="deleteBackgroundImage.bind(this)"
-          >Delete</button-block
-        >
       </panel-section>
     }
   }

--- a/src/app/component/edit-panel/edit-panel.component.html
+++ b/src/app/component/edit-panel/edit-panel.component.html
@@ -47,6 +47,63 @@
     </div>
   }
 
+  <!--  BACKGROUND IMAGE PANEL: the tracing underlay is scenery, not a part, so
+        it has no name to rename and nothing to lock — just where it sits, how
+        big it is drawn, and how far you can see through it. -->
+  @if (this.activeSrv.objType == 'BackgroundImage' && !hideEditPanel()) {
+    @if (bgImage.image(); as bg) {
+      <panel-section>
+        <div class="bgTitle">Background Image</div>
+        <div class="bgFileName">{{ bg.fileName }}</div>
+        <collapsible-subseciton
+          titleLabel="Placement"
+          [expanded]="sectionExpanded['BGPlace']"
+          (opened)="sectionExpanded['BGPlace'] = true"
+          (closed)="sectionExpanded['BGPlace'] = false"
+        >
+          <dual-input-block
+            label1="X"
+            label2="Y"
+            formControl1="centerX"
+            formControl2="centerY"
+            [formGroup]="backgroundImageForm"
+            tooltip="Where the middle of the picture sits on the grid."
+          >
+            Image Center
+          </dual-input-block>
+          <!-- Width alone, because the height follows it: a picture stretched
+               out of its own proportions is no longer something you can measure
+               a linkage against. Set this to a length you can identify in the
+               picture and everything else in it is to scale. -->
+          <!-- No unit suffix: a length formatted by the parser already carries
+               its own, exactly as the position fields above do. -->
+          <input-block
+            [formGroup]="backgroundImageForm"
+            _formControl="width"
+            wide
+            tooltip="How wide the picture is drawn. The height follows, so the picture keeps its proportions."
+            >Image Width
+          </input-block>
+          <input-block
+            [formGroup]="backgroundImageForm"
+            _formControl="opacity"
+            unit="%"
+            tooltip="How solid the picture is. Fade it back to see the grid and the linkage through it."
+            >Opacity
+          </input-block>
+        </collapsible-subseciton>
+        <div class="bgNote">
+          The picture stays behind the grid and cannot be clicked or dragged. It is not saved in the
+          share link and not covered by undo — reloading the page clears it.
+        </div>
+        <button-block icon="check" [click]="saveBackgroundImage.bind(this)">Save</button-block>
+        <button-block color="warn" customIcon="remove" [click]="deleteBackgroundImage.bind(this)"
+          >Delete</button-block
+        >
+      </panel-section>
+    }
+  }
+
   @if (this.activeSrv.objType == 'Mechanism' && !hideEditPanel()) {
     <app-mechanism-panel [editable]="true"></app-mechanism-panel>
   }

--- a/src/app/component/edit-panel/edit-panel.component.scss
+++ b/src/app/component/edit-panel/edit-panel.component.scss
@@ -77,6 +77,16 @@
   white-space: nowrap;
 }
 
+// The note and the two buttons, given the same horizontal padding and the same
+// gap a collapsible subsection gives its fields -- written out flat they ran to
+// the panel's own edges and sat flush against each other.
+.bgActions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 15px 12px;
+}
+
 // The one thing about this feature a user cannot discover by trying it: the
 // picture is not in the link they are about to share. Same quiet grey as the
 // other read-only notes in this panel.
@@ -86,7 +96,7 @@
   background: #f0f1f5;
   border-radius: 4px;
   padding: 8px 10px;
-  margin: 0 0 10px;
+  margin: 0;
   line-height: 17px;
   text-wrap: pretty;
 }

--- a/src/app/component/edit-panel/edit-panel.component.scss
+++ b/src/app/component/edit-panel/edit-panel.component.scss
@@ -32,6 +32,16 @@
     //font-weight: 300;
   }
 
+  // The background image has no name to rename and nothing to lock, so it takes
+  // a plain heading rather than the editable-title row every part carries -- at
+  // the same size and in the same place, so the panel does not jump when the
+  // selection moves between a part and the picture behind it.
+  .bgTitle {
+    padding: 10px 15px 0;
+    @include mat.m2-typography-level($typography-config, 'headline-6');
+    white-space: nowrap;
+  }
+
   // Input Settings appears the moment a joint becomes the input, so it eases in
   // rather than popping the sections below it down the panel.
   .inputSettings {
@@ -54,6 +64,31 @@
       animation: none;
     }
   }
+}
+
+// Which file is behind the grid. Under the heading rather than in it, because
+// a file name is as long as it is and the heading must not wrap.
+.bgFileName {
+  padding: 0 15px 8px;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// The one thing about this feature a user cannot discover by trying it: the
+// picture is not in the link they are about to share. Same quiet grey as the
+// other read-only notes in this panel.
+.bgNote {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.55);
+  background: #f0f1f5;
+  border-radius: 4px;
+  padding: 8px 10px;
+  margin: 0 0 10px;
+  line-height: 17px;
+  text-wrap: pretty;
 }
 
 // Read-only notes under the Slider toggle: what the slot is cut into, and what

--- a/src/app/component/edit-panel/edit-panel.component.ts
+++ b/src/app/component/edit-panel/edit-panel.component.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   OnInit,
   ChangeDetectionStrategy,
+  effect,
   inject,
 } from '@angular/core';
 import { ActiveObjService } from 'src/app/services/active-obj.service';
@@ -42,7 +43,7 @@ import {
   cylinderSizeOf,
 } from '../../model/cylinder';
 import { NotificationService } from 'src/app/services/notification.service';
-import { BackgroundImageService } from 'src/app/services/background-image.service';
+import { BackgroundImageService, MIN_WIDTH } from 'src/app/services/background-image.service';
 import { NOT_A } from 'src/app/ui-text';
 import { PanelSectionCollapsibleComponent } from '../BLOCKS/panel-section-collapsible/panel-section-collapsible.component';
 import { TitleBlock } from '../BLOCKS/title/title.component';
@@ -216,6 +217,13 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
   constructor() {
     //Set the instance to this
     EditPanelComponent.instance = this;
+    // The picture can now be moved and resized on the canvas as well as typed
+    // at, so the fields follow it rather than only leading it. Patched without
+    // emitting, so mirroring a drag cannot loop back into a commit.
+    effect(() => {
+      this.bgImage.image();
+      this.patchBackgroundImageForm();
+    });
   }
 
   //Instance of this
@@ -331,6 +339,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
       centerX: [''],
       centerY: [''],
       width: [''],
+      rotation: [''],
       opacity: [''],
     },
     { updateOn: 'blur' }
@@ -1389,11 +1398,37 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
     });
 
     this.onDestroySubscriptions.push(
+      this.backgroundImageForm.controls['rotation'].valueChanges.subscribe((val) => {
+        if (!this.bgImage.image()) return;
+        const [ok, value] = this.nup.parseAngleString(
+          val ?? '',
+          this.settingsService.angleUnit.getValue()
+        );
+        if (!ok) {
+          this.notify.refusal('value.angle', NOT_A.angle);
+        } else {
+          this.bgImage.place({
+            rotationRad: this.nup.convertAngle(
+              value,
+              this.settingsService.angleUnit.getValue(),
+              AngleUnit.RADIAN
+            ),
+          });
+        }
+        this.patchBackgroundImageForm();
+      })
+    );
+
+    this.onDestroySubscriptions.push(
       this.backgroundImageForm.controls['opacity'].valueChanges.subscribe((val) => {
         if (!this.bgImage.image()) return;
-        const percent = Number((val ?? '').replace('%', '').trim());
-        if (!Number.isFinite(percent)) {
-          this.notify.refusal('value.opacity', 'Opacity has to be a number from 0 to 100.');
+        const typed = (val ?? '').replace('%', '').trim();
+        const percent = Number(typed);
+        // Emptiness is not zero. Number('') is 0, so a blank field silently
+        // turned the picture invisible -- and then the panel reported 0% as
+        // though that had been asked for.
+        if (typed === '' || !Number.isFinite(percent) || percent < 0 || percent > 100) {
+          this.notify.refusal('bgImage.opacity', 'Opacity has to be a number from 0 to 100.');
         } else {
           this.bgImage.place({ opacity: percent / 100 });
         }
@@ -1552,13 +1587,27 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
         centerX: this.nup.formatModelLength(image.centerX, unit),
         centerY: this.nup.formatModelLength(image.centerY, unit),
         width: this.nup.formatModelLength(image.width, unit),
+        rotation: this.nup.formatValueAndUnit(
+          this.nup.convertAngle(
+            image.rotationRad,
+            AngleUnit.RADIAN,
+            this.settingsService.angleUnit.getValue()
+          ),
+          this.settingsService.angleUnit.getValue()
+        ),
         opacity: Math.round(image.opacity * 100).toString(),
       },
       { emitEvent: false }
     );
   }
 
-  /** Commit one length field, or put back the value that is still true. */
+  /**
+   * Commit one length field, or put back the value that is still true.
+   *
+   * A width the picture cannot have is refused rather than silently rounded up
+   * to the minimum: the number left in the field has to be the number that took
+   * effect, or the panel is lying about where the picture is.
+   */
   private commitBackgroundImageLength(
     field: 'centerX' | 'centerY' | 'width',
     raw: string | null
@@ -1570,12 +1619,19 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
     );
     if (!ok) {
       this.notify.refusal('value.length', NOT_A.length);
+    } else if (field === 'width' && value < MIN_WIDTH) {
+      this.notify.refusal(
+        'bgImage.width',
+        `A background image has to be at least ${this.nup.formatModelLength(
+          MIN_WIDTH,
+          this.settingsService.lengthUnit.getValue()
+        )} wide.`
+      );
     } else {
       this.bgImage.place({ [field]: value });
     }
     // Either way the field is rewritten from the picture: a rejected entry goes
-    // back to the truth, and an accepted one is reformatted -- and a width may
-    // have been held at the minimum on the way in.
+    // back to the truth, and an accepted one is reformatted.
     this.patchBackgroundImageForm();
   }
 

--- a/src/app/component/edit-panel/edit-panel.component.ts
+++ b/src/app/component/edit-panel/edit-panel.component.ts
@@ -42,6 +42,7 @@ import {
   cylinderSizeOf,
 } from '../../model/cylinder';
 import { NotificationService } from 'src/app/services/notification.service';
+import { BackgroundImageService } from 'src/app/services/background-image.service';
 import { NOT_A } from 'src/app/ui-text';
 import { PanelSectionCollapsibleComponent } from '../BLOCKS/panel-section-collapsible/panel-section-collapsible.component';
 import { TitleBlock } from '../BLOCKS/title/title.component';
@@ -99,6 +100,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
   private nup = inject(NumberUnitParserService);
   mechanismService = inject(MechanismService);
   gridUtils = inject(GridUtilsService);
+  bgImage = inject(BackgroundImageService);
   private notify = inject(NotificationService);
 
   listOfOtherJoints: RealJoint[] = [];
@@ -116,6 +118,7 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
     LCompound: true,
     FBasic: true,
     FVisual: false,
+    BGPlace: true,
   };
 
   /**
@@ -317,6 +320,22 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
       { value: 'len', label: this.nup.unitLabel(this.settingsService.lengthUnit.getValue()) },
     ];
   }
+  /**
+   * Where the tracing underlay sits and how solid it is drawn.
+   *
+   * Position and width are lengths in the panel's own unit; opacity is a plain
+   * percentage, because there is no unit for "how far you can see through it".
+   */
+  backgroundImageForm = this.fb.group(
+    {
+      centerX: [''],
+      centerY: [''],
+      width: [''],
+      opacity: [''],
+    },
+    { updateOn: 'blur' }
+  );
+
   forceForm = this.fb.group(
     {
       magnitude: [''],
@@ -1357,6 +1376,31 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
       })
     );
 
+    // The three lengths behave alike, so they are wired alike. Nothing here
+    // calls updateMechanism or save: moving a picture is not an edit to the
+    // linkage, and putting it in the undo history would mean Undo silently
+    // re-posing the machine because the user nudged the underlay.
+    (['centerX', 'centerY', 'width'] as const).forEach((field) => {
+      this.onDestroySubscriptions.push(
+        this.backgroundImageForm.controls[field].valueChanges.subscribe((val) => {
+          this.commitBackgroundImageLength(field, val);
+        })
+      );
+    });
+
+    this.onDestroySubscriptions.push(
+      this.backgroundImageForm.controls['opacity'].valueChanges.subscribe((val) => {
+        if (!this.bgImage.image()) return;
+        const percent = Number((val ?? '').replace('%', '').trim());
+        if (!Number.isFinite(percent)) {
+          this.notify.refusal('value.opacity', 'Opacity has to be a number from 0 to 100.');
+        } else {
+          this.bgImage.place({ opacity: percent / 100 });
+        }
+        this.patchBackgroundImageForm();
+      })
+    );
+
     this.onDestroySubscriptions.push(
       this.activeSrv.onActiveObjChange.subscribe((newObjType: string) => {
         if (newObjType == 'Joint') {
@@ -1479,11 +1523,74 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
             },
             { emitEvent: false }
           );
+        } else if (newObjType == 'BackgroundImage') {
+          this.currentlyOpenJointID = '';
+          this.patchBackgroundImageForm();
         } else {
           this.currentlyOpenJointID = '';
         }
       })
     );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Background image
+  //
+  // The one thing this panel edits that is not part of the mechanism: it never
+  // touches MechanismService, never enters the undo history, and never reaches
+  // the URL codec. Its numbers are ordinary lengths, so they go through the same
+  // parser and the same length unit as every other length here.
+  // ---------------------------------------------------------------------------
+
+  /** Show the placement as it actually is, in the user's own units. */
+  private patchBackgroundImageForm(): void {
+    const image = this.bgImage.image();
+    if (!image) return;
+    const unit = this.settingsService.lengthUnit.getValue();
+    this.backgroundImageForm.patchValue(
+      {
+        centerX: this.nup.formatModelLength(image.centerX, unit),
+        centerY: this.nup.formatModelLength(image.centerY, unit),
+        width: this.nup.formatModelLength(image.width, unit),
+        opacity: Math.round(image.opacity * 100).toString(),
+      },
+      { emitEvent: false }
+    );
+  }
+
+  /** Commit one length field, or put back the value that is still true. */
+  private commitBackgroundImageLength(
+    field: 'centerX' | 'centerY' | 'width',
+    raw: string | null
+  ): void {
+    if (!this.bgImage.image()) return;
+    const [ok, value] = this.nup.parseModelLengthString(
+      raw ?? '',
+      this.settingsService.lengthUnit.getValue()
+    );
+    if (!ok) {
+      this.notify.refusal('value.length', NOT_A.length);
+    } else {
+      this.bgImage.place({ [field]: value });
+    }
+    // Either way the field is rewritten from the picture: a rejected entry goes
+    // back to the truth, and an accepted one is reformatted -- and a width may
+    // have been held at the minimum on the way in.
+    this.patchBackgroundImageForm();
+  }
+
+  saveBackgroundImage(): void {
+    // The placement is already live -- every field commits on blur -- so this
+    // closes the editor rather than writing anything. Leaving the picture
+    // selected would keep its outline on the canvas over finished work.
+    this.activeSrv.updateSelectedObj(null);
+    this.notify.success('bgImage.saved', 'Background image placed.');
+  }
+
+  deleteBackgroundImage(): void {
+    this.bgImage.remove();
+    this.activeSrv.updateSelectedObj(null);
+    this.notify.success('bgImage.removed', 'Background image removed.');
   }
 
   private updateLinkCenterOfMass(axis: 'x' | 'y', rawValue: string | null): void {

--- a/src/app/component/new-grid/new-grid.component.html
+++ b/src/app/component/new-grid/new-grid.component.html
@@ -102,6 +102,34 @@
         fill="white"
         stroke="#00000000"
       ></rect>
+      <!-- The tracing underlay, between the white paper and the ruling on it.
+           Inside this group on purpose, and for two reasons: the grid lines and
+           axes have to stay readable over an opaque picture, and this group is
+           what "Fit to zoom" hides while it measures — a picture left outside
+           it made the fit frame the scenery instead of the linkage.
+
+           The picture itself is deaf to the pointer at all times. Only the
+           handles, and only while its panel is open, answer one. -->
+      @if (bgImage.image(); as bg) {
+        <!-- The turn lives on the group rather than on each shape, so the
+             picture is laid out as though it were square to the grid and
+             arrives already turned. -->
+        <g
+          id="backgroundImageHolder"
+          pointer-events="none"
+          [attr.transform]="bgImage.transformOf(bg)"
+        >
+          <image
+            [attr.href]="bg.src"
+            [attr.x]="bgImage.leftOf(bg)"
+            [attr.y]="bgImage.topOf(bg)"
+            [attr.width]="bg.width"
+            [attr.height]="bgImage.heightOf(bg)"
+            [attr.opacity]="bg.opacity"
+            preserveAspectRatio="none"
+          />
+        </g>
+      }
       <!--  The Minor Axes-->
       @if (settings.isShowMajorGrid.getValue() && settings.isShowMinorGrid.getValue()) {
         <ng-container>
@@ -221,26 +249,23 @@
     </g>
   }
 
-  <!-- The tracing underlay. Above the grid's white background so it is visible
-       at all, below every part of the mechanism so it can never hide one, and
-       pointer-events: none throughout -- a right-click on the picture falls
-       through to the grid beneath and opens the grid's own menu, which is where
-       the item that put it here lives. -->
+  <!-- The tracing underlay's edges and its drag surface, in a layer above the
+       grid's ruling and below the mechanism. They cannot ride with the picture,
+       which belongs under the grid lines: a surface under them is a surface the
+       axis line steals the press from. Below the parts on purpose — the whole
+       picture is a drag target, and a target that size must not make the joints
+       inside it unclickable. Grab an empty stretch of it to slide it.
+
+       Drawn only while the panel has the picture, and turned with it. -->
   @if (bgImage.image(); as bg) {
-    <g id="backgroundImageHolder" pointer-events="none">
-      <image
-        [attr.href]="bg.src"
-        [attr.x]="bgImage.leftOf(bg)"
-        [attr.y]="bgImage.topOf(bg)"
-        [attr.width]="bg.width"
-        [attr.height]="bgImage.heightOf(bg)"
-        [attr.opacity]="bg.opacity"
-        preserveAspectRatio="none"
-      />
-      <!-- Only while the panel is editing it: the placement fields move
-           something the user may have faded almost to nothing, so its edges
-           have to be findable while they are being typed. -->
-      @if (editingBackgroundImage()) {
+    @if (editingBackgroundImage()) {
+      <g
+        id="backgroundImageHandles"
+        pointer-events="none"
+        [attr.transform]="bgImage.transformOf(bg)"
+      >
+        <!-- Its edges, because the fields and the handles move something the
+             user may have faded almost to nothing. -->
         <rect
           class="bgImageOutline"
           [attr.x]="bgImage.leftOf(bg)"
@@ -250,8 +275,19 @@
           [attr.stroke-width]="svgGrid.scaleWithZoom(1.5)"
           [attr.stroke-dasharray]="svgGrid.scaleWithZoom(6) + ' ' + svgGrid.scaleWithZoom(4)"
         />
-      }
-    </g>
+        <!-- Grab anywhere inside to slide it. Invisible rather than absent so
+             the whole picture is the target, not just its edges. -->
+        <rect
+          class="bgImageMoveSurface"
+          pointer-events="all"
+          [attr.x]="bgImage.leftOf(bg)"
+          [attr.y]="bgImage.topOf(bg)"
+          [attr.width]="bg.width"
+          [attr.height]="bgImage.heightOf(bg)"
+          (pointerdown)="startBackgroundImageMove($event)"
+        />
+      </g>
+    }
   }
 
   <!-- Decoration, not controls: the ground triangle and the input arrow mark
@@ -728,7 +764,6 @@
             [attr.stroke-width]="svgGrid.scaleWithZoom(3)"
           />
         }
-
       </g>
     }
     <!-- The ghost of the two-point creation gesture: the same paths the
@@ -1128,9 +1163,7 @@
          the rest of an unanalysable machine does. -->
     <g
       id="forcesHolder"
-      [attr.cursor]="
-        force.locked && mechanismSrv.lockVisualsOn() ? 'not-allowed' : 'move'
-      "
+      [attr.cursor]="force.locked && mechanismSrv.lockVisualsOn() ? 'not-allowed' : 'move'"
       [class.force-inert]="mechanismSrv.isPartInert(force.link)"
       [class.force-locked]="force.locked && mechanismSrv.lockVisualsOn()"
       [attr.pointer-events]="geometryLocked ? 'none' : null"
@@ -1166,7 +1199,11 @@
           <!-- Same badge the joints wear, at the anchor: a force has no joint
                to carry it, so the mark rides where the load is applied. -->
           @if (force.locked && mechanismSrv.lockVisualsOn()) {
-            <g class="lockBadge" pointer-events="none" [attr.transform]="offsetLockBadgeTransform()">
+            <g
+              class="lockBadge"
+              pointer-events="none"
+              [attr.transform]="offsetLockBadgeTransform()"
+            >
               <circle
                 [attr.r]="0.13 * settings.objectScale"
                 fill="#ffffff"
@@ -1243,6 +1280,54 @@
         </ng-container>
       }
     </g>
+  }
+
+  <!-- The corners and the turn knob, above every part: they are the controls of
+       the gesture, and a link lying across one made it ungrabbable. Small
+       enough that what they cover is not worth having. -->
+  @if (bgImage.image(); as bg) {
+    @if (editingBackgroundImage()) {
+      <g id="backgroundImageGrips" pointer-events="none" [attr.transform]="bgImage.transformOf(bg)">
+        <!-- The turn knob, on a stalk above the top edge so it cannot be taken
+             for a corner. Round, because it swings rather than pulls. Alt
+             suspends its 15° snap, as it does everywhere else on this canvas. -->
+        <line
+          class="bgImageRotateStalk"
+          [attr.x1]="bg.centerX"
+          [attr.y1]="bgImage.topOf(bg)"
+          [attr.x2]="bg.centerX"
+          [attr.y2]="bgImage.topOf(bg) - backgroundImageRotateReach()"
+          [attr.stroke-width]="svgGrid.scaleWithZoom(1.5)"
+        />
+        <circle
+          class="bgImageHandle bgImageRotateKnob"
+          pointer-events="all"
+          cursor="grab"
+          [attr.cx]="bg.centerX"
+          [attr.cy]="bgImage.topOf(bg) - backgroundImageRotateReach()"
+          [attr.r]="backgroundImageHandleSize() * 0.65"
+          [attr.stroke-width]="svgGrid.scaleWithZoom(1.5)"
+          (pointerdown)="startBackgroundImageRotate($event)"
+        />
+        <!-- Corners resize about the opposite corner, with the file's own
+             proportions locked: a picture stretched out of shape is no longer
+             something a linkage can be measured against. Drawn at a constant
+             size on screen, so they stay grabbable at every zoom. -->
+        @for (corner of backgroundImageHandles(); track corner.id) {
+          <rect
+            class="bgImageHandle"
+            pointer-events="all"
+            [attr.x]="corner.x - backgroundImageHandleSize() / 2"
+            [attr.y]="corner.y - backgroundImageHandleSize() / 2"
+            [attr.width]="backgroundImageHandleSize()"
+            [attr.height]="backgroundImageHandleSize()"
+            [attr.stroke-width]="svgGrid.scaleWithZoom(1.5)"
+            [attr.cursor]="corner.cursor"
+            (pointerdown)="startBackgroundImageResize($event, corner.id)"
+          />
+        }
+      </g>
+    }
   }
 
   <g id="jointTagHolder" style="pointer-events: none">
@@ -1612,4 +1697,3 @@
 <ng-template #context_menu>
   <app-context-menu [menuItems]="cMenuItems"> </app-context-menu>
 </ng-template>
-

--- a/src/app/component/new-grid/new-grid.component.html
+++ b/src/app/component/new-grid/new-grid.component.html
@@ -221,6 +221,39 @@
     </g>
   }
 
+  <!-- The tracing underlay. Above the grid's white background so it is visible
+       at all, below every part of the mechanism so it can never hide one, and
+       pointer-events: none throughout -- a right-click on the picture falls
+       through to the grid beneath and opens the grid's own menu, which is where
+       the item that put it here lives. -->
+  @if (bgImage.image(); as bg) {
+    <g id="backgroundImageHolder" pointer-events="none">
+      <image
+        [attr.href]="bg.src"
+        [attr.x]="bgImage.leftOf(bg)"
+        [attr.y]="bgImage.topOf(bg)"
+        [attr.width]="bg.width"
+        [attr.height]="bgImage.heightOf(bg)"
+        [attr.opacity]="bg.opacity"
+        preserveAspectRatio="none"
+      />
+      <!-- Only while the panel is editing it: the placement fields move
+           something the user may have faded almost to nothing, so its edges
+           have to be findable while they are being typed. -->
+      @if (editingBackgroundImage()) {
+        <rect
+          class="bgImageOutline"
+          [attr.x]="bgImage.leftOf(bg)"
+          [attr.y]="bgImage.topOf(bg)"
+          [attr.width]="bg.width"
+          [attr.height]="bgImage.heightOf(bg)"
+          [attr.stroke-width]="svgGrid.scaleWithZoom(1.5)"
+          [attr.stroke-dasharray]="svgGrid.scaleWithZoom(6) + ' ' + svgGrid.scaleWithZoom(4)"
+        />
+      }
+    </g>
+  }
+
   <!-- Decoration, not controls: the ground triangle and the input arrow mark
        what a joint *is*, and both are drawn wider than the joint itself. Left
        hit-testable they sit over whatever is beneath them and swallow clicks
@@ -1552,6 +1585,17 @@
     </g>
   }
 </svg>
+<!-- The file dialog the Add background image menu item opens. Off-screen
+     rather than display:none, because a hidden input cannot be driven by the
+     browser's own picker on every platform. Its value is cleared after each
+     pick so choosing the same file twice still fires a change. -->
+<input
+  #backgroundImageInput
+  type="file"
+  accept="image/*"
+  class="offscreenFileInput"
+  (change)="onBackgroundImageChosen($event)"
+/>
 @if (settings.isGridDebugOn) {
   <div id="mouseLocation">
     Mouse Location: {{ (mouseLocation.x / MODEL_SCALE).toFixed(2) }},

--- a/src/app/component/new-grid/new-grid.component.scss
+++ b/src/app/component/new-grid/new-grid.component.scss
@@ -143,6 +143,26 @@
   // nothing here restyles strokes and no state can cover another. The classes
   // below stay as truthful state markers for tests and tooling.
 
+  // The edges of the tracing underlay, drawn only while its panel is open. The
+  // same accent every other "this is the thing you are editing" mark uses,
+  // broken rather than solid so a rectangle of picture cannot read as a part.
+  .bgImageOutline {
+    fill: none;
+    stroke: mat.m2-get-color-from-palette($accent-palette, 500);
+    pointer-events: none;
+  }
+
+  // The file dialog's input, kept out of the layout without display:none --
+  // which stops some browsers opening a picker from a synthetic click.
+  .offscreenFileInput {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+    left: -9999px;
+  }
+
   #mouseLocation {
     position: absolute;
     top: 35px;

--- a/src/app/component/new-grid/new-grid.component.scss
+++ b/src/app/component/new-grid/new-grid.component.scss
@@ -152,6 +152,27 @@
     pointer-events: none;
   }
 
+  // Grab anywhere inside to slide the picture. Invisible, but a target: the
+  // whole picture moves, not just its edges.
+  .bgImageMoveSurface {
+    fill: transparent;
+    cursor: move;
+  }
+
+  // The corners and the turn knob. Filled rather than hollow so they read as
+  // things to take hold of, and white-edged so they stay findable over a dark
+  // photograph.
+  .bgImageHandle {
+    fill: mat.m2-get-color-from-palette($accent-palette, 500);
+    stroke: #fff;
+  }
+
+  // What holds the turn knob off the top edge, so it is not read as a corner.
+  .bgImageRotateStalk {
+    stroke: mat.m2-get-color-from-palette($accent-palette, 500);
+    pointer-events: none;
+  }
+
   // The file dialog's input, kept out of the layout without display:none --
   // which stops some browsers opening a picker from a synthetic click.
   .offscreenFileInput {

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -2,6 +2,7 @@ import { SvgGridService } from '../../services/svg-grid.service';
 import {
   OnDestroy,
   Component,
+  ElementRef,
   HostListener,
   ChangeDetectionStrategy,
   inject,
@@ -32,6 +33,7 @@ import {
 } from '../../model/utils';
 import { Force } from '../../model/force';
 import { NotificationService } from '../../services/notification.service';
+import { BackgroundImageService } from '../../services/background-image.service';
 import { CdkContextMenuTrigger } from '@angular/cdk/menu';
 import { MatDialog } from '@angular/material/dialog';
 import { TouchscreenWarningComponent } from '../MODALS/touchscreen-warning/touchscreen-warning.component';
@@ -132,6 +134,7 @@ export class NewGridComponent implements OnDestroy {
   nup = inject(NumberUnitParserService);
   dragState = inject(DragStateService);
   sliderMarks = inject(SliderMarkService);
+  bgImage = inject(BackgroundImageService);
 
   public static debugValue: unknown;
   static debugPoints: Coord[] = [];
@@ -229,6 +232,8 @@ export class NewGridComponent implements OnDestroy {
   }
 
   readonly contextMenu = viewChild.required<CdkContextMenuTrigger>('trigger');
+  private readonly backgroundImageInput =
+    viewChild.required<ElementRef<HTMLInputElement>>('backgroundImageInput');
 
   ngOnInit() {
     const svgElement = document.getElementById('canvas') as HTMLElement;
@@ -635,6 +640,16 @@ export class NewGridComponent implements OnDestroy {
         this.cMenuItems.push(
           new cMenuItem('Add Cylinder', this.startCreatingCylinder.bind(this), 'add_cylinder')
         );
+        // Scenery rather than mechanism, so it sits below the two items that
+        // draw parts. One item for both halves: with a picture already placed
+        // there is nothing left to add, only somewhere to adjust it.
+        this.cMenuItems.push(
+          new cMenuItem(
+            this.bgImage.image() ? 'Edit background image' : 'Add background image',
+            () => this.openBackgroundImage(),
+            'background_image'
+          )
+        );
         // Lock everything, unlock one handle, drag: the posing workflow. On
         // the canvas menu because this is where the locking gesture lives —
         // and greyed rather than hidden when there is nothing to act on.
@@ -654,6 +669,65 @@ export class NewGridComponent implements OnDestroy {
             !this.mechanismSrv.anythingLocked()
           )
         );
+    }
+  }
+
+  /**
+   * Whether the panel is currently editing the background image.
+   *
+   * Every clause is a way the panel can go without the selection changing: the
+   * analysis modes replace it, and playback covers it with the stop-the-
+   * animation placeholder. An outline for controls that are not on screen is a
+   * mark nobody can explain.
+   */
+  editingBackgroundImage(): boolean {
+    return (
+      this.activeObjService.objType === 'BackgroundImage' &&
+      !this.tabService.isAnalysisMode() &&
+      !this.mechanismSrv.isPlaying &&
+      this.mechanismSrv.mechanismTimeStep === 0
+    );
+  }
+
+  /**
+   * The one menu item, doing whichever half applies: pick a file if there is no
+   * picture yet, otherwise just open the panel on the one there is.
+   */
+  private openBackgroundImage(): void {
+    this.tabService.setTab(TabID.EDIT);
+    if (this.bgImage.image()) {
+      this.activeObjService.selectBackgroundImage();
+      return;
+    }
+    const input = this.backgroundImageInput().nativeElement;
+    input.value = '';
+    input.click();
+  }
+
+  /** Read the chosen file, place it across half the visible grid, and select it. */
+  async onBackgroundImageChosen(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = '';
+    if (!file) return;
+
+    try {
+      // Half the width of what is on screen: big enough to be obviously there,
+      // small enough that the mechanism under construction is still visible
+      // around it. Zoom-dependent by design — the picture arrives where the
+      // user is looking rather than at some fixed size off the edge.
+      const visibleWidth = this.svgGrid.viewBoxMaxX - this.svgGrid.viewBoxMinX;
+      await this.bgImage.load(file, visibleWidth / 2);
+      this.activeObjService.selectBackgroundImage();
+      this.notify.success(
+        'bgImage.added',
+        `${file.name} is behind the grid. It is not saved in the share link.`
+      );
+    } catch (error) {
+      this.notify.failure(
+        'bgImage.failed',
+        error instanceof Error ? error.message : 'That image could not be loaded.'
+      );
     }
   }
 

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -33,7 +33,7 @@ import {
 } from '../../model/utils';
 import { Force } from '../../model/force';
 import { NotificationService } from '../../services/notification.service';
-import { BackgroundImageService } from '../../services/background-image.service';
+import { BackgroundImageService, MIN_WIDTH } from '../../services/background-image.service';
 import { CdkContextMenuTrigger } from '@angular/cdk/menu';
 import { MatDialog } from '@angular/material/dialog';
 import { TouchscreenWarningComponent } from '../MODALS/touchscreen-warning/touchscreen-warning.component';
@@ -110,6 +110,9 @@ export interface SlotStackItem {
 }
 import introJs from 'intro.js';
 import { SvgArrowComponent } from '../svg-arrow/svg-arrow.component';
+
+/** Which corner of the tracing underlay a resize gesture is holding. */
+type BackgroundImageCorner = 'tl' | 'tr' | 'bl' | 'br';
 
 @Component({
   selector: 'app-new-grid',
@@ -679,14 +682,186 @@ export class NewGridComponent implements OnDestroy {
    * analysis modes replace it, and playback covers it with the stop-the-
    * animation placeholder. An outline for controls that are not on screen is a
    * mark nobody can explain.
+   *
+   * The last one is not about the panel at all. `tempGridDisable` is the flag
+   * "Fit to zoom" sets while it measures the drawing, and an outline the size
+   * of the picture counts towards that box exactly as the picture would -- the
+   * fit framed a hundred-centimetre photograph and left the linkage too small
+   * to work on.
    */
   editingBackgroundImage(): boolean {
     return (
       this.activeObjService.objType === 'BackgroundImage' &&
       !this.tabService.isAnalysisMode() &&
       !this.mechanismSrv.isPlaying &&
-      this.mechanismSrv.mechanismTimeStep === 0
+      this.mechanismSrv.mechanismTimeStep === 0 &&
+      !this.settings.tempGridDisable
     );
+  }
+
+  /** Half a centimetre of screen, whatever the zoom: a grabbable corner. */
+  backgroundImageHandleSize(): number {
+    return this.svgGrid.scaleWithZoom(10);
+  }
+
+  /** How far above the top edge the turn handle stands, at any zoom. */
+  backgroundImageRotateReach(): number {
+    return this.svgGrid.scaleWithZoom(34);
+  }
+
+  /**
+   * The four corners, in SVG coordinates, each with the cursor that says which
+   * way it pulls.
+   */
+  backgroundImageHandles(): { id: BackgroundImageCorner; x: number; y: number; cursor: string }[] {
+    const image = this.bgImage.image();
+    if (!image) return [];
+    const left = this.bgImage.leftOf(image);
+    const top = this.bgImage.topOf(image);
+    const right = left + image.width;
+    const bottom = top + this.bgImage.heightOf(image);
+    return [
+      { id: 'tl', x: left, y: top, cursor: 'nwse-resize' },
+      { id: 'tr', x: right, y: top, cursor: 'nesw-resize' },
+      { id: 'bl', x: left, y: bottom, cursor: 'nesw-resize' },
+      { id: 'br', x: right, y: bottom, cursor: 'nwse-resize' },
+    ];
+  }
+
+  /**
+   * The gesture in flight on the picture, if there is one.
+   *
+   * `stopPropagation` on the press is what keeps svg-pan-zoom out of it — the
+   * library binds its own handler to the canvas root, so a press that reaches
+   * it starts a pan under the drag. The state lives here rather than in
+   * DragStateService's enums because moving scenery is not an edit: it earns no
+   * rebuild and no undo entry.
+   */
+  private bgDrag?: {
+    corner?: BackgroundImageCorner;
+    /** For a move: model-space offset from the pointer to the picture's centre. */
+    grabOffset?: Coord;
+    /** For a resize: the corner that stays where it is, in model coordinates. */
+    anchor?: Coord;
+    /** For a turn: the angle the hand grabbed at, less the picture's own. */
+    grabAngleRad?: number;
+  };
+
+  startBackgroundImageMove(event: PointerEvent): void {
+    const image = this.bgImage.image();
+    if (!image || !this.editingBackgroundImage()) return;
+    event.stopPropagation();
+    const at = this.svgGrid.screenToSVGfromXY(event.clientX, event.clientY);
+    this.bgDrag = { grabOffset: new Coord(image.centerX - at.x, image.centerY - at.y) };
+    this.dragState.press();
+    this.dragState.beginDraggingBackgroundImage();
+  }
+
+  /**
+   * How far along the picture's own axes a corner sits from its centre: +1 to
+   * the right and up in the picture's frame, whatever the picture is turned to.
+   */
+  private cornerSigns(corner: BackgroundImageCorner): { alongX: number; alongY: number } {
+    return {
+      alongX: corner === 'tr' || corner === 'br' ? 1 : -1,
+      alongY: corner === 'tl' || corner === 'tr' ? 1 : -1,
+    };
+  }
+
+  startBackgroundImageResize(event: PointerEvent, corner: BackgroundImageCorner): void {
+    const image = this.bgImage.image();
+    if (!image || !this.editingBackgroundImage()) return;
+    event.stopPropagation();
+    // The opposite corner is what the drag pivots on, and it is held in world
+    // coordinates: the resize moves the centre, and the picture may be turned,
+    // so an anchor remembered in the picture's own frame would not stay put.
+    const { alongX, alongY } = this.cornerSigns(corner);
+    const axes = this.backgroundImageAxes(image);
+    const halfHeight = this.bgImage.heightOf(image) / 2;
+    this.bgDrag = {
+      corner,
+      anchor: new Coord(
+        image.centerX - alongX * (image.width / 2) * axes.u.x - alongY * halfHeight * axes.v.x,
+        image.centerY - alongX * (image.width / 2) * axes.u.y - alongY * halfHeight * axes.v.y
+      ),
+    };
+    this.dragState.press();
+    this.dragState.beginDraggingBackgroundImage();
+  }
+
+  startBackgroundImageRotate(event: PointerEvent): void {
+    const image = this.bgImage.image();
+    if (!image || !this.editingBackgroundImage()) return;
+    event.stopPropagation();
+    const at = this.svgGrid.screenToSVGfromXY(event.clientX, event.clientY);
+    // What the hand grabbed at, less what the picture already is: the drag then
+    // turns the picture with the hand rather than snapping it to the pointer.
+    this.bgDrag = {
+      grabAngleRad: Math.atan2(at.y - image.centerY, at.x - image.centerX) - image.rotationRad,
+    };
+    this.dragState.press();
+    this.dragState.beginDraggingBackgroundImage();
+  }
+
+  /** The picture's own axes in model coordinates: along its width, and up it. */
+  private backgroundImageAxes(image: { rotationRad: number }): { u: Coord; v: Coord } {
+    const cos = Math.cos(image.rotationRad);
+    const sin = Math.sin(image.rotationRad);
+    return { u: new Coord(cos, sin), v: new Coord(-sin, cos) };
+  }
+
+  /**
+   * Follow the pointer for whichever gesture is in flight. Returns whether it
+   * handled the move, so mouseMove can stop before the mechanism's own drags.
+   */
+  private dragBackgroundImage(at: Coord): boolean {
+    const image = this.bgImage.image();
+    if (!this.bgDrag || !image) return false;
+
+    if (this.bgDrag.grabOffset) {
+      this.bgImage.place({
+        centerX: at.x + this.bgDrag.grabOffset.x,
+        centerY: at.y + this.bgDrag.grabOffset.y,
+      });
+      return true;
+    }
+
+    if (this.bgDrag.grabAngleRad !== undefined) {
+      const turned =
+        Math.atan2(at.y - image.centerY, at.x - image.centerX) - this.bgDrag.grabAngleRad;
+      // Quarter turns and the common skews land exactly, which is most of what
+      // squaring a photograph to a grid actually needs. Alt suspends it, the
+      // same key that suspends snapping everywhere else on this canvas.
+      const step = Math.PI / 12; // 15 degrees
+      this.bgImage.place({
+        rotationRad: this.snapSuspended ? turned : Math.round(turned / step) * step,
+      });
+      return true;
+    }
+
+    const anchor = this.bgDrag.anchor!;
+    const ratio = image.naturalHeight / image.naturalWidth;
+    const { alongX, alongY } = this.cornerSigns(this.bgDrag.corner!);
+    const axes = this.backgroundImageAxes(image);
+    // How far the pointer is from the anchor along each of the picture's own
+    // axes. Measuring in the picture's frame is what lets a turned picture
+    // resize by the corner the hand is actually holding.
+    const reach = new Coord(at.x - anchor.x, at.y - anchor.y);
+    const alongWidth = reach.x * axes.u.x + reach.y * axes.u.y;
+    const alongHeight = reach.x * axes.v.x + reach.y * axes.v.y;
+    // Whichever axis the hand pulled further decides the size, so the corner
+    // keeps up with a diagonal drag instead of tracking only one of them.
+    const width = Math.max(MIN_WIDTH, Math.abs(alongWidth), Math.abs(alongHeight) / ratio);
+    const height = width * ratio;
+    // The signs come from which corner is held, not from where the pointer is:
+    // dragged past its anchor, the picture pins at its minimum rather than
+    // flipping to the other side of it.
+    this.bgImage.place({
+      width,
+      centerX: anchor.x + alongX * (width / 2) * axes.u.x + alongY * (height / 2) * axes.v.x,
+      centerY: anchor.y + alongX * (width / 2) * axes.u.y + alongY * (height / 2) * axes.v.y,
+    });
+    return true;
   }
 
   /**
@@ -1161,6 +1336,11 @@ export class NewGridComponent implements OnDestroy {
     this.svgGrid.cursorAt = mousePosInSvg;
 
     this.dragState.notePointerMoved();
+
+    // The picture is scenery, and its gesture owns the pointer outright: no
+    // snapping, no drop candidates, no mechanism state to keep in step.
+    if (this.dragBackgroundImage(mousePosInSvg)) return;
+
     let deltaMouseX = this.mouseLocation.x - this.lastMouseLocation.x;
     let deltaMouseY = this.mouseLocation.y - this.lastMouseLocation.y;
 
@@ -1914,6 +2094,7 @@ export class NewGridComponent implements OnDestroy {
 
   mouseUp($event: MouseEvent) {
     //This is the mouseUp that is called no matter what is clicked on
+    this.bgDrag = undefined;
     this.synthesisClickMode = SynthesisClickMode.NORMAL;
     // The alignment guides belong to the drag that made them.
     this.axisSnapGuides = [];

--- a/src/app/services/active-obj.service.ts
+++ b/src/app/services/active-obj.service.ts
@@ -6,7 +6,15 @@ import { Coord } from '../model/coord';
 import { SynthesisPose } from './synthesis/synthesis-util';
 
 export type ActiveObjType =
-  'Nothing' | 'Joint' | 'Force' | 'Link' | 'Grid' | 'SynthesisPose' | 'Mechanism';
+  | 'Nothing'
+  | 'Joint'
+  | 'Force'
+  | 'Link'
+  | 'Grid'
+  | 'SynthesisPose'
+  | 'Mechanism'
+  /** The tracing underlay, which is scenery rather than part of the linkage. */
+  | 'BackgroundImage';
 
 @Injectable({
   providedIn: 'root',
@@ -51,6 +59,19 @@ export class ActiveObjService {
 
   fakeUpdateSelectedObj() {
     //Don't actually update the selected object, just emit the event so subscribers can update
+    this.onActiveObjChange.emit(this.objType);
+  }
+
+  /**
+   * Put the background image in the edit panel.
+   *
+   * It is not a mechanism object and has no entry in getSelectedObj(): the only
+   * thing this selection does is decide which panel is showing, and the panel
+   * reads the picture from its own service.
+   */
+  selectBackgroundImage() {
+    this.selectedMechanismIndex = -1;
+    this.objType = 'BackgroundImage';
     this.onActiveObjChange.emit(this.objType);
   }
 

--- a/src/app/services/background-image.service.spec.ts
+++ b/src/app/services/background-image.service.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
-import { BackgroundImageService, BackgroundImage } from './background-image.service';
+import { BackgroundImageService, BackgroundImage, MIN_WIDTH } from './background-image.service';
+import { SettingsService } from './settings.service';
+import { LengthUnit } from '../model/unit-enums';
 import { MODEL_SCALE } from '../model/render-scale';
 
 /** A placed picture with a known 2:1 shape, so the derived height is checkable. */
@@ -11,6 +13,7 @@ function placed(over: Partial<BackgroundImage> = {}): BackgroundImage {
     centerX: 0,
     centerY: 0,
     width: 4 * MODEL_SCALE,
+    rotationRad: 0,
     opacity: 0.5,
     fileName: 'rig.png',
     ...over,
@@ -70,10 +73,13 @@ describe('BackgroundImageService', () => {
       expect(image.src).toBe('data:image/png;base64,AAAA');
     });
 
-    it('refuses to shrink the picture to nothing', () => {
+    // The floor exists for the corner drag, which can be pulled through zero.
+    // A typed width below it is refused by the panel instead, so the number in
+    // the field is always the number that took effect.
+    it('holds the picture at its minimum width rather than letting it vanish', () => {
       service.image.set(placed());
       service.place({ width: 0 });
-      expect(service.image()!.width).toBeGreaterThan(0);
+      expect(service.image()!.width).toBe(MIN_WIDTH);
     });
 
     it('holds opacity inside 0..1', () => {
@@ -104,6 +110,82 @@ describe('BackgroundImageService', () => {
       Object.defineProperty(file, 'size', { value: 13 * 1024 * 1024 });
       await expect(service.load(file, MODEL_SCALE)).rejects.toThrow(/limit is 12 MB/);
       expect(service.image()).toBeNull();
+    });
+  });
+
+  /**
+   * A unit change rescales every stored coordinate in the drawing, so a picture
+   * that stayed put would be left the conversion factor's worth of wrong size
+   * against the very linkage it was put there to be traced by.
+   */
+  describe('a change of length unit', () => {
+    let settings: SettingsService;
+
+    beforeEach(() => {
+      settings = TestBed.inject(SettingsService);
+      settings.lengthUnit.next(LengthUnit.CM);
+      service.image.set(placed({ centerX: 3 * MODEL_SCALE, centerY: -1 * MODEL_SCALE }));
+    });
+
+    it('restates the placement in the new unit', () => {
+      settings.lengthUnit.next(LengthUnit.METER);
+      const image = service.image()!;
+      // A centimetre is a hundredth of a metre, so every number is too.
+      expect(image.centerX).toBeCloseTo(0.03 * MODEL_SCALE, 6);
+      expect(image.centerY).toBeCloseTo(-0.01 * MODEL_SCALE, 6);
+      expect(image.width).toBeCloseTo(0.04 * MODEL_SCALE, 6);
+    });
+
+    it('leaves the picture and its proportions alone', () => {
+      settings.lengthUnit.next(LengthUnit.INCH);
+      const image = service.image()!;
+      expect(image.src).toBe('data:image/png;base64,AAAA');
+      expect(service.heightOf(image) / image.width).toBeCloseTo(0.5, 9);
+    });
+
+    it('does nothing when the unit is set to the one already in force', () => {
+      const before = service.image()!;
+      settings.lengthUnit.next(LengthUnit.CM);
+      expect(service.image()).toBe(before);
+    });
+
+    it('is harmless with no picture placed', () => {
+      service.remove();
+      expect(() => settings.lengthUnit.next(LengthUnit.METER)).not.toThrow();
+      expect(service.image()).toBeNull();
+    });
+  });
+
+  /**
+   * The stored angle is counter-clockwise-positive like every other angle in
+   * the app; SVG's rotate is clockwise-positive because its y points down. A
+   * transform that forgot the sign turns the picture the wrong way, which on a
+   * photograph of a linkage looks like a mirror rather than a mistake.
+   */
+  describe('the turn', () => {
+    it('is the identity when the picture is square to the grid', () => {
+      const image = placed({ centerX: 2 * MODEL_SCALE, centerY: MODEL_SCALE });
+      expect(service.transformOf(image)).toBe(`rotate(0, ${2 * MODEL_SCALE}, ${-MODEL_SCALE})`);
+    });
+
+    it('goes to SVG the other way round, about the picture’s own centre', () => {
+      const image = placed({ centerX: 0, centerY: 2 * MODEL_SCALE, rotationRad: Math.PI / 2 });
+      expect(service.transformOf(image)).toBe(`rotate(-90, 0, ${-2 * MODEL_SCALE})`);
+    });
+
+    it('is placed like any other part of the placement', () => {
+      service.image.set(placed());
+      service.place({ rotationRad: Math.PI / 4 });
+      expect(service.image()!.rotationRad).toBeCloseTo(Math.PI / 4, 9);
+      expect(service.image()!.width).toBe(4 * MODEL_SCALE);
+    });
+
+    it('survives a change of length unit, which rescales rather than turns', () => {
+      const settings = TestBed.inject(SettingsService);
+      settings.lengthUnit.next(LengthUnit.CM);
+      service.image.set(placed({ rotationRad: Math.PI / 6 }));
+      settings.lengthUnit.next(LengthUnit.METER);
+      expect(service.image()!.rotationRad).toBeCloseTo(Math.PI / 6, 9);
     });
   });
 

--- a/src/app/services/background-image.service.spec.ts
+++ b/src/app/services/background-image.service.spec.ts
@@ -1,0 +1,115 @@
+import { TestBed } from '@angular/core/testing';
+import { BackgroundImageService, BackgroundImage } from './background-image.service';
+import { MODEL_SCALE } from '../model/render-scale';
+
+/** A placed picture with a known 2:1 shape, so the derived height is checkable. */
+function placed(over: Partial<BackgroundImage> = {}): BackgroundImage {
+  return {
+    src: 'data:image/png;base64,AAAA',
+    naturalWidth: 400,
+    naturalHeight: 200,
+    centerX: 0,
+    centerY: 0,
+    width: 4 * MODEL_SCALE,
+    opacity: 0.5,
+    fileName: 'rig.png',
+    ...over,
+  };
+}
+
+describe('BackgroundImageService', () => {
+  let service: BackgroundImageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BackgroundImageService);
+  });
+
+  it('starts with nothing behind the grid', () => {
+    expect(service.image()).toBeNull();
+  });
+
+  describe('geometry', () => {
+    it('derives the height from the file’s own proportions', () => {
+      const image = placed();
+      expect(service.heightOf(image)).toBe(2 * MODEL_SCALE);
+    });
+
+    it('keeps those proportions when the width changes', () => {
+      service.image.set(placed());
+      service.place({ width: 10 * MODEL_SCALE });
+      expect(service.heightOf(service.image()!)).toBe(5 * MODEL_SCALE);
+    });
+
+    it('places the left edge half a width left of centre', () => {
+      const image = placed({ centerX: 3 * MODEL_SCALE });
+      expect(service.leftOf(image)).toBe(MODEL_SCALE);
+    });
+
+    /**
+     * The image layer is drawn unflipped while the model has y up, so a picture
+     * centred above the axis has to be at a negative SVG y. Getting this
+     * backwards mirrors the underlay about the x axis, which is invisible on a
+     * symmetric picture and wrong on every other one.
+     */
+    it('flips y, because the image layer is drawn in SVG coordinates', () => {
+      const image = placed({ centerY: 5 * MODEL_SCALE });
+      expect(service.topOf(image)).toBe(-6 * MODEL_SCALE);
+    });
+  });
+
+  describe('place', () => {
+    it('changes only the field it is given', () => {
+      service.image.set(placed());
+      service.place({ centerX: 2 * MODEL_SCALE });
+      const image = service.image()!;
+      expect(image.centerX).toBe(2 * MODEL_SCALE);
+      expect(image.centerY).toBe(0);
+      expect(image.width).toBe(4 * MODEL_SCALE);
+      expect(image.opacity).toBe(0.5);
+      expect(image.src).toBe('data:image/png;base64,AAAA');
+    });
+
+    it('refuses to shrink the picture to nothing', () => {
+      service.image.set(placed());
+      service.place({ width: 0 });
+      expect(service.image()!.width).toBeGreaterThan(0);
+    });
+
+    it('holds opacity inside 0..1', () => {
+      service.image.set(placed());
+      service.place({ opacity: 4 });
+      expect(service.image()!.opacity).toBe(1);
+      service.place({ opacity: -1 });
+      expect(service.image()!.opacity).toBe(0);
+    });
+
+    it('does nothing when there is no picture', () => {
+      service.place({ centerX: 5 });
+      expect(service.image()).toBeNull();
+    });
+  });
+
+  describe('load', () => {
+    it('refuses a file that is not an image', async () => {
+      const file = new File(['not a picture'], 'notes.txt', { type: 'text/plain' });
+      await expect(service.load(file, MODEL_SCALE)).rejects.toThrow(/not an image/);
+      expect(service.image()).toBeNull();
+    });
+
+    it('refuses a file too large to hold in memory', async () => {
+      const file = new File(['x'], 'huge.png', { type: 'image/png' });
+      // A real 13 MB buffer would slow every run of this suite; the guard reads
+      // the reported size, so a reported size is what it is given.
+      Object.defineProperty(file, 'size', { value: 13 * 1024 * 1024 });
+      await expect(service.load(file, MODEL_SCALE)).rejects.toThrow(/limit is 12 MB/);
+      expect(service.image()).toBeNull();
+    });
+  });
+
+  it('remove clears the picture', () => {
+    service.image.set(placed());
+    service.remove();
+    expect(service.image()).toBeNull();
+  });
+});

--- a/src/app/services/background-image.service.ts
+++ b/src/app/services/background-image.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, signal } from '@angular/core';
+import { MODEL_SCALE } from '../model/render-scale';
+
+/**
+ * A picture pinned behind the grid, for building a linkage on top of one.
+ *
+ * Everything here is in internal model units (see MODEL_SCALE), the same units
+ * a Joint's x and y are in, so the placement numbers can be handed straight to
+ * the SVG alongside the mechanism's own geometry.
+ */
+export interface BackgroundImage {
+  /** The picture itself, as a data URL: the file is never uploaded anywhere. */
+  src: string;
+  /** The file's own pixel size, which fixes the aspect ratio. */
+  naturalWidth: number;
+  naturalHeight: number;
+  /** Where the middle of the picture sits, in model units. */
+  centerX: number;
+  centerY: number;
+  /** How wide the picture is drawn, in model units. Height follows the ratio. */
+  width: number;
+  /** 0..1. A tracing underlay wants to be visible *through*, not just under. */
+  opacity: number;
+  /** The name of the file it came from, for the panel to show. */
+  fileName: string;
+}
+
+/** The largest file we will read, in bytes. */
+export const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
+
+/** Nothing narrower than this is a picture you could trace anything against. */
+const MIN_WIDTH = 0.05 * MODEL_SCALE;
+
+@Injectable({ providedIn: 'root' })
+export class BackgroundImageService {
+  /**
+   * The one picture, or none.
+   *
+   * Deliberately outside the URL codec and outside the undo history: an image
+   * is megabytes and a shared URL is a few hundred characters, so there is no
+   * version of this that survives a link. The panel says so in as many words.
+   */
+  readonly image = signal<BackgroundImage | null>(null);
+
+  /** How tall the picture is drawn, in model units — the ratio decides. */
+  heightOf(image: BackgroundImage): number {
+    return (image.width * image.naturalHeight) / image.naturalWidth;
+  }
+
+  /** The picture's left edge in SVG coordinates. */
+  leftOf(image: BackgroundImage): number {
+    return image.centerX - image.width / 2;
+  }
+
+  /**
+   * The picture's top edge in SVG coordinates.
+   *
+   * The image layer is drawn unflipped, so a model y of +2 is an SVG y of -2 —
+   * which is why this negates the centre rather than adding to it.
+   */
+  topOf(image: BackgroundImage): number {
+    return -image.centerY - this.heightOf(image) / 2;
+  }
+
+  /**
+   * Read a chosen file and place it, centred on the origin, sized to `fitWidth`.
+   *
+   * Rejects rather than guesses on anything it cannot decode: a broken data URL
+   * drawn into the canvas is an invisible failure, and the caller turns this
+   * into a message the user can act on.
+   */
+  async load(file: File, fitWidth: number): Promise<void> {
+    if (!file.type.startsWith('image/')) {
+      throw new Error(`${file.name} is not an image.`);
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+      throw new Error(
+        `${file.name} is ${(file.size / 1024 / 1024).toFixed(1)} MB. The limit is ${
+          MAX_IMAGE_BYTES / 1024 / 1024
+        } MB.`
+      );
+    }
+
+    const src = await readAsDataURL(file);
+    const { width, height } = await measure(src);
+
+    this.image.set({
+      src,
+      naturalWidth: width,
+      naturalHeight: height,
+      centerX: 0,
+      centerY: 0,
+      width: Math.max(MIN_WIDTH, fitWidth),
+      opacity: 0.5,
+      fileName: file.name,
+    });
+  }
+
+  /** Change part of the placement, leaving the picture itself alone. */
+  place(change: Partial<Pick<BackgroundImage, 'centerX' | 'centerY' | 'width' | 'opacity'>>): void {
+    const current = this.image();
+    if (!current) return;
+    this.image.set({
+      ...current,
+      ...change,
+      width: Math.max(MIN_WIDTH, change.width ?? current.width),
+      opacity: clamp(change.opacity ?? current.opacity, 0, 1),
+    });
+  }
+
+  remove(): void {
+    this.image.set(null);
+  }
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(high, Math.max(low, value));
+}
+
+function readAsDataURL(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error(`${file.name} could not be read.`));
+    reader.readAsDataURL(file);
+  });
+}
+
+function measure(src: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const probe = new Image();
+    probe.onload = () => {
+      if (!probe.naturalWidth || !probe.naturalHeight) {
+        reject(new Error('That image has no size the browser could read.'));
+        return;
+      }
+      resolve({ width: probe.naturalWidth, height: probe.naturalHeight });
+    };
+    probe.onerror = () => reject(new Error('That image could not be decoded.'));
+    probe.src = src;
+  });
+}

--- a/src/app/services/background-image.service.ts
+++ b/src/app/services/background-image.service.ts
@@ -1,5 +1,7 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { MODEL_SCALE } from '../model/render-scale';
+import { SettingsService } from './settings.service';
+import { NumberUnitParserService } from './number-unit-parser.service';
 
 /**
  * A picture pinned behind the grid, for building a linkage on top of one.
@@ -19,6 +21,12 @@ export interface BackgroundImage {
   centerY: number;
   /** How wide the picture is drawn, in model units. Height follows the ratio. */
   width: number;
+  /**
+   * How far the picture is turned about its own centre, in radians,
+   * counter-clockwise-positive — the same sense as every other angle in the
+   * app. A photograph is rarely taken square to the mechanism in it.
+   */
+  rotationRad: number;
   /** 0..1. A tracing underlay wants to be visible *through*, not just under. */
   opacity: number;
   /** The name of the file it came from, for the panel to show. */
@@ -28,8 +36,14 @@ export interface BackgroundImage {
 /** The largest file we will read, in bytes. */
 export const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
 
-/** Nothing narrower than this is a picture you could trace anything against. */
-const MIN_WIDTH = 0.05 * MODEL_SCALE;
+/**
+ * Nothing narrower than this is a picture you could trace anything against.
+ *
+ * A floor for the corner drag, which can be pulled through zero; a typed width
+ * below it is refused by the panel rather than quietly rounded up here, so the
+ * number in the field is always the number that took effect.
+ */
+export const MIN_WIDTH = 0.05 * MODEL_SCALE;
 
 @Injectable({ providedIn: 'root' })
 export class BackgroundImageService {
@@ -41,6 +55,39 @@ export class BackgroundImageService {
    * version of this that survives a link. The panel says so in as many words.
    */
   readonly image = signal<BackgroundImage | null>(null);
+
+  private settings = inject(SettingsService);
+  private nup = inject(NumberUnitParserService);
+
+  constructor() {
+    // A change of length unit rescales every stored coordinate in the drawing,
+    // so a picture whose placement stayed put would be left at the conversion
+    // factor's worth of wrong size — a linkage traced in centimetres came back
+    // a hundred times too small against its own photograph.
+    //
+    // Watched here rather than patched into the settings panel because a unit
+    // change also arrives by replaying a URL: undo and redo cross one whenever
+    // the step they are undoing did, and both routes come through this subject.
+    let previous = this.settings.lengthUnit.value;
+    this.settings.lengthUnit.subscribe((unit) => {
+      const from = previous;
+      previous = unit;
+      if (from === unit) return;
+      this.rescale(this.nup.convertLength(1, from, unit));
+    });
+  }
+
+  /** Restate the placement in units that are now worth `factor` times as much. */
+  private rescale(factor: number): void {
+    const current = this.image();
+    if (!current || !Number.isFinite(factor) || factor <= 0) return;
+    this.image.set({
+      ...current,
+      centerX: current.centerX * factor,
+      centerY: current.centerY * factor,
+      width: current.width * factor,
+    });
+  }
 
   /** How tall the picture is drawn, in model units — the ratio decides. */
   heightOf(image: BackgroundImage): number {
@@ -60,6 +107,19 @@ export class BackgroundImageService {
    */
   topOf(image: BackgroundImage): number {
     return -image.centerY - this.heightOf(image) / 2;
+  }
+
+  /**
+   * The turn, as an SVG transform about the picture's own centre.
+   *
+   * Negated: the stored angle is counter-clockwise-positive like every other
+   * angle in the app, and SVG's rotate is clockwise-positive because its y
+   * points down. Everything drawn inside this transform can then be laid out
+   * as though the picture were square to the grid.
+   */
+  transformOf(image: BackgroundImage): string {
+    const degrees = (-image.rotationRad * 180) / Math.PI;
+    return `rotate(${degrees}, ${image.centerX}, ${-image.centerY})`;
   }
 
   /**
@@ -91,13 +151,18 @@ export class BackgroundImageService {
       centerX: 0,
       centerY: 0,
       width: Math.max(MIN_WIDTH, fitWidth),
+      rotationRad: 0,
       opacity: 0.5,
       fileName: file.name,
     });
   }
 
   /** Change part of the placement, leaving the picture itself alone. */
-  place(change: Partial<Pick<BackgroundImage, 'centerX' | 'centerY' | 'width' | 'opacity'>>): void {
+  place(
+    change: Partial<
+      Pick<BackgroundImage, 'centerX' | 'centerY' | 'width' | 'rotationRad' | 'opacity'>
+    >
+  ): void {
     const current = this.image();
     if (!current) return;
     this.image.set({

--- a/src/app/services/drag-state.service.ts
+++ b/src/app/services/drag-state.service.ts
@@ -60,6 +60,15 @@ export class DragStateService {
     );
   }
 
+  /**
+   * The tracing underlay is being moved or resized by its handles.
+   *
+   * Kept apart from the four enums because it is not mechanism state: it makes
+   * `isDragging` true, so the canvas does not pan underneath the gesture, but
+   * it never reaches `noteMechanismModified` and so earns no undo entry.
+   */
+  private backgroundImageHeld = false;
+
   /** True while an existing object is being moved, as opposed to created. */
   get isDragging(): boolean {
     return (
@@ -67,7 +76,8 @@ export class DragStateService {
       this._link === linkStates.dragging ||
       this._force === forceStates.draggingStart ||
       this._force === forceStates.draggingEnd ||
-      this._force === forceStates.draggingBody
+      this._force === forceStates.draggingBody ||
+      this.backgroundImageHeld
     );
   }
 
@@ -131,6 +141,10 @@ export class DragStateService {
     this._force = forceStates.draggingBody;
   }
 
+  beginDraggingBackgroundImage(): void {
+    this.backgroundImageHeld = true;
+  }
+
   // --- Gesture ----------------------------------------------------------
 
   /** A pointer went down. Starts a fresh gesture; nothing is owed yet. */
@@ -177,5 +191,6 @@ export class DragStateService {
     this._joint = jointStates.waiting;
     this._link = linkStates.waiting;
     this._force = forceStates.waiting;
+    this.backgroundImageHeld = false;
   }
 }

--- a/src/app/services/svg-grid.service.ts
+++ b/src/app/services/svg-grid.service.ts
@@ -507,12 +507,36 @@ export class SvgGridService {
       this.settingsService.tempGridDisable = false;
       return;
     }
+    const restoreScenery = this.hideSceneryWhileMeasuring();
     this.panZoomObject.updateBBox(); // Update viewport bounding box
+    restoreScenery();
     this.settingsService.tempGridDisable = false;
     if (animate) NewGridComponent.instance.enableGridAnimationForThisAction();
     this.panZoomObject.fit();
     this.panZoomObject.center();
     this.zoomOut();
+  }
+
+  /**
+   * Take the background image out of the box this fit is about to measure.
+   *
+   * `tempGridDisable` is meant to do this in the template, but afterNextRender
+   * can land before Angular has acted on the flag -- which went unnoticed while
+   * the only thing it hid was the grid ruling, drawn to the viewport and so
+   * never bigger than the box anyway. A background image is as big as the user
+   * made it, and a hundred-centimetre photograph got framed instead of the
+   * linkage. Hidden straight on the element, so it is gone by the next
+   * statement rather than by the next render.
+   *
+   * Returns the undo, to be called once the measurement is taken.
+   */
+  private hideSceneryWhileMeasuring(): () => void {
+    const layers = ['backgroundImageHolder', 'backgroundImageHandles', 'backgroundImageGrips']
+      .map((id) => document.getElementById(id))
+      .filter((node): node is HTMLElement => node !== null);
+    const was = layers.map((node) => node.style.display);
+    layers.forEach((node) => (node.style.display = 'none'));
+    return () => layers.forEach((node, index) => (node.style.display = was[index]));
   }
 
   updateObjectScale() {

--- a/src/app/services/url-processor.service.ts
+++ b/src/app/services/url-processor.service.ts
@@ -76,8 +76,13 @@ export class UrlProcessorService {
     //
     // Selecting something is not an edit. It earns no history entry, so it
     // should not be undone by one.
+    //
+    // Named rather than excluded: getSelectedObj() answers for exactly these
+    // three and throws for anything else, so a deny-list turns every selection
+    // kind added later into a crash on Undo. The background image was one --
+    // it is not a mechanism object and has no id to hold.
     const heldSelection =
-      continuingHistory && this.activeObj.objType !== 'Nothing' && this.activeObj.objType !== 'Grid'
+      continuingHistory && ['Joint', 'Link', 'Force'].includes(this.activeObj.objType)
         ? { type: this.activeObj.objType, id: this.activeObj.getSelectedObj()?.id }
         : undefined;
     mechanismSrv.rewindToStart();

--- a/src/assets/icons/background_image.svg
+++ b/src/assets/icons/background_image.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <!-- One filled path with even-odd cut-outs, like the other icons here: the
+       icon theme floods every path solid, so the empty frame and the sky above
+       the hills have to be holes in the geometry rather than an absent fill. -->
+  <path
+    fill-rule="evenodd"
+    fill="currentColor"
+    d="M3 4h18v16H3V4Zm2 2v12h14V6H5Zm1.5 10.5 3.75-5 2.75 3.5 2-2.5 3.5 4h-12Z"
+  />
+</svg>


### PR DESCRIPTION
Right-click the grid and you can pin an image behind it — a photo or a drawing of a real linkage — then build a PMKS mechanism over it and match its dimensions and proportions.

Preview: https://background-image--pmks.netlify.app

## What it does

One context-menu item on the grid, which reads **Add background image** until there is one and **Edit background image** after. Adding opens a file picker; the chosen image lands centred on the origin, drawn across half the visible grid, at 50% opacity, and the Edit panel opens on it.

The panel gives you where it sits, how wide it is drawn, how far it is turned, and how far you can see through it. Width alone resizes it — the height follows the file's own proportions, because a picture stretched out of shape is no longer something you can measure anything against. On the canvas you can drag the picture to slide it, drag a corner to resize it about the corner opposite, and drag the knob on its stalk to turn it (snapping to whole 15°, unless Alt says otherwise).

Everything else about it is scenery. Once you save, it is deaf to the pointer: a click on it selects the grid, a right-click on it opens the grid's own menu, and it never enters an analysis. Nothing about having one changes how a linkage is built.

**It is deliberately outside the URL codec and outside the undo history.** An image is megabytes and a share link is a few hundred characters, so there is no version of this that survives a link. The panel says so rather than letting anyone find out by sharing one.

## Layers, and why there are three

| layer | where | why |
| --- | --- | --- |
| the picture | inside the grid group, above the white paper, below the ruling | the grid lines and axes stay readable over an opaque photograph, and the group is what Fit to zoom hides while it measures |
| its outline and drag surface | above the ruling, below the parts | the whole picture is a drag target, and a target that size must not make the joints inside it unclickable — a press over a link belongs to the link |
| its corners and turn knob | above everything | a link lying across a corner made it ungrabbable, and the knob sits on the y axis at the default placement, where the axis line took the press |

## Fixed in review (GPT-5.6 sol)

- **Undo threw with the panel open.** The history holds the selection across a replay and asked `getSelectedObj()` for its id, which answers for a joint, a link or a force and throws for anything else. It now names those three rather than excluding two.
- **A change of length unit left the picture behind** — a linkage traced in centimetres came back a hundred times too small against its own photograph. Watched on the unit itself, so undo and redo, which cross a unit change by replaying a URL, are carried too.
- **Fit to zoom framed the photograph** instead of the linkage. `tempGridDisable` is meant to take the scenery out of the measurement, but `afterNextRender` lands before Angular has acted on it — unnoticed while the only thing the flag hid was ruling drawn to the viewport, which never enlarged the box anyway.
- **Values the picture cannot have are refused and the field put back**, rather than silently clamped. A blank opacity read as zero and faded the picture to nothing while the panel reported 0% as though that had been asked for.
- **The picture was painted over the grid**; it now sits under the ruling, as the name says.

## Checks

- 1084 unit tests across 123 files, including `background-image.service.spec.ts` — the y-flip, the aspect lock, the turn's sign into SVG, the unit rescale, and the refusals.
- `e2e/background-image.mjs`: 53 browser checks — the menu's two halves, layer order, pointer pass-through, every field, all three gestures, the turned resize, Fit to zoom, the unit switch, undo, Save and Delete.
- Production build clean; Prettier clean on every file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)