### PR TITLE
Force gaps both browsers agree on, and cycles that close where they close

### DIFF
--- a/src/app/component/analysis-graph/analysis-graph.component.html
+++ b/src/app/component/analysis-graph/analysis-graph.component.html
@@ -6,7 +6,7 @@
   >
     <mat-icon class="gapIcon">warning_amber</mat-icon>
     <span>No solution at {{ gap.failed }} of {{ gap.total }} positions</span>
-    <button class="gapShow" (click)="showGapPosition()">Show them</button>
+    <button class="gapShow" (click)="showGapPosition()">{{ gapShowLabel }}</button>
   </div>
 }
 @if (analysisDiagnostic) {

--- a/src/app/component/analysis-graph/analysis-graph.component.scss
+++ b/src/app/component/analysis-graph/analysis-graph.component.scss
@@ -90,14 +90,19 @@
     color: mat.m2-get-color-from-palette($primary-palette, 900);
   }
 
+  // Sized like its siblings — the gap strip above the chart and the
+  // placeholder that stands in for one. Left to inherit, this spoke at the
+  // panel's base size out of a 16px-padded box, and read as a headline
+  // rather than as one more quiet note about the chart.
   .analysis-diagnostic {
-    margin: 16px 4px 12px;
-    padding: 16px;
+    margin: 4px 0 8px;
+    padding: 8px 12px;
     border: 1px solid mat.m2-get-color-from-palette($primary-palette, 200);
     border-radius: var(--border-radius);
     background: mat.m2-get-color-from-palette($primary-palette, 50);
     color: mat.m2-get-color-from-palette($primary-palette, 900);
-    line-height: 1.4;
+    font-size: 13px;
+    line-height: 1.5;
   }
 }
 
@@ -112,7 +117,11 @@
   color: #7a5600;
   font-size: 12.5px;
 
-  .gapIcon { font-size: 16px; width: 16px; height: 16px; }
+  .gapIcon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
 
   .gapShow {
     margin-left: auto;

--- a/src/app/component/analysis-graph/analysis-graph.component.spec.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.spec.ts
@@ -299,8 +299,20 @@ describe('AnalysisGraphComponent production fixtures', () => {
     );
 
     const seek = vi.fn();
-    Object.assign(fixture.service, { seekMechanism: seek });
+    const animate = vi.fn();
+    const togglePlaying = vi.fn();
+    Object.assign(fixture.service, {
+      seekMechanism: seek,
+      animate,
+      isPlaying: true,
+      isMechanismPlaying: () => true,
+      toggleMechanismPlaying: togglePlaying,
+    });
     component.showGapPosition();
+    // Pressed mid-animation, the button pauses playback first -- a seek that
+    // kept playing would sail straight past the pose it names.
+    expect(animate).toHaveBeenCalledWith(fixture.service.mechanismTimeStep, false);
+    expect(togglePlaying).toHaveBeenCalledWith(0);
     expect(seek).toHaveBeenCalledWith(0, series.frames[1].timeSeconds);
 
     // A fully solved series takes the banner down...
@@ -601,7 +613,11 @@ describe('AnalysisGraphComponent rendered controls', () => {
     const fixtureData = buildMechanismFixture(TEMPLATE_LINKAGES['4-Bar']);
     const series = failForceFrames(fixtureData, 'static', [2]);
     const seek = vi.fn();
-    Object.assign(fixtureData.service, { seekMechanism: seek });
+    Object.assign(fixtureData.service, {
+      seekMechanism: seek,
+      isPlaying: false,
+      isMechanismPlaying: () => false,
+    });
     const ground = fixtureData.mechanism.joints[0].find(
       (candidate): candidate is RealJoint => candidate instanceof RealJoint && candidate.ground
     )!;

--- a/src/app/component/analysis-graph/analysis-graph.component.spec.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.spec.ts
@@ -260,7 +260,7 @@ describe('AnalysisGraphComponent production fixtures', () => {
     const component = createComponent(fixture);
     component.determineChart('force', 'static', 'Joint Forces', 'B');
 
-    expect(component.analysisDiagnostic).toContain('welded inside one rigid body');
+    expect(component.analysisDiagnostic).toContain('Only one part meets this joint');
     expect(
       component.chartOptions.series!.every((series) =>
         (series.data as unknown as Array<{ y: number | null }>).every((point) => point.y === null)

--- a/src/app/component/analysis-graph/analysis-graph.component.spec.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.spec.ts
@@ -119,13 +119,13 @@ function expectNumericSeries(
 }
 
 /**
- * No constructible linkage produces a partially failed force series any more:
- * the position solver only emits frames it solved, and the overhauled force
- * solver handles toggle and dead-center poses (verified 2026-08-16 against
- * rocker-driven four-bars, TDC slider-cranks, and the square four-bar). The
- * banner's input is fabricated here instead, failing frames the way
- * `analyzeFrame`'s `empty('singular')` does, so the gap rendering cannot rot
- * invisibly while it waits for a mechanism that can reach it.
+ * A partially failed force series is rare but real: the square-rod tangency
+ * slider-crank (fixture gallery) goes singular at the one sampled frame where
+ * the rod stands square to its guide, and a mechanism drawn exactly at a dead
+ * pose fails at frame 0 (square-rod-tangency.spec.ts pins the real case).
+ * This spec fabricates the failure instead, the way `analyzeFrame`'s
+ * `empty('singular')` fails a frame, so the rendering assertions stay
+ * deterministic and independent of solver behavior.
  */
 function failForceFrames(
   fixture: MechanismFixture,

--- a/src/app/component/analysis-graph/analysis-graph.component.spec.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.spec.ts
@@ -260,7 +260,7 @@ describe('AnalysisGraphComponent production fixtures', () => {
     const component = createComponent(fixture);
     component.determineChart('force', 'static', 'Joint Forces', 'B');
 
-    expect(component.analysisDiagnostic).toContain('internal to one welded body');
+    expect(component.analysisDiagnostic).toContain('welded inside one rigid body');
     expect(
       component.chartOptions.series!.every((series) =>
         (series.data as unknown as Array<{ y: number | null }>).every((point) => point.y === null)

--- a/src/app/component/analysis-graph/analysis-graph.component.spec.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.spec.ts
@@ -12,7 +12,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ApexAxisChartSeries } from 'apexcharts';
 import { RealJoint } from '../../model/joint';
 import { RealLink } from '../../model/link';
-import { ForceSolver } from '../../model/mechanism/force-solver';
+import { ForceAnalysisSeries, ForceSolver } from '../../model/mechanism/force-solver';
 import { KinematicsSolver } from '../../model/mechanism/kinematic-solver';
 import { ForceUnit, LengthUnit } from '../../model/unit-enums';
 import { NumberUnitParserService } from '../../services/number-unit-parser.service';
@@ -116,6 +116,36 @@ function expectNumericSeries(
       ).toBeGreaterThanOrEqual(2);
     }
   }
+}
+
+/**
+ * No constructible linkage produces a partially failed force series any more:
+ * the position solver only emits frames it solved, and the overhauled force
+ * solver handles toggle and dead-center poses (verified 2026-08-16 against
+ * rocker-driven four-bars, TDC slider-cranks, and the square four-bar). The
+ * banner's input is fabricated here instead, failing frames the way
+ * `analyzeFrame`'s `empty('singular')` does, so the gap rendering cannot rot
+ * invisibly while it waits for a mechanism that can reach it.
+ */
+function failForceFrames(
+  fixture: MechanismFixture,
+  mode: 'static' | 'dynamic',
+  indices: number[]
+): ForceAnalysisSeries {
+  const series = fixture.mechanism.getForceAnalysis(mode);
+  for (const index of indices) {
+    const frame = series.frames[index];
+    frame.status = 'singular';
+    frame.jointReactionsByLink = new Map();
+    frame.jointReactions = new Map();
+    frame.guideCouples = new Map();
+    frame.inputEffort = undefined;
+    frame.rank = 0;
+    frame.residual = Number.POSITIVE_INFINITY;
+    frame.message = ForceSolver.statusMessage('singular');
+  }
+  series.successfulFrames = series.frames.filter((frame) => frame.status === 'ok').length;
+  return series;
 }
 
 describe('AnalysisGraphComponent production fixtures', () => {
@@ -236,6 +266,47 @@ describe('AnalysisGraphComponent production fixtures', () => {
         (series.data as unknown as Array<{ y: number | null }>).every((point) => point.y === null)
       )
     ).toBe(true);
+  });
+
+  it('counts the positions with no solution and can stand the mechanism at the first', () => {
+    const fixture = buildMechanismFixture(TEMPLATE_LINKAGES['4-Bar']);
+    const component = createComponent(fixture);
+    const ground = fixture.mechanism.joints[0].find(
+      (candidate): candidate is RealJoint => candidate instanceof RealJoint && candidate.ground
+    )!;
+    const series = failForceFrames(fixture, 'static', [1, 4]);
+
+    component.determineChart('force', 'static', 'Joint Forces', ground.id);
+
+    expect(component.analysisGap).toEqual({
+      failed: 2,
+      total: series.frames.length,
+      firstSeconds: series.frames[1].timeSeconds,
+      mechIndex: 0,
+    });
+    // A hole in a good series, not a failure of the whole series.
+    expect(component.analysisDiagnostic).toBeNull();
+    const points = component.chartOptions.series![0].data as unknown as Array<{
+      y: number | null;
+    }>;
+    expect(points[1].y).toBeNull();
+    expect(points[4].y).toBeNull();
+    expect(Number.isFinite(points[0].y ?? Number.NaN)).toBe(true);
+
+    const seek = vi.fn();
+    Object.assign(fixture.service, { seekMechanism: seek });
+    component.showGapPosition();
+    expect(seek).toHaveBeenCalledWith(0, series.frames[1].timeSeconds);
+
+    // A fully solved series takes the banner down...
+    component.determineChart('force', 'dynamic', 'Joint Forces', ground.id);
+    expect(component.analysisGap).toBeNull();
+
+    // ...and so does leaving force analysis for a kinematic graph.
+    component.determineChart('force', 'static', 'Joint Forces', ground.id);
+    expect(component.analysisGap).not.toBeNull();
+    component.determineChart('kinematic', 'loop', 'Linear Joint Pos', ground.id);
+    expect(component.analysisGap).toBeNull();
   });
 
   it('says the analysis failed rather than showing an empty series selection', () => {
@@ -435,8 +506,10 @@ describe('AnalysisGraphComponent lifecycle', () => {
 describe('AnalysisGraphComponent rendered controls', () => {
   afterEach(() => TestBed.resetTestingModule());
 
-  it('updates the rendered chart series when a series is switched off and on', async () => {
-    const fixtureData = buildMechanismFixture(TEMPLATE_LINKAGES['4-Bar']);
+  async function mountGraph(
+    fixtureData: MechanismFixture,
+    inputs: { analysis: string; analysisType: string; mechProp: string; mechPart: string }
+  ): Promise<ComponentFixture<AnalysisGraphComponent>> {
     await TestBed.configureTestingModule({
       imports: [
         ReactiveFormsModule,
@@ -465,13 +538,24 @@ describe('AnalysisGraphComponent rendered controls', () => {
 
     const fixture: ComponentFixture<AnalysisGraphComponent> =
       TestBed.createComponent(AnalysisGraphComponent);
-    fixture.componentRef.setInput('analysis', 'kinematic');
-    fixture.componentRef.setInput('analysisType', 'loop');
-    fixture.componentRef.setInput('mechProp', 'Linear Joint Pos');
-    fixture.componentRef.setInput('mechPart', 'B');
+    fixture.componentRef.setInput('analysis', inputs.analysis);
+    fixture.componentRef.setInput('analysisType', inputs.analysisType);
+    fixture.componentRef.setInput('mechProp', inputs.mechProp);
+    fixture.componentRef.setInput('mechPart', inputs.mechPart);
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+    return fixture;
+  }
+
+  it('updates the rendered chart series when a series is switched off and on', async () => {
+    const fixtureData = buildMechanismFixture(TEMPLATE_LINKAGES['4-Bar']);
+    const fixture = await mountGraph(fixtureData, {
+      analysis: 'kinematic',
+      analysisType: 'loop',
+      mechProp: 'Linear Joint Pos',
+      mechPart: 'B',
+    });
 
     // The switches live on the panel header that owns this graph now -- one row
     // that reads the values out and turns the lines on and off -- so this drives
@@ -505,6 +589,31 @@ describe('AnalysisGraphComponent rendered controls', () => {
       expect.objectContaining({ x: fixtureData.mechanism.timeNum[annotationIndex] }),
       false
     );
+    fixture.destroy();
+  });
+
+  it('renders the no-solution banner, and Show them drives the mechanism there', async () => {
+    const fixtureData = buildMechanismFixture(TEMPLATE_LINKAGES['4-Bar']);
+    const series = failForceFrames(fixtureData, 'static', [2]);
+    const seek = vi.fn();
+    Object.assign(fixtureData.service, { seekMechanism: seek });
+    const ground = fixtureData.mechanism.joints[0].find(
+      (candidate): candidate is RealJoint => candidate instanceof RealJoint && candidate.ground
+    )!;
+
+    const fixture = await mountGraph(fixtureData, {
+      analysis: 'force',
+      analysisType: 'static',
+      mechProp: 'Joint Forces',
+      mechPart: ground.id,
+    });
+
+    const banner = fixture.nativeElement.querySelector('.analysis-gap') as HTMLElement | null;
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain(`No solution at 1 of ${series.frames.length} positions`);
+
+    (banner!.querySelector('.gapShow') as HTMLButtonElement).click();
+    expect(seek).toHaveBeenCalledWith(0, series.frames[2].timeSeconds);
     fixture.destroy();
   });
 });

--- a/src/app/component/analysis-graph/analysis-graph.component.spec.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.spec.ts
@@ -293,6 +293,11 @@ describe('AnalysisGraphComponent production fixtures', () => {
     expect(points[4].y).toBeNull();
     expect(Number.isFinite(points[0].y ?? Number.NaN)).toBe(true);
 
+    // Several holes: the button names the one it goes to, which is the first.
+    expect(component.gapShowLabel).toBe(
+      `Show first (${formatTimeLabel(series.frames[1].timeSeconds)} s)`
+    );
+
     const seek = vi.fn();
     Object.assign(fixture.service, { seekMechanism: seek });
     component.showGapPosition();
@@ -612,7 +617,10 @@ describe('AnalysisGraphComponent rendered controls', () => {
     expect(banner).not.toBeNull();
     expect(banner!.textContent).toContain(`No solution at 1 of ${series.frames.length} positions`);
 
-    (banner!.querySelector('.gapShow') as HTMLButtonElement).click();
+    const showButton = banner!.querySelector('.gapShow') as HTMLButtonElement;
+    // One hole: singular wording, no time needed.
+    expect(showButton.textContent!.trim()).toBe('Show position');
+    showButton.click();
     expect(seek).toHaveBeenCalledWith(0, series.frames[2].timeSeconds);
     fixture.destroy();
   });

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -976,7 +976,7 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
         ? null
         : (result.diagnostic ??
           (mechProp === 'Joint Forces'
-            ? 'This joint is welded inside one rigid body, so no force passes between parts here.'
+            ? 'Only one part meets this joint, so there is no force to graph here.'
             : 'Input effort is unavailable for this mechanism.'));
       return [[datum_X, datum_Y, datum_Z], categories];
     }

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -391,7 +391,16 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
 
   showGapPosition(): void {
     if (!this.analysisGap) return;
-    this.mechanismService.seekMechanism(this.analysisGap.mechIndex, this.analysisGap.firstSeconds);
+    const service = this.mechanismService;
+    // A seek keeps the playback state, so pressed mid-animation it would sail
+    // straight past the pose it names. Standing at the pose IS the point.
+    if (service.isPlaying) {
+      service.animate(service.mechanismTimeStep, false);
+    }
+    if (service.isMechanismPlaying(this.analysisGap.mechIndex)) {
+      service.toggleMechanismPlaying(this.analysisGap.mechIndex);
+    }
+    service.seekMechanism(this.analysisGap.mechIndex, this.analysisGap.firstSeconds);
   }
 
   loading: boolean = false;

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -976,7 +976,7 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
         ? null
         : (result.diagnostic ??
           (mechProp === 'Joint Forces'
-            ? 'This point is internal to one welded body and has no independent joint reaction.'
+            ? 'This joint is welded inside one rigid body, so no force passes between parts here.'
             : 'Input effort is unavailable for this mechanism.'));
       return [[datum_X, datum_Y, datum_Z], categories];
     }

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -377,6 +377,18 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
   analysisGap: { failed: number; total: number; firstSeconds: number; mechIndex: number } | null =
     null;
 
+  /**
+   * One hole is "the position"; several are shown by naming the one the
+   * button actually goes to — the first — so the jump has no surprise in it.
+   */
+  get gapShowLabel(): string {
+    const gap = this.analysisGap;
+    if (!gap) return '';
+    return gap.failed === 1
+      ? 'Show position'
+      : `Show first (${formatTimeLabel(gap.firstSeconds)} s)`;
+  }
+
   showGapPosition(): void {
     if (!this.analysisGap) return;
     this.mechanismService.seekMechanism(this.analysisGap.mechIndex, this.analysisGap.firstSeconds);

--- a/src/app/component/analysis-graph/analysis-graph.component.ts
+++ b/src/app/component/analysis-graph/analysis-graph.component.ts
@@ -744,6 +744,9 @@ export class AnalysisGraphComponent implements OnInit, AfterViewInit, OnDestroy,
     const velAngUnit = '(' + this.getUnitStr(this.settingsService.angleUnit.value) + '/s)';
     const accAngUnit = '(' + this.getUnitStr(this.settingsService.angleUnit.value) + '/s²)';
     this.analysisDiagnostic = null;
+    // Only the force branch writes the gap, so a kinematic graph would
+    // otherwise inherit the banner from the force graph shown before it.
+    this.analysisGap = null;
     switch (analysis) {
       case 'force':
         switch (mechProp) {

--- a/src/app/component/analysis-panel/analysis-panel.component.html
+++ b/src/app/component/analysis-panel/analysis-panel.component.html
@@ -159,10 +159,7 @@
           <div class="helpRule"></div>
           <div class="helpHint" role="status">
             <mat-icon>touch_app</mat-icon>
-            <span
-              >Only one part meets Joint {{ this.activeSrv.selectedJoint.name }}, so there is no
-              force to graph here. Click a joint where separate parts meet, or a grounded one.</span
-            >
+            <span>Click a joint where separate parts meet, or a grounded one.</span>
           </div>
         }
         @for (row of jointForceRows(); track row.linkId) {
@@ -298,10 +295,7 @@
           <div class="helpRule"></div>
           <div class="helpHint" role="status">
             <mat-icon>touch_app</mat-icon>
-            <span
-              >{{ selectedBodyLabel }} does not meet another part at any of its joints, so there is
-              no force to graph here. Click a part that touches another, or a grounded joint.</span
-            >
+            <span>Click a part that touches another, or a grounded joint.</span>
           </div>
         }
         @for (row of linkForceRows(); track row.jointId) {

--- a/src/app/component/analysis-panel/analysis-panel.component.html
+++ b/src/app/component/analysis-panel/analysis-panel.component.html
@@ -106,7 +106,7 @@
   <!-- Joint Kinematics-->
   @if (validMechanisms() && this.activeSrv.objType == 'Joint') {
     <panel-section id="analysis-panel">
-      <title-block description="{{ inputSummary }} {{ inputEditHint }}">
+      <title-block description="{{ panelDescription }}">
         {{ modeLabel }} for Joint {{ this.activeSrv.selectedJoint.name }}
       </title-block>
       @if (showKinematic) {
@@ -142,20 +142,24 @@
         ></app-analysis-graph-section>
       }
       @if (showForce) {
-        <div class="forceModeRow">
-          <radio-block
-            tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
-            option1="Static (Equilibrium)"
-            option2="In-motion (Dynamic)"
-            [formGroup]="this.forceAnalysisFormGroup"
-            _formControl="mode"
-            >Force Analysis Type
-          </radio-block>
-        </div>
+        <!-- Nothing to graph, so nothing to configure: the note stands alone. -->
+        @if (jointForceHasGraphs) {
+          <div class="forceModeRow">
+            <radio-block
+              tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
+              option1="Static (Equilibrium)"
+              option2="In-motion (Dynamic)"
+              [formGroup]="this.forceAnalysisFormGroup"
+              _formControl="mode"
+              >Force Analysis Type
+            </radio-block>
+          </div>
+        }
         @if (jointForceRows().length === 0) {
           <div class="analysis-message" role="status">
-            Joint {{ this.activeSrv.selectedJoint.name }} is internal to one welded body and has no
-            independent pin reaction. Select an external or grounded joint to graph a reaction.
+            Joint {{ this.activeSrv.selectedJoint.name }} is welded inside one rigid body, so no
+            force passes between parts there. Select a joint where separate parts meet, or a
+            grounded one.
           </div>
         }
         @for (row of jointForceRows(); track row.linkId) {
@@ -190,7 +194,7 @@
   <!-- Link Kinematics-->
   @if (validMechanisms() && this.activeSrv.objType == 'Link') {
     <panel-section id="analysis-panel">
-      <title-block description="{{ inputSummary }} {{ inputEditHint }}">
+      <title-block description="{{ panelDescription }}">
         {{ modeLabel }} for {{ selectedBodyLabel }}
       </title-block>
       <!-- <subtitle-block>Kinematics</subtitle-block> -->
@@ -274,19 +278,23 @@
         ></app-analysis-graph-section>
       }
       @if (showForce) {
-        <div class="forceModeRow">
-          <radio-block
-            tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
-            option1="Static (Equilibrium)"
-            option2="In-motion (Dynamic)"
-            [formGroup]="this.forceAnalysisFormGroup"
-            _formControl="mode"
-            >Force Analysis Type
-          </radio-block>
-        </div>
+        <!-- Nothing to graph, so nothing to configure: the note stands alone. -->
+        @if (linkForceHasGraphs) {
+          <div class="forceModeRow">
+            <radio-block
+              tooltip="Static holds the mechanism still; In-motion includes the forces of movement."
+              option1="Static (Equilibrium)"
+              option2="In-motion (Dynamic)"
+              [formGroup]="this.forceAnalysisFormGroup"
+              _formControl="mode"
+              >Force Analysis Type
+            </radio-block>
+          </div>
+        }
         @if (linkForceRows().length === 0) {
           <div class="analysis-message" role="status">
-            {{ selectedBodyLabel }} has no external joint that carries an independent pin reaction.
+            {{ selectedBodyLabel }} is welded inside one rigid body, so its forces act on that body
+            as a whole. Select the welded body to see them.
           </div>
         }
         @for (row of linkForceRows(); track row.jointId) {

--- a/src/app/component/analysis-panel/analysis-panel.component.html
+++ b/src/app/component/analysis-panel/analysis-panel.component.html
@@ -156,10 +156,13 @@
           </div>
         }
         @if (jointForceRows().length === 0) {
-          <div class="analysis-message" role="status">
-            Joint {{ this.activeSrv.selectedJoint.name }} is welded inside one rigid body, so no
-            force passes between parts there. Select a joint where separate parts meet, or a
-            grounded one.
+          <div class="helpRule"></div>
+          <div class="helpHint" role="status">
+            <mat-icon>touch_app</mat-icon>
+            <span
+              >Only one part meets Joint {{ this.activeSrv.selectedJoint.name }}, so there is no
+              force to graph here. Click a joint where separate parts meet, or a grounded one.</span
+            >
           </div>
         }
         @for (row of jointForceRows(); track row.linkId) {
@@ -292,9 +295,13 @@
           </div>
         }
         @if (linkForceRows().length === 0) {
-          <div class="analysis-message" role="status">
-            {{ selectedBodyLabel }} is welded inside one rigid body, so its forces act on that body
-            as a whole. Select the welded body to see them.
+          <div class="helpRule"></div>
+          <div class="helpHint" role="status">
+            <mat-icon>touch_app</mat-icon>
+            <span
+              >{{ selectedBodyLabel }} does not meet another part at any of its joints, so there is
+              no force to graph here. Click a part that touches another, or a grounded joint.</span
+            >
           </div>
         }
         @for (row of linkForceRows(); track row.jointId) {

--- a/src/app/component/analysis-panel/analysis-panel.component.scss
+++ b/src/app/component/analysis-panel/analysis-panel.component.scss
@@ -55,19 +55,6 @@
     // }
   }
 }
-// Speaks at the size of the title-block description above it (body-2, 14px).
-// Left to inherit, it picked up the panel's base size, and a note about one
-// joint read louder than the panel's own heading.
-#analysisWrapper .analysis-message {
-  margin: 8px 0 12px;
-  padding: 10px 12px;
-  border-radius: var(--border-radius);
-  background: #f4f5fb;
-  color: rgba(0, 0, 0, 0.7);
-  font-size: 14px;
-  line-height: 1.45;
-}
-
 // Names the group of graphs under it. It used to be a subtitle-block nudged
 // down 20px, which read as a stray line of text between two cards rather than
 // as a heading for the ones below it.

--- a/src/app/component/analysis-panel/analysis-panel.component.scss
+++ b/src/app/component/analysis-panel/analysis-panel.component.scss
@@ -55,12 +55,17 @@
     // }
   }
 }
+// Speaks at the size of the title-block description above it (body-2, 14px).
+// Left to inherit, it picked up the panel's base size, and a note about one
+// joint read louder than the panel's own heading.
 #analysisWrapper .analysis-message {
   margin: 8px 0 12px;
-  padding: 12px;
+  padding: 10px 12px;
   border-radius: var(--border-radius);
   background: #f4f5fb;
-  line-height: 1.4;
+  color: rgba(0, 0, 0, 0.7);
+  font-size: 14px;
+  line-height: 1.45;
 }
 
 // Names the group of graphs under it. It used to be a subtitle-block nudged

--- a/src/app/component/analysis-panel/analysis-panel.component.scss
+++ b/src/app/component/analysis-panel/analysis-panel.component.scss
@@ -78,3 +78,16 @@
   padding: 0 15px 12px;
   border-bottom: 1px solid #eceef5;
 }
+
+// The help card's hint pattern, worn inside a panel section: the card brings
+// its own padding, a section does not, so the rows take the section's 15px
+// gutter themselves. As padding, not margin — the row is stretched to the
+// section's full width, and a side margin pushed it out the right edge.
+#analysisWrapper panel-section .helpRule {
+  margin: 4px 15px 12px;
+  width: auto;
+}
+#analysisWrapper panel-section .helpHint {
+  margin: 0 0 14px;
+  padding: 0 15px;
+}

--- a/src/app/component/analysis-panel/analysis-panel.component.spec.ts
+++ b/src/app/component/analysis-panel/analysis-panel.component.spec.ts
@@ -128,12 +128,17 @@ describe('AnalysisPanelComponent welded mechanism regression', () => {
 
     expect(fixture.componentInstance.jointForceRows()).toHaveLength(0);
     const text = fixture.nativeElement.textContent;
-    expect(text).toContain('welded inside one rigid body');
-    expect(text).toContain('Select a joint where separate parts meet');
+    // "Only one part" covers the tracer on a plain ternary link as well as a
+    // welded-in pin — a joint can have no reaction without a weld anywhere.
+    expect(text).toContain('Only one part meets Joint');
+    expect(text).toContain('Click a joint where separate parts meet');
     // With no graph to configure, the mode selector and the input-speed
     // summary would describe things that are not on the panel.
     expect(text).not.toContain('Force Analysis Type');
     expect(text).not.toContain('input speed is set');
+    // And it is the help-card hint pattern, not a boxed banner.
+    expect(fixture.nativeElement.querySelector('.helpHint')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.analysis-message')).toBeNull();
     fixture.destroy();
   });
 

--- a/src/app/component/analysis-panel/analysis-panel.component.spec.ts
+++ b/src/app/component/analysis-panel/analysis-panel.component.spec.ts
@@ -28,7 +28,12 @@ async function createPanel(payload: string, selectedId: string, mode: TabID = Ta
   const tabs = { getCurrentTab: () => mode } as unknown as SelectedTabService;
 
   await TestBed.configureTestingModule({
-    imports: [ReactiveFormsModule, MatFormFieldModule, NoopAnimationsModule, AnalysisPanelComponent],
+    imports: [
+      ReactiveFormsModule,
+      MatFormFieldModule,
+      NoopAnimationsModule,
+      AnalysisPanelComponent,
+    ],
     providers: [
       { provide: ActiveObjService, useValue: fixtureData.active },
       { provide: MechanismService, useValue: fixtureData.service },
@@ -62,7 +67,11 @@ async function createPanel(payload: string, selectedId: string, mode: TabID = Ta
 function sectionLabels(fixture: ComponentFixture<AnalysisPanelComponent>): string[] {
   return [...fixture.nativeElement.querySelectorAll('app-analysis-graph-section')].map(
     (section: Element) =>
-      ((section as unknown as { label?: string }).label ?? section.getAttribute('label') ?? '').trim()
+      (
+        (section as unknown as { label?: string }).label ??
+        section.getAttribute('label') ??
+        ''
+      ).trim()
   );
 }
 
@@ -113,13 +122,18 @@ describe('AnalysisPanelComponent welded mechanism regression', () => {
     fixture.destroy();
   });
 
-  it('explains that an internal welded joint has no independent pin reaction', async () => {
+  it('explains a welded-in joint plainly, and shows nothing else to configure', async () => {
     const { fixture } = await createPanel(LOOPLESS_WELDED_MECHANISM, 'B', TabID.FORCE);
     fixture.detectChanges();
 
     expect(fixture.componentInstance.jointForceRows()).toHaveLength(0);
-    expect(fixture.nativeElement.textContent).toContain('internal to one welded body');
-    expect(fixture.nativeElement.textContent).toContain('no independent pin reaction');
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('welded inside one rigid body');
+    expect(text).toContain('Select a joint where separate parts meet');
+    // With no graph to configure, the mode selector and the input-speed
+    // summary would describe things that are not on the panel.
+    expect(text).not.toContain('Force Analysis Type');
+    expect(text).not.toContain('input speed is set');
     fixture.destroy();
   });
 

--- a/src/app/component/analysis-panel/analysis-panel.component.ts
+++ b/src/app/component/analysis-panel/analysis-panel.component.ts
@@ -303,15 +303,18 @@ export class AnalysisPanelComponent {
   }
 
   /**
-   * The heading's description. A part with nothing to graph gets only the
-   * note that says so — the speed summary and the mode selector describe
-   * graphs that are not on the panel.
+   * The heading's description. A part with nothing to graph gets the cause in
+   * the description and the way out in the hint row below — the speed summary
+   * and the mode selector describe graphs that are not on the panel.
    */
   get panelDescription(): string {
-    const bare =
-      this.showForce &&
-      (this.activeSrv.objType === 'Joint' ? !this.jointForceHasGraphs : !this.linkForceHasGraphs);
-    return bare ? '' : `${this.inputSummary} ${this.inputEditHint}`;
+    if (this.showForce && this.activeSrv.objType === 'Joint' && !this.jointForceHasGraphs) {
+      return `Only one part meets Joint ${this.activeSrv.selectedJoint?.name}, so there is no force to graph here.`;
+    }
+    if (this.showForce && this.activeSrv.objType === 'Link' && !this.linkForceHasGraphs) {
+      return `${this.selectedBodyLabel} does not meet another part at any of its joints, so there is no force to graph here.`;
+    }
+    return `${this.inputSummary} ${this.inputEditHint}`;
   }
 
   /** One row per external joint of the selected link. */

--- a/src/app/component/analysis-panel/analysis-panel.component.ts
+++ b/src/app/component/analysis-panel/analysis-panel.component.ts
@@ -292,6 +292,28 @@ export class AnalysisPanelComponent {
     return this.cachedRows('joint', this.activeSrv.selectedJoint?.id ?? '');
   }
 
+  /** In Force mode, does the selected joint have any graph to offer? */
+  get jointForceHasGraphs(): boolean {
+    return this.jointForceRows().length > 0 || !!this.activeSrv.selectedJoint?.input;
+  }
+
+  /** In Force mode, does the selected link have any graph to offer? */
+  get linkForceHasGraphs(): boolean {
+    return this.linkForceRows().length > 0;
+  }
+
+  /**
+   * The heading's description. A part with nothing to graph gets only the
+   * note that says so — the speed summary and the mode selector describe
+   * graphs that are not on the panel.
+   */
+  get panelDescription(): string {
+    const bare =
+      this.showForce &&
+      (this.activeSrv.objType === 'Joint' ? !this.jointForceHasGraphs : !this.linkForceHasGraphs);
+    return bare ? '' : `${this.inputSummary} ${this.inputEditHint}`;
+  }
+
   /** One row per external joint of the selected link. */
   linkForceRows(): ForceAnalysisRow[] {
     const rows = this.cachedRows('link', this.activeSrv.selectedLink?.id ?? '');

--- a/src/app/model/mechanism/drive-profile.spec.ts
+++ b/src/app/model/mechanism/drive-profile.spec.ts
@@ -14,6 +14,8 @@ import { MechanismBuilder } from '../../services/transcoding/mechanism-builder';
 import { StringTranscoder } from '../../services/transcoding/string-transcoder';
 import { TemplateID, TEMPLATE_LINKAGES } from '../../component/MODALS/templates/template-linkages';
 import { silentNotifications } from '../../../test-utils/notification-stub';
+import { buildMechanism } from '../../../test-utils/verification/fixture';
+import { squareRodSliderCrankFixture } from '../../../test-utils/verification/slot-fixtures';
 
 /** The solved first mechanism of a template, and what its input does. */
 function profileOf(template: TemplateID): DriveProfile {
@@ -51,6 +53,38 @@ describe('Where a machine says its input is', () => {
     // opposite of the direction a reader expects the handle to travel.
     const profile = profileOf('4-Bar');
     expect(profile.along[1]).toBeGreaterThan(profile.along[0]);
+  });
+
+  it('spans a branch-swapping two-revolution cycle once, so a drag cannot flicker', () => {
+    // The tangency slider-crank closes only after two crank revolutions.
+    // Wrapped to one turn, sample t and t+360 shared a handle position, and
+    // the scrubber flickered between the two assembly branches while
+    // dragging, float noise picking the winner on each event.
+    const { mechanism } = buildMechanism(squareRodSliderCrankFixture());
+    const profile = driveProfileOf(mechanism)!;
+
+    expect(profile.continuous).toBe(true);
+    expect(profile.along).toHaveLength(721);
+    // Monotone: every handle position names exactly one pose.
+    for (let i = 1; i < profile.along.length; i++) {
+      expect(profile.along[i]).toBeGreaterThan(profile.along[i - 1]);
+    }
+    expect(profile.along[0]).toBeCloseTo(0, 9);
+    expect(profile.along.at(-1)!).toBeCloseTo(1, 9);
+
+    // A simulated drag across the whole track lands on nearby samples in
+    // order, never across the cycle to the other branch. Distance is measured
+    // round the loop: the right edge of the track is the left edge, and both
+    // name the same (closed) pose -- a real branch flicker is a ~360-sample
+    // hop, which no seam can excuse.
+    const last = profile.along.length - 1;
+    let previous = 0;
+    for (let i = 0; i <= 200; i++) {
+      const sample = sampleAlong(profile, i / 200, previous);
+      const hop = Math.abs(sample - previous);
+      expect(Math.min(hop, last - hop)).toBeLessThanOrEqual(8);
+      previous = sample;
+    }
   });
 
   it('measures a ram between the ends of its own stroke, not its clock', () => {

--- a/src/app/model/mechanism/drive-profile.spec.ts
+++ b/src/app/model/mechanism/drive-profile.spec.ts
@@ -146,4 +146,17 @@ describe('Where a machine says its input is', () => {
     const profile = profileOf('4-Bar');
     expect(sampleAlong(profile, 1, 0)).toBe(0);
   });
+
+  it('lands a drag TO the right edge on the last sample, not sample zero', () => {
+    // The two ends of the loop are the same pose, but not the same readout: a
+    // drag arriving at the right edge should read as the end of the cycle
+    // (24.00 s, 720 degrees), and it used to snap to 0.00 s because the tie
+    // between the two ends went to whichever sample the scan met first.
+    const { mechanism } = buildMechanism(squareRodSliderCrankFixture());
+    const profile = driveProfileOf(mechanism)!;
+    const last = profile.along.length - 1;
+    expect(sampleAlong(profile, 1, last - 4)).toBe(last);
+    // And from rest at the start, the same place is still the start.
+    expect(sampleAlong(profile, 1, 0)).toBe(0);
+  });
 });

--- a/src/app/model/mechanism/drive-profile.ts
+++ b/src/app/model/mechanism/drive-profile.ts
@@ -15,9 +15,10 @@ import { Mechanism } from './mechanism';
  *
  * - A ram or slider runs from one end of its stroke to the other.
  * - A rocking crank runs from one angular limit to the other.
- * - A crank that goes all the way round has no limits to run between, so one
- *   turn spans the track and it wraps, with zero at the pose the drawing was
- *   authored in.
+ * - A crank that goes all the way round has no limits to run between, so the
+ *   whole cycle spans the track -- one turn usually, two for a rod that swaps
+ *   assembly branch at a slot tangency -- with zero at the pose the drawing
+ *   was authored in.
  *
  * Time is still what the machine is *at*, and still what the readout shows. It
  * is just no longer what the handle means.
@@ -71,18 +72,21 @@ export function driveProfileOf(mechanism: Mechanism, ram?: RamEnds): DriveProfil
   // it is a loop, and the only honest thing to show is how far round it is,
   // from the pose the drawing was authored in.
   //
+  // Round the WHOLE cycle, however many turns that is: a rod that swaps
+  // assembly branch at a slot tangency closes after two, and a track wrapped
+  // to one turn made every handle position name two different poses -- the
+  // scrubber flickered between them, float noise picking the winner.
+  //
   // Signed, and taken from the angle rather than from the sample index: the
   // crank is at the angle it is at whichever way it is being driven, so turning
   // the drive round must leave the handle where it is. Off the sample index it
   // would jump to the mirror image of itself.
   const continuous = !turnsBack(raw);
   if (continuous) {
-    const turn = 2 * Math.PI;
+    const total = raw[raw.length - 1] - raw[0];
+    const denominator = Math.abs(total) > 1e-9 ? total : 1;
     return {
-      along: raw.map((value) => {
-        const wrapped = ((value - raw[0]) / turn) % 1;
-        return wrapped < 0 ? wrapped + 1 : wrapped;
-      }),
+      along: raw.map((value) => (value - raw[0]) / denominator),
       continuous,
       linear,
       span: 0,

--- a/src/app/model/mechanism/drive-profile.ts
+++ b/src/app/model/mechanism/drive-profile.ts
@@ -225,11 +225,15 @@ function nearestSample(profile: DriveProfile, along: number, near: number): numb
   }
   if (profile.continuous) {
     // Round the loop: the place next to 0 is 1, not the far side of the track.
+    // The seam makes the track's two ends the same place, so distance to the
+    // sample the machine is at breaks that tie -- enough to keep a drag on its
+    // own end of the track, never enough to reach a place the reader did not
+    // point at.
     let best = 0;
     let bestCost = Infinity;
     profile.along.forEach((value, sample) => {
       const gap = Math.abs(value - along);
-      const cost = Math.min(gap, 1 - gap);
+      const cost = Math.min(gap, 1 - gap) + (Math.abs(sample - near) / last) * 1e-6;
       if (cost < bestCost) {
         bestCost = cost;
         best = sample;

--- a/src/app/model/mechanism/force-solver.fixture.spec.ts
+++ b/src/app/model/mechanism/force-solver.fixture.spec.ts
@@ -27,6 +27,10 @@ function expectForceAnalysis(mechanism: Mechanism, mode: ForceAnalysisMode) {
     expect(frame.rank).toBeGreaterThan(0);
     expect(Number.isFinite(frame.residual)).toBe(true);
     expect(frame.residual).toBeLessThanOrEqual(1e-8);
+    // Healthy solves stay an order of magnitude above the singularity
+    // tolerance (corpus-wide minimum measured 3.4e-3 against the 1e-4 line),
+    // so the cross-browser determinism guard cannot refuse real frames.
+    expect(frame.minPivot).toBeGreaterThan(1e-3);
     expect(frame.inputEffort).toBeDefined();
     expect(Number.isFinite(frame.inputEffort!.valueSI)).toBe(true);
     frame.jointReactionsByLink.forEach((byLink) =>

--- a/src/app/model/mechanism/force-solver.ts
+++ b/src/app/model/mechanism/force-solver.ts
@@ -36,6 +36,8 @@ export interface ForceAnalysisFrame {
   inputEffort?: ForceAnalysisEffort;
   rank: number;
   residual: number;
+  /** Smallest scaled pivot of the solve — how far this pose sat from singular. */
+  minPivot?: number;
   message?: string;
 }
 
@@ -115,10 +117,28 @@ interface LinearSolution {
   values: number[];
   rank: number;
   residual: number;
+  /** Smallest scaled pivot the elimination met — distance from singular. */
+  minPivot: number;
 }
 
 const GRAVITY = 9.80665;
 const MAX_NORMALIZED_RESIDUAL = 1e-8;
+/**
+ * The smallest scaled pivot the elimination accepts before calling the pose
+ * singular.
+ *
+ * A toggle pose reached through exact arithmetic pivots at exactly zero, but
+ * the same pose reached through floating-point trig lands within round-off of
+ * zero — and *which* side of zero differs by browser, because engines round
+ * transcendentals differently at the last bit. Chrome refused the square-rod
+ * tangency frame while Safari "solved" it into 8.5e5 N reactions from a 10 N
+ * load. Refusing anything below this line makes the call deterministic. The
+ * smallest scaled pivot of any healthy solve across the whole fixture corpus
+ * is 3.4e-3, 34x above the line (force-solver.fixture.spec.ts holds every
+ * frame above 1e-3), so frames the sampler lands merely *near* a toggle still
+ * solve, as designed.
+ */
+const SINGULAR_PIVOT_TOLERANCE = 1e-4;
 
 /**
  * Free-body force analysis for the current root topology.
@@ -241,8 +261,7 @@ export class ForceSolver {
       // the status alone can only say "topology".
       diagnostic:
         successfulFrames === 0
-          ? (frames[0]?.message ??
-            this.statusMessage(frames[0]?.status ?? 'unsupported-topology'))
+          ? (frames[0]?.message ?? this.statusMessage(frames[0]?.status ?? 'unsupported-topology'))
           : undefined,
     };
   }
@@ -526,6 +545,7 @@ export class ForceSolver {
       inputEffort,
       rank: solution.rank,
       residual: solution.residual,
+      minPivot: solution.minPivot,
     };
   }
 
@@ -591,9 +611,7 @@ export class ForceSolver {
         // has to appear in the carrier's equilibrium as well or the slot
         // transmits force out of nowhere. Resolved through compounds: a weld
         // may have folded the carrier into a root whose id is not its own.
-        const carrier = candidate.isFloating
-          ? this.rootBody(bodies, candidate.carrier)
-          : undefined;
+        const carrier = candidate.isFloating ? this.rootBody(bodies, candidate.carrier) : undefined;
         if (piston && (candidate.ground || carrier)) {
           reactions.push({
             joint: candidate,
@@ -895,6 +913,7 @@ export class ForceSolver {
     const matrix = A.map((row, index) => [...row, b[index]]);
     const scales = A.map((row) => Math.max(...row.map(Math.abs), 0));
     let rank = 0;
+    let minPivot = Infinity;
 
     for (let column = 0; column < n; column++) {
       let pivotRow = -1;
@@ -906,16 +925,18 @@ export class ForceSolver {
           pivotRow = row;
         }
       }
-      // Near-toggle frames legitimately have extremely small pivots and very
-      // large reactions. Solve them, then let the normalized residual decide
-      // whether the result is usable; reject only an exact/non-finite pivot.
+      // Near-toggle frames legitimately have small pivots and large reactions;
+      // they solve, and the normalized residual judges the result. But a pivot
+      // within SINGULAR_PIVOT_TOLERANCE of zero is a toggle pose seen through
+      // round-off, and which browser's round-off must not decide the answer.
       if (
         pivotRow < 0 ||
         !Number.isFinite(matrix[pivotRow][column]) ||
-        matrix[pivotRow][column] === 0
+        pivotScore < SINGULAR_PIVOT_TOLERANCE
       ) {
         return undefined;
       }
+      minPivot = Math.min(minPivot, pivotScore);
       if (pivotRow !== column) {
         [matrix[column], matrix[pivotRow]] = [matrix[pivotRow], matrix[column]];
         [scales[column], scales[pivotRow]] = [scales[pivotRow], scales[column]];
@@ -958,6 +979,6 @@ export class ForceSolver {
       solutionNorm = Math.max(solutionNorm, Math.abs(values[row]));
     }
     const residual = residualNorm / Math.max(1, matrixNorm * solutionNorm + rhsNorm);
-    return { values, rank, residual };
+    return { values, rank, residual, minPivot };
   }
 }

--- a/src/app/model/mechanism/mechanism.ts
+++ b/src/app/model/mechanism/mechanism.ts
@@ -438,9 +438,20 @@ export class Mechanism {
     // fraction of its stroke happened to lie on one side of where it was drawn.
     // The cycle is closed only once both limits have been reached and the
     // mechanism is home again.
+    // One revolution closes most cycles, but not every one: a rod that passes
+    // through tangency with its slot comes back on the other assembly branch,
+    // so after a full turn of the crank the block is across the slot from
+    // where it started. Its true period is two revolutions — out on one
+    // branch, home on the other. Watching only the reference joint missed
+    // this (the crank pin is home; the block is not), and the animation
+    // teleported at the wrap.
+    let revolutionsToClose = 1;
+    // One-shot: an abandoned extension rewinds to the very pose that asked for
+    // it, and without this it would ask again forever.
+    let extensionAbandoned = false;
     const cycleIncomplete = () =>
       revoluteInput && reversals === 0
-        ? currentTimeStamp < STEPS_PER_REVOLUTION
+        ? currentTimeStamp < STEPS_PER_REVOLUTION * revolutionsToClose
         : reversals < 2 || xDiff > TOLERANCE || yDiff > TOLERANCE;
 
     while (!simForward || currentTimeStamp === 0 || cycleIncomplete()) {
@@ -526,6 +537,15 @@ export class Mechanism {
         curTimeNum = curTimeNum + timeNumIncrement;
         this._timeNum.push(curTimeNum);
         this._inputAngularVelocities.push(inputAngVel);
+      } else if (revolutionsToClose === 2 && currentTimeStamp >= STEPS_PER_REVOLUTION) {
+        // The second revolution could not be solved through. Fall back to the
+        // one-revolution cycle and its warned seam rather than losing a
+        // mechanism the old behavior kept.
+        this.trimToSample(STEPS_PER_REVOLUTION);
+        currentTimeStamp = STEPS_PER_REVOLUTION;
+        curTimeNum = this._timeNum[currentTimeStamp];
+        revolutionsToClose = 1;
+        extensionAbandoned = true;
       } else {
         if ((!simForward && currentTimeStamp === 0) || falseTwice === 2) {
           //If we are here, the mechnism is in a toggle point
@@ -547,6 +567,18 @@ export class Mechanism {
       yDiff = Math.abs(
         startingPositionY - roundNumber(this._joints[currentTimeStamp][desiredJointIndex].y, 2)
       );
+      // The whole drawing has to be home, not just the reference joint, before
+      // the first revolution is allowed to be the whole cycle.
+      if (
+        revoluteInput &&
+        reversals === 0 &&
+        revolutionsToClose === 1 &&
+        !extensionAbandoned &&
+        currentTimeStamp === STEPS_PER_REVOLUTION &&
+        this.seamGapAt(currentTimeStamp) > this.seamTolerance()
+      ) {
+        revolutionsToClose = 2;
+      }
       if (currentTimeStamp === 750) {
         // How close it ever came to its starting pose, skipping the first few
         // frames where it is trivially still there. setMechanismInvalid wipes
@@ -566,20 +598,72 @@ export class Mechanism {
       }
     }
 
-    // Pin the closing sample to the analytic period 2*pi/|w| rather than to 360
-    // accumulated float additions, so the reported cycle time scales exactly with
-    // input speed and the last sample lines up with the first.
+    // An extension that ran its full second revolution and is still not home
+    // bought nothing: keep the one-revolution cycle the old behavior kept.
+    if (
+      revoluteInput &&
+      reversals === 0 &&
+      revolutionsToClose === 2 &&
+      this.seamGapAt(currentTimeStamp) > this.seamTolerance()
+    ) {
+      this.trimToSample(STEPS_PER_REVOLUTION);
+      currentTimeStamp = STEPS_PER_REVOLUTION;
+      revolutionsToClose = 1;
+    }
+
+    // Pin the closing sample to the analytic period rather than to hundreds of
+    // accumulated float additions, so the reported cycle time scales exactly
+    // with input speed and the last sample lines up with the first.
     if (revoluteInput && reversals === 0 && angularSpeed > Number.EPSILON) {
-      this._timeNum[this._timeNum.length - 1] = (2 * Math.PI) / angularSpeed;
-      // Closing at a fixed 360 steps assumes assembly-mode tracking held all the
-      // way around; if it did not, the cycle no longer ends where it began and
-      // the seam would otherwise be silent.
-      if (xDiff > TOLERANCE || yDiff > TOLERANCE) {
+      this._timeNum[this._timeNum.length - 1] = (revolutionsToClose * 2 * Math.PI) / angularSpeed;
+      // Closing at a fixed step count assumes assembly-mode tracking held all
+      // the way around; if it did not, the cycle no longer ends where it began
+      // and the seam would otherwise be silent.
+      const seam = this.seamGapAt(currentTimeStamp);
+      if (seam > this.seamTolerance()) {
         console.warn(
-          `Cycle did not close: after one input revolution the reference joint is off by (${xDiff}, ${yDiff})`
+          `Cycle did not close: after ${revolutionsToClose} input revolution(s) the drawing is off by ${seam}`
         );
       }
     }
+  }
+
+  /** Drop precomputed samples past `lastSample`, keeping 0..lastSample. */
+  private trimToSample(lastSample: number): void {
+    this._joints.length = lastSample + 1;
+    this._links.length = lastSample + 1;
+    this._forces.length = lastSample + 1;
+    this._timeNum.length = lastSample + 1;
+    this._inputAngularVelocities.length = lastSample + 1;
+  }
+
+  /** How far the furthest joint stands from its starting position at `sample`. */
+  private seamGapAt(sample: number): number {
+    const start = this._joints[0];
+    const now = this._joints[sample];
+    if (!now || now.length !== start.length) return Infinity;
+    let gap = 0;
+    for (let index = 0; index < start.length; index++) {
+      gap = Math.max(gap, Math.hypot(now[index].x - start[index].x, now[index].y - start[index].y));
+    }
+    return gap;
+  }
+
+  /**
+   * A seam wide enough to mean "different pose", not solver noise.
+   *
+   * Relative to the drawing's own size because coordinates arrive at whatever
+   * scale the caller drew in: solved positions are held to four decimals, so
+   * noise is orders below a thousandth of the drawing while a branch swap is
+   * on the order of a link length.
+   */
+  private seamTolerance(): number {
+    const start = this._joints[0];
+    let extent = 0;
+    for (const joint of start) {
+      extent = Math.max(extent, Math.abs(joint.x), Math.abs(joint.y));
+    }
+    return Math.max(extent, 1) * 1e-3;
   }
 
   /** Seconds spanned by one full traversal of the precomputed motion. */

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -2104,9 +2104,7 @@ export class MechanismService {
    */
   private storedMoiFactor(unitStr: string): number {
     const units = siUnitFactors(unitStr);
-    return (
-      ((units.massToKg * units.distanceToM ** 2) / units.inertiaToKgM2) / MODEL_SCALE ** 2
-    );
+    return (units.massToKg * units.distanceToM ** 2) / units.inertiaToKgM2 / MODEL_SCALE ** 2;
   }
 
   private currentUnitStr(): string {
@@ -2161,7 +2159,9 @@ export class MechanismService {
           );
     const moi = parts.reduce(
       (sum, part) =>
-        sum + part.moi + part.mass * ((part.com.x - com.x) ** 2 + (part.com.y - com.y) ** 2) * factor,
+        sum +
+        part.moi +
+        part.mass * ((part.com.x - com.x) ** 2 + (part.com.y - com.y) ** 2) * factor,
       0
     );
     return { com, moi };
@@ -3250,7 +3250,8 @@ export class MechanismService {
     if (!frames || times.length === 0) return 0;
     const period = frames.cyclePeriod;
     let local = this.secondsOf(index);
-    if (period > 0 && Number.isFinite(local)) {
+    if (period > 0 && Number.isFinite(local) && local !== period) {
+      // Exactly the period is the last sample, not a wrap back to the first.
       local = ((local % period) + period) % period;
     }
     let step = 0;
@@ -3699,6 +3700,11 @@ export class MechanismService {
    * comparing the drawing with the readout is looking at where the crank is
    * pointing, and "0" meaning "wherever it was drawn" is a different question
    * they did not ask.
+   *
+   * Except on a cycle of several turns — a branch-swapping slide closes after
+   * two — where the bearing repeats every turn and cannot say which one the
+   * machine is on. There the readout is progress round the whole cycle,
+   * 0 to 720.
    */
   inputAngleDegrees(index: number): number | undefined {
     const partition = this.partitions[index];
@@ -3710,6 +3716,12 @@ export class MechanismService {
     // itself is usually pinned to the frame and points nowhere.
     const end = driven.connectedJoints.find((joint) => !(joint as RealJoint).ground);
     if (!end) return undefined;
+    const samples = this.mechanisms[index]?.joints.length ?? 0;
+    const turns = samples > 1 ? Math.round((samples - 1) / 360) : 1;
+    const profile = this.driveProfileOf(index);
+    if (turns > 1 && profile?.continuous && !profile.linear) {
+      return (this.currentSampleOf(index) * (turns * 360)) / (samples - 1);
+    }
     const degrees = (Math.atan2(end.y - driven.y, end.x - driven.x) * 180) / Math.PI;
     return (degrees + 360) % 360;
   }
@@ -3768,7 +3780,10 @@ export class MechanismService {
   /** Put one machine at a place in its own cycle, and leave the others alone. */
   seekMechanism(index: number, seconds: number): void {
     const period = this.mechanisms[index]?.cyclePeriod ?? 0;
-    const local = period > 0 ? ((seconds % period) + period) % period : seconds;
+    // Exactly the period is the end of the cycle, not the start: dragging the
+    // handle to the track's right edge should read 24.00 s, not 0.00 s.
+    const local =
+      period > 0 ? (seconds === period ? period : ((seconds % period) + period) % period) : seconds;
     this.ownSeconds[index] = local;
     // The sample index is the master machine's, and half the app reads it --
     // the graphs, the URL, and the rule that says the editor is only open at

--- a/src/tests/verification/square-rod-tangency.spec.ts
+++ b/src/tests/verification/square-rod-tangency.spec.ts
@@ -93,4 +93,28 @@ describe('a slider-crank whose rod comes square to its guide', () => {
       expect(Math.abs(at(t, 'C').x - expected)).toBeLessThan(3e-4 * (1 + height / reach));
     }
   });
+
+  it('is force-singular at the tangency pose and nowhere else', () => {
+    // With the rod square to the guide, every force the rod can put on the
+    // block is normal to the slot -- nothing balances a slot-axis load, and
+    // the reactions grow without bound approaching the pose. The merged roots
+    // put C bitwise under B at the sampled tangency, so the equilibrium matrix
+    // is exactly singular at one interior frame of an otherwise good cycle:
+    // the one constructible mechanism known to produce a partial force series,
+    // which is the state the analysis chart's "No solution at N of M
+    // positions" banner exists for. If this ever starts solving, that banner
+    // has lost its last real trigger -- look before deleting it.
+    for (const mode of ['static', 'dynamic'] as const) {
+      const series = mechanism.getForceAnalysis(mode);
+      const failed = series.frames
+        .map((frame, index) => (frame.status !== 'ok' ? index : -1))
+        .filter((index) => index >= 0);
+      expect(failed).toEqual([tangency]);
+      expect(series.frames[tangency].status).toBe('singular');
+      expect(series.successfulFrames).toBe(samples - 1);
+      // A hole, not a verdict on the series: one bad pose must not raise the
+      // whole-series diagnostic.
+      expect(series.diagnostic).toBeUndefined();
+    }
+  });
 });

--- a/src/tests/verification/square-rod-tangency.spec.ts
+++ b/src/tests/verification/square-rod-tangency.spec.ts
@@ -32,7 +32,25 @@ describe('a slider-crank whose rod comes square to its guide', () => {
   /** How high the crank pin rides above the guide at each sample. */
   const heights = Array.from({ length: samples }, (_, t) => at(t, 'B').y);
   /** The sample the rod stands up on: the pin's height is greatest there. */
-  const tangency = heights.indexOf(Math.max(...heights));
+  const tangency = heights.slice(0, 361).indexOf(Math.max(...heights.slice(0, 361)));
+  /**
+   * Both stand-ups. Each pass through tangency swaps the assembly branch, so
+   * the block is across the slot after one crank revolution and home after
+   * two -- the cycle is 721 samples with a tangency in each revolution.
+   */
+  const tangencies = [tangency, tangency + 360];
+
+  it('needs two crank revolutions to close, and does close', () => {
+    // One revolution used to be assumed as the whole cycle, and the branch
+    // swap meant frame 360 was nowhere near frame 0: the animation teleported
+    // the block across the slot at every wrap.
+    expect(samples).toBe(721);
+    for (const joint of mechanism.joints[0]) {
+      const last = at(samples - 1, joint.id);
+      const gap = Math.hypot(last.x - joint.x, last.y - joint.y);
+      expect(gap, `joint ${joint.id} is not home at the seam`).toBeLessThan(1e-2);
+    }
+  });
 
   it('turns all the way round, through the pose rather than stopping at it', () => {
     expect(samples).toBeGreaterThan(300);
@@ -40,8 +58,10 @@ describe('a slider-crank whose rod comes square to its guide', () => {
     // started on it, would exercise nothing.
     expect(tangency).toBeGreaterThan(20);
     expect(tangency).toBeLessThan(samples - 20);
-    // And it really is the tangency: the rod reaches exactly to the guide.
-    expect(Math.abs(heights[tangency] - ROD)).toBeLessThan(2e-3);
+    // And both really are the tangency: the rod reaches exactly to the guide.
+    for (const pass of tangencies) {
+      expect(Math.abs(heights[pass] - ROD)).toBeLessThan(2e-3);
+    }
   });
 
   it('keeps the rod rigid and the slider on its guide', () => {
@@ -71,15 +91,16 @@ describe('a slider-crank whose rod comes square to its guide', () => {
   it('matches the closed form, swapping branch where the roots meet', () => {
     // s = r cos(theta) +/- sqrt(rod^2 - h^2), h the pin's height above the
     // guide. Which sign is not a free choice and not a fitted parameter: the
-    // slider crosses the foot of the perpendicular at the tangency, so it comes
-    // out on the other root, and the sign flips there and nowhere else.
+    // slider crosses the foot of the perpendicular at each tangency, so it
+    // comes out on the other root, and the sign flips there and nowhere else
+    // -- minus between the two stand-ups, plus outside them.
     for (let t = 1; t < samples; t++) {
       const a = at(t, 'A');
       const b = at(t, 'B');
       const theta = Math.atan2(b.y - a.y, b.x - a.x);
       const height = SQUARE_ROD_OFFSET + SQUARE_ROD_CRANK * Math.sin(theta);
       const reach = Math.sqrt(Math.max(0, ROD * ROD - height * height));
-      const sign = t <= tangency ? 1 : -1;
+      const sign = t <= tangencies[0] || t > tangencies[1] ? 1 : -1;
       const expected = SQUARE_ROD_CRANK * Math.cos(theta) + sign * reach;
 
       // The bound is derived rather than chosen, because the formula is
@@ -94,14 +115,14 @@ describe('a slider-crank whose rod comes square to its guide', () => {
     }
   });
 
-  it('is force-singular at the tangency pose and nowhere else', () => {
+  it('is force-singular at the tangency poses and nowhere else', () => {
     // With the rod square to the guide, every force the rod can put on the
     // block is normal to the slot -- nothing balances a slot-axis load, and
     // the reactions grow without bound approaching the pose. The merged roots
-    // put C bitwise under B at the sampled tangency, so the equilibrium matrix
-    // is exactly singular at one interior frame of an otherwise good cycle:
-    // the one constructible mechanism known to produce a partial force series,
-    // which is the state the analysis chart's "No solution at N of M
+    // put C bitwise under B at each sampled tangency, so the equilibrium
+    // matrix is exactly singular at two interior frames of an otherwise good
+    // cycle: the one constructible mechanism known to produce a partial force
+    // series, which is the state the analysis chart's "No solution at N of M
     // positions" banner exists for. If this ever starts solving, that banner
     // has lost its last real trigger -- look before deleting it.
     for (const mode of ['static', 'dynamic'] as const) {
@@ -109,10 +130,12 @@ describe('a slider-crank whose rod comes square to its guide', () => {
       const failed = series.frames
         .map((frame, index) => (frame.status !== 'ok' ? index : -1))
         .filter((index) => index >= 0);
-      expect(failed).toEqual([tangency]);
-      expect(series.frames[tangency].status).toBe('singular');
-      expect(series.successfulFrames).toBe(samples - 1);
-      // A hole, not a verdict on the series: one bad pose must not raise the
+      expect(failed).toEqual(tangencies);
+      for (const pass of tangencies) {
+        expect(series.frames[pass].status).toBe('singular');
+      }
+      expect(series.successfulFrames).toBe(samples - 2);
+      // Holes, not a verdict on the series: two bad poses must not raise the
       // whole-series diagnostic.
       expect(series.diagnostic).toBeUndefined();
     }


### PR DESCRIPTION
Stacked on #237 (`mass-settings`); retargets to `multi-mechanism-redesign` when that merges. Ten commits: the force-analysis "No solution" banner made real and browser-deterministic, cycles that close where they actually close, honest scrubbing and readouts on two-turn cycles, and the empty force panel redesigned in the Analysis Help card's pattern.

## The gap banner is real, and both browsers agree on it

- The "No solution at N of M positions" banner was believed unreachable. A systematic hunt falsified that: the gallery's **square-rod tangency slider-crank** goes force-singular at exactly the sampled frames where the merged position-solver roots put the block bitwise under the pin. Pinned in `square-rod-tangency.spec.ts`, with the banner/gap rendering pinned by fabricated-frame component specs.
- Chrome and Safari disagreed by **one ulp in a link CoM** (engine trig), flipping that frame between "singular" (banner) and "solved" into 8.5e5 N reactions from a 10 N load. The elimination now refuses any scaled pivot under `SINGULAR_PIVOT_TOLERANCE = 1e-4` — the corpus-wide smallest healthy pivot is 3.4e-3, and the fixture sweep holds every ok frame's new `minPivot` diagnostic above 1e-3 — so the classification is deterministic across engines. Verified in Chromium and WebKit.
- `determineChart` also stops leaking a stale gap banner into kinematic graphs, and pressing the banner's button mid-animation now pauses before seeking, so the mechanism actually stands at the pose it names.
- The button reads **"Show position"** for one hole and **"Show first (9 s)"** — naming the time it jumps to — for several.

## Cycles close where the mechanism closes

- A rod passing through slot tangency comes back on the other assembly branch, so its true period is **two crank revolutions** — but the cycle builder assumed one and only watched the crank pin, which is home after one. The animation teleported the block across the slot at every wrap. The builder now checks the whole drawing and solves a second revolution when the first doesn't close (falling back to the old warned seam if the extension can't be solved or still doesn't close).
- The playback track spans the **whole cycle**: wrapped to one turn, every handle position named two poses and scrubbing flickered between branches (82 hops per sweep, float noise picking the winner). The profile is monotone now; dragging is continuous through both revolutions.
- The angle readout shows **0–720°** on multi-turn cycles (compass bearing can't say which turn you're on), seeking exactly the period parks at the cycle's end instead of wrapping to 0.00 s, and the seam tie at the track's right edge breaks toward wherever the machine already is.

## The empty force panel stops shouting

- A joint with no force graphs (a tracer on one link, or a pin welded inside a compound) used to show the Static/In-motion selector, the input-speed summary, and a large grey banner speaking solver ("internal to one welded body", "independent pin reaction"). It now shows the Analysis Help card's pattern: the cause in the title's description ("Only one part meets Joint C, so there is no force to graph here"), a rule, and an icon hint with the way out ("Click a joint where separate parts meet, or a grounded one"). The link panel's twin and the in-graph diagnostic match.
- The wording deliberately avoids "welded" — a tracer point has no reaction without a weld anywhere in the mechanism.

## Verification

Unit specs pin each behavior (tangency singularity, corpus pivot floor, two-revolution closure, monotone drive profile, seam tie-break, banner wording/pause, panel empty state). Everything was also verified live against the dev build with Playwright — Chromium and WebKit both — including screenshots at each step, and two independent GPT-5.6 sol browser reviews passed the banner flow and the cycle/scrub fixes with no functional deviations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
