### PR TITLE
Bring Make Circular and a real six-bar driver over from PMKS-Refactor

### DIFF
--- a/e2e/circular-link-and-driver.mjs
+++ b/e2e/circular-link-and-driver.mjs
@@ -58,6 +58,8 @@ const linkState = () =>
       id: crank?.id,
       isCircle: crank?.isCircle,
       arcs: (crank?.d.match(/A /g) ?? []).length,
+      // A bar has two arcs too (its end caps); only a disc has no straight edge.
+      sides: (crank?.d.match(/ L /g) ?? []).length,
       edges: crank?.externalLines.length,
       box: rect ? [Math.round(rect.width), Math.round(rect.height)] : null,
       url: location.search,
@@ -109,8 +111,8 @@ stage = 'made-circular';
 const after = await linkState();
 check(
   'the crank is drawn as a disc',
-  after.isCircle === true && after.arcs === 2,
-  `${after.arcs} arcs`
+  after.isCircle === true && after.arcs === 2 && after.sides === 0,
+  `${after.arcs} arcs, ${after.sides} straight edges`
 );
 check(
   'the disc is as tall as it is wide',
@@ -136,7 +138,10 @@ if (shared) {
   await waitForReady(page);
   await dismissTour();
   const reopened = await linkState();
-  check('a shared URL reopens as a disc', reopened.isCircle === true && reopened.arcs === 2);
+  check(
+    'a shared URL reopens as a disc',
+    reopened.isCircle === true && reopened.arcs === 2 && reopened.sides === 0
+  );
 } else {
   check('a shared URL reopens as a disc', false, 'could not reach the url generator');
 }
@@ -151,9 +156,13 @@ await page.waitForTimeout(1200);
 const running = await page.evaluate(() => {
   const grid = ng.getComponent(document.querySelector('app-new-grid'));
   const crank = grid.mechanismSrv.links.find((l) => l.isCircle);
-  return { arcs: (crank?.d.match(/A /g) ?? []).length, d: crank?.d.slice(0, 40) };
+  return {
+    arcs: (crank?.d.match(/A /g) ?? []).length,
+    sides: (crank?.d.match(/ L /g) ?? []).length,
+    d: crank?.d.slice(0, 40),
+  };
 });
-check('it is still a disc while running', running.arcs === 2, running.d);
+check('it is still a disc while running', running.arcs === 2 && running.sides === 0, running.d);
 await shot('2-running');
 
 // -------------------------------------------------------------- synthesis

--- a/e2e/circular-link-and-driver.mjs
+++ b/e2e/circular-link-and-driver.mjs
@@ -1,0 +1,288 @@
+/**
+ * The two things brought over from PMKS-Refactor, driven through the app:
+ * Make Circular on a crank, and the driver dyad that turns a synthesised
+ * four-bar into a six-bar a motor can run.
+ *
+ *   BASE=http://localhost:4310 node e2e/circular-link-and-driver.mjs
+ */
+const { chromium } = await import('/tmp/pmks-playwright/node_modules/playwright/index.mjs');
+import { waitForReady } from './app-ready.mjs';
+import { readFileSync, mkdirSync } from 'node:fs';
+
+const BASE = process.env.BASE ?? 'http://localhost:4310';
+const SHOTS = new URL('../artifacts/screenshots/', import.meta.url).pathname;
+mkdirSync(SHOTS, { recursive: true });
+
+const source = readFileSync(
+  new URL('../src/app/component/MODALS/templates/template-linkages.ts', import.meta.url).pathname,
+  'utf8'
+);
+const payloads = Object.fromEntries(
+  [...source.matchAll(/^ {2}'?([\w-]+)'?:\n {4}'([^']+)',$/gm)].map(([, id, p]) => [id, p])
+);
+
+const checks = [];
+const check = (name, pass, detail = '') => {
+  checks.push({ name, pass, detail });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+};
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1500, height: 950 } });
+const errors = [];
+let stage = 'load';
+const note = (text) => errors.push(`[${stage}] ${text.split('\n')[0].slice(0, 140)}`);
+page.on('pageerror', (e) => note(String(e)));
+page.on('console', (m) => m.type() === 'error' && note(m.text()));
+
+const shot = (name) => page.screenshot({ path: `${SHOTS}circdrv-${name}.png` });
+
+const dismissTour = async () => {
+  const skip = page.locator('.introjs-skipbutton').first();
+  if (await skip.isVisible().catch(() => false)) await skip.click({ force: true });
+  await page.waitForTimeout(400);
+};
+
+// ---------------------------------------------------------------- circular
+await page.goto(`${BASE}/?${payloads['4-Bar']}`, { waitUntil: 'domcontentloaded' });
+await waitForReady(page);
+await dismissTour();
+
+const linkState = () =>
+  page.evaluate(() => {
+    const grid = ng.getComponent(document.querySelector('app-new-grid'));
+    const crank = grid.mechanismSrv.links.find((l) => l.canBeCircular?.());
+    const box = crank ? document.querySelector(`#linkHolder path#${crank.id}`) : null;
+    const rect = box?.getBoundingClientRect();
+    return {
+      id: crank?.id,
+      isCircle: crank?.isCircle,
+      arcs: (crank?.d.match(/A /g) ?? []).length,
+      edges: crank?.externalLines.length,
+      box: rect ? [Math.round(rect.width), Math.round(rect.height)] : null,
+      url: location.search,
+    };
+  });
+
+stage = 'template-loaded';
+const before = await linkState();
+check('a grounded crank is eligible for a disc', !!before.id, `link ${before.id}`);
+
+// What the right-click menu actually offers, which is the only way anyone
+// reaches this feature.
+const menuLabels = (linkId) =>
+  page.evaluate((id) => {
+    const grid = ng.getComponent(document.querySelector('app-new-grid'));
+    grid.setLastRightClick(grid.mechanismSrv.links.find((l) => l.id === id));
+    grid.updateContextMenuItems();
+    return grid.cMenuItems.map((item) => item.label);
+  }, linkId);
+
+const coupler = await page.evaluate(() => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  const free = grid.mechanismSrv.links.find((l) => !l.canBeCircular());
+  return free ? { id: free.id, can: free.canBeCircular() } : null;
+});
+check('a coupler is not', coupler !== null && coupler.can === false, `link ${coupler?.id}`);
+
+const crankMenu = await menuLabels(before.id);
+const couplerMenu = await menuLabels(coupler.id);
+check(
+  'the crank is offered Make Circular',
+  crankMenu.includes('Make Circular'),
+  crankMenu.join(', ')
+);
+check(
+  'the coupler is offered nothing of the kind',
+  !couplerMenu.some((label) => label === 'Make Circular' || label === 'Make Bar'),
+  couplerMenu.join(', ')
+);
+
+await page.evaluate((id) => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  grid.activeObjService.updateSelectedObj(grid.mechanismSrv.links.find((l) => l.id === id));
+  grid.mechanismSrv.toggleLinkCircular();
+}, before.id);
+await page.waitForTimeout(500);
+
+stage = 'made-circular';
+const after = await linkState();
+check(
+  'the crank is drawn as a disc',
+  after.isCircle === true && after.arcs === 2,
+  `${after.arcs} arcs`
+);
+check(
+  'the disc is as tall as it is wide',
+  after.box && Math.abs(after.box[0] - after.box[1]) <= 2,
+  `${after.box}`
+);
+check('the disc has no edges to hang a joint on', after.edges === 0, `${after.edges} edges`);
+check(
+  'the disc is bigger than the bar it replaced',
+  after.box[0] > before.box[0],
+  `${before.box[0]} → ${after.box[0]}`
+);
+await shot('1-disc');
+
+// The URL has to carry it, and reloading has to bring it back.
+const shared = await page.evaluate(() => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  return grid.saveHistoryService.urlGenerationService.generateUrlQuery();
+});
+stage = 'share-url';
+if (shared) {
+  await page.goto(`${BASE}/?${shared}`, { waitUntil: 'domcontentloaded' });
+  await waitForReady(page);
+  await dismissTour();
+  const reopened = await linkState();
+  check('a shared URL reopens as a disc', reopened.isCircle === true && reopened.arcs === 2);
+} else {
+  check('a shared URL reopens as a disc', false, 'could not reach the url generator');
+}
+
+// It has to survive being animated: every solved frame is a fresh copy.
+await page.evaluate(() => {
+  const bar = ng.getComponent(document.querySelector('app-playback-bar'));
+  bar.togglePlay ? bar.togglePlay() : bar.play?.();
+});
+stage = 'animating';
+await page.waitForTimeout(1200);
+const running = await page.evaluate(() => {
+  const grid = ng.getComponent(document.querySelector('app-new-grid'));
+  const crank = grid.mechanismSrv.links.find((l) => l.isCircle);
+  return { arcs: (crank?.d.match(/A /g) ?? []).length, d: crank?.d.slice(0, 40) };
+});
+check('it is still a disc while running', running.arcs === 2, running.d);
+await shot('2-running');
+
+// -------------------------------------------------------------- synthesis
+await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+await waitForReady(page);
+await dismissTour();
+
+// Synthesis tab, then three poses via the panel's own model.
+await page.evaluate(() => {
+  // TabID.SYNTHESIZE is 0.
+  ng.getComponent(document.querySelector('app-left-tabs')).tabs.setTab(0);
+});
+await page.waitForTimeout(600);
+await shot('3-synthesis-tab');
+
+stage = 'synthesis-poses';
+const posed = await page.evaluate(() => {
+  const panel = ng.getComponent(document.querySelector('app-synthesis-panel'));
+  if (!panel) return { ok: false };
+  const b = panel.synthesisBuilder;
+  [1, 2, 3].forEach((i) => b.isPoseDefined(i) || b.createPose(i));
+  const at = [
+    [-2, 1, 20],
+    [0, 2.2, 45],
+    [2.4, 1.4, 70],
+  ];
+  [1, 2, 3].forEach((i) => {
+    const [x, y, deg] = at[i - 1];
+    b.poses[i].position = new b.poses[i].position.constructor(x * 200, y * 200);
+    b.poses[i].thetaDegrees = deg;
+  });
+  b.valueChanges.next(true);
+  return {
+    ok: true,
+    links: panel.mechanismSrv.links.length,
+    joints: panel.mechanismSrv.joints.length,
+  };
+});
+check(
+  'three poses synthesise a four-bar',
+  posed.ok && posed.links === 3,
+  `${posed.links} links, ${posed.joints} joints`
+);
+await page.waitForTimeout(500);
+await shot('4-fourbar');
+
+const driverState = () =>
+  page.evaluate(() => {
+    const panel = ng.getComponent(document.querySelector('app-synthesis-panel'));
+    const m = panel.mechanismSrv;
+    return {
+      links: m.links.length,
+      joints: m.joints.length,
+      grounds: m.joints.filter((j) => j.ground).length,
+      inputs: m.joints.filter((j) => j.input).length,
+      refusal: panel.synthesisBuilder.driverRefusal ?? null,
+      wanted: panel.synthesisBuilder.driverWanted,
+      valid: m.mechanisms[0]?.mechanismValid,
+      frames: m.mechanisms[0]?.joints?.length ?? 0,
+    };
+  });
+
+stage = 'four-bar';
+const fourBar = await driverState();
+check(
+  'the four-bar is driven from one ground pin',
+  fourBar.inputs === 1 && fourBar.grounds === 2,
+  `${fourBar.inputs} input, ${fourBar.grounds} ground`
+);
+
+await page.evaluate(() =>
+  ng.getComponent(document.querySelector('app-synthesis-panel')).toggleDriver()
+);
+await page.waitForTimeout(900);
+stage = 'six-bar';
+const sixBar = await driverState();
+check(
+  'adding a driver makes it a six-bar',
+  sixBar.links === 5 && sixBar.joints === 6 && sixBar.grounds === 3,
+  `${sixBar.links} links, ${sixBar.joints} joints, ${sixBar.grounds} grounds, refusal=${sixBar.refusal}`
+);
+check('the drive moved to the new pin', sixBar.inputs === 1, `${sixBar.inputs} inputs`);
+check('the six-bar solves', sixBar.valid === true, `valid=${sixBar.valid} frames=${sixBar.frames}`);
+check(
+  'one full turn of the driver, not a stub of one',
+  sixBar.frames > 100,
+  `${sixBar.frames} frames`
+);
+await shot('5-sixbar');
+
+await page.evaluate(() =>
+  ng.getComponent(document.querySelector('app-synthesis-panel')).swapDrivePin()
+);
+await page.waitForTimeout(900);
+stage = 'swap-pin';
+const swapped = await driverState();
+check(
+  'swapping the drive pin rebuilds it whole',
+  swapped.links === 5 && swapped.joints === 6,
+  `${swapped.links} links, ${swapped.joints} joints, refusal=${swapped.refusal}`
+);
+await shot('6-swapped');
+
+await page.evaluate(() =>
+  ng.getComponent(document.querySelector('app-synthesis-panel')).toggleDriver()
+);
+await page.waitForTimeout(900);
+stage = 'driver-removed';
+const removed = await driverState();
+check(
+  'removing the driver leaves the four-bar behind',
+  removed.links === 3 && removed.joints === 4 && removed.inputs === 1,
+  `${removed.links} links, ${removed.joints} joints`
+);
+await shot('7-driver-removed');
+
+// One console error predates this branch: setting up three synthesis poses
+// draws a path the browser rejects for a frame, and it reproduces identically
+// on multi-mechanism-redesign at b3f9e08. Named rather than ignored, so that a
+// second copy of it — or any other error — still fails this run.
+const KNOWN_BEFORE_THIS_BRANCH = /^\[synthesis-poses\] Error: Invalid SVG path number$/;
+const unexpected = errors.filter((e) => !KNOWN_BEFORE_THIS_BRANCH.test(e));
+check(
+  'no page errors beyond the one that predates this work',
+  unexpected.length === 0,
+  unexpected.slice(0, 6).join('\n        ')
+);
+
+await browser.close();
+const failed = checks.filter((c) => !c.pass);
+console.log(`\n${checks.length - failed.length}/${checks.length} passed`);
+process.exit(failed.length ? 1 : 0);

--- a/e2e/pointer-pairing.mjs
+++ b/e2e/pointer-pairing.mjs
@@ -1,0 +1,135 @@
+/**
+ * A press that arrives as a bare `mousedown`, with no `pointerdown` before it.
+ *
+ * Safari does this exactly once after a native `<select>` popup is dismissed.
+ * The canvas is driven by pointer events and svg-pan-zoom by mouse events, so
+ * the unpaired press went to the library alone: the canvas panned under a
+ * cursor that was holding a link, and the drag did nothing. The gesture after
+ * it is paired again, which is why clicking once "fixes" it and hides the cause.
+ *
+ * The sequence below is the one traced from the failing gesture in Safari, so
+ * this reproduces it in any engine — no native popup required.
+ *
+ *   BASE=http://127.0.0.1:4310 node e2e/pointer-pairing.mjs
+ */
+const { chromium, webkit } = await import('/tmp/pmks-playwright/node_modules/playwright/index.mjs');
+import { waitForReady } from './app-ready.mjs';
+import { readFileSync } from 'node:fs';
+
+const BASE = process.env.BASE ?? 'http://127.0.0.1:4310';
+const source = readFileSync(
+  new URL('../src/app/component/MODALS/templates/template-linkages.ts', import.meta.url).pathname,
+  'utf8'
+);
+const payloads = Object.fromEntries(
+  [...source.matchAll(/^ {2}'?([\w-]+)'?:\n {4}'([^']+)',$/gm)].map(([, id, p]) => [id, p])
+);
+
+const checks = [];
+const check = (name, pass, detail = '') => {
+  checks.push({ name, pass });
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+};
+
+/** Grabs a third of the way along B→C, clear of the CoM handle at the midpoint. */
+const GRAB = () => {
+  const at = (id) => {
+    const r = document.querySelector(`#joint_${id}`).closest('svg[x]').getBoundingClientRect();
+    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+  };
+  const B = at('B');
+  const C = at('C');
+  return { x: B.x + (C.x - B.x) / 3, y: B.y + (C.y - B.y) / 3 };
+};
+
+for (const engine of [chromium, webkit]) {
+  const name = engine === chromium ? 'chromium' : 'webkit';
+  const browser = await engine.launch();
+  const page = await browser.newPage({ viewport: { width: 1500, height: 950 } });
+  await page.goto(`${BASE}/?${payloads['4-Bar']}`, { waitUntil: 'domcontentloaded' });
+  await waitForReady(page);
+  const skip = page.locator('.introjs-skipbutton').first();
+  if (await skip.isVisible().catch(() => false)) await skip.click({ force: true });
+  await page.waitForTimeout(900);
+  await page.evaluate(() => {
+    const grid = ng.getComponent(document.querySelector('app-new-grid'));
+    grid.activeObjService.updateSelectedObj(grid.mechanismSrv.links.find((l) => l.id === 'BC'));
+  });
+  await page.waitForTimeout(600);
+
+  const unpaired = await page.evaluate((grabSource) => {
+    const grid = ng.getComponent(document.querySelector('app-new-grid'));
+    const joints = () =>
+      JSON.stringify(grid.mechanismSrv.joints.map((j) => [j.id, Math.round(j.x), Math.round(j.y)]));
+    const pan = () => JSON.stringify(grid.svgGrid.panZoomObject.getPan());
+    const before = joints();
+    const panBefore = pan();
+    const p = new Function('return ' + grabSource)()();
+    const target = document.elementFromPoint(p.x, p.y);
+    const at = (x, y, buttons) => ({
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      clientX: x,
+      clientY: y,
+      screenX: x,
+      screenY: y,
+      button: 0,
+      buttons,
+    });
+    // The press with nothing before it — what Safari sends after its popup.
+    target.dispatchEvent(new MouseEvent('mousedown', at(p.x, p.y, 1)));
+    for (let i = 1; i <= 10; i++) {
+      const x = p.x + i * 5;
+      const y = p.y + i * 3;
+      const move = { ...at(x, y, 1), pointerId: 1, pointerType: 'mouse' };
+      target.dispatchEvent(new PointerEvent('pointermove', move));
+      target.dispatchEvent(new MouseEvent('mousemove', at(x, y, 1)));
+    }
+    const up = { ...at(p.x + 50, p.y + 30, 0), pointerId: 1, pointerType: 'mouse' };
+    target.dispatchEvent(new PointerEvent('pointerup', up));
+    target.dispatchEvent(new MouseEvent('mouseup', at(p.x + 50, p.y + 30, 0)));
+    return { target: target.tagName, linkMoved: joints() !== before, panned: pan() !== panBefore };
+  }, GRAB.toString());
+
+  check(`${name}: an unpaired mousedown drags the link`, unpaired.linkMoved, unpaired.target);
+  check(`${name}: and does not pan the canvas instead`, !unpaired.panned);
+
+  // The ordinary paired gesture must still work, and must not act twice.
+  const paired = await page.evaluate(() => {
+    const grid = ng.getComponent(document.querySelector('app-new-grid'));
+    window.__downs = 0;
+    document.addEventListener('pointerdown', () => (window.__downs += 1), true);
+    return grid.mechanismSrv.joints.map((j) => [j.id, Math.round(j.x), Math.round(j.y)]);
+  });
+  const p = await page.evaluate(GRAB);
+  await page.mouse.move(p.x, p.y);
+  await page.mouse.down();
+  for (let i = 1; i <= 10; i++) {
+    await page.mouse.move(p.x + i * 5, p.y + i * 3);
+    await page.waitForTimeout(25);
+  }
+  await page.mouse.up();
+  await page.waitForTimeout(400);
+  const afterPaired = await page.evaluate(() => ({
+    joints: ng
+      .getComponent(document.querySelector('app-new-grid'))
+      .mechanismSrv.joints.map((j) => [j.id, Math.round(j.x), Math.round(j.y)]),
+    downs: window.__downs,
+  }));
+  check(
+    `${name}: a normal drag still works`,
+    JSON.stringify(paired) !== JSON.stringify(afterPaired.joints)
+  );
+  check(
+    `${name}: and the browser's own pointerdown is not doubled`,
+    afterPaired.downs === 1,
+    `${afterPaired.downs} pointerdown(s)`
+  );
+
+  await browser.close();
+}
+
+const failed = checks.filter((c) => !c.pass);
+console.log(`\n${checks.length - failed.length}/${checks.length} passed`);
+process.exit(failed.length ? 1 : 0);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -121,6 +121,14 @@ export class AppComponent {
       this.domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/unweld_joint.svg')
     );
     this.matIconRegistry.addSvgIcon(
+      'make_circular',
+      this.domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/make_circular.svg')
+    );
+    this.matIconRegistry.addSvgIcon(
+      'make_bar',
+      this.domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/make_bar.svg')
+    );
+    this.matIconRegistry.addSvgIcon(
       'github',
       this.domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/github.svg')
     );

--- a/src/app/component/BLOCKS/button/button.component.html
+++ b/src/app/component/BLOCKS/button/button.component.html
@@ -7,6 +7,9 @@
     [color]="this.color()"
     [disabled]="this.disabled()"
     [class]="this.color()"
+    [matTooltip]="this.tooltip() ?? ''"
+    [matTooltipDisabled]="!this.tooltip()"
+    [matTooltipShowDelay]="1000"
   >
     @if (icon && !customIcon) {
       <mat-icon>{{ icon }}</mat-icon>

--- a/src/app/component/BLOCKS/button/button.component.scss
+++ b/src/app/component/BLOCKS/button/button.component.scss
@@ -13,6 +13,19 @@
 
   #button-block {
     width: 100%;
+
+    // Material gives mat-icon a box taller than the glyph it holds (22px
+    // against an 18px drawing), and lays that drawing out at the top of it.
+    // The button then centres the box, which leaves the icon itself riding a
+    // couple of pixels above the label beside it -- visible on every icon
+    // button in the panels, and obvious on one whose glyph is a plain circle.
+    // Centring the contents of the box puts the drawing where the box is.
+    mat-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
     //height: 30px;
     //color: white;
     //background-color: mat.get-color-from-palette($primary-palette, 400);

--- a/src/app/component/BLOCKS/button/button.component.ts
+++ b/src/app/component/BLOCKS/button/button.component.ts
@@ -2,13 +2,14 @@ import { Component, Input, ChangeDetectionStrategy, inject, input } from '@angul
 import { ActiveObjService } from 'src/app/services/active-obj.service';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
 
 @Component({
   selector: 'button-block',
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
   changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [MatButton, MatIcon],
+  imports: [MatButton, MatIcon, MatTooltip],
 })
 export class ButtonComponent {
   activeSrv = inject(ActiveObjService);
@@ -19,4 +20,11 @@ export class ButtonComponent {
 
   @Input() customIcon: string | undefined;
   readonly disabled = input<boolean>(false);
+  /**
+   * Said on hover, the way every other block in the panels says it. On the
+   * button itself rather than on a help icon beside it: a button is its own
+   * label, so there is nothing for the icon to sit next to, and a button that
+   * needs explaining is exactly the one a person is already pointing at.
+   */
+  readonly tooltip = input<string>();
 }

--- a/src/app/component/edit-panel/edit-panel.component.html
+++ b/src/app/component/edit-panel/edit-panel.component.html
@@ -561,6 +561,15 @@
             }
           </span>
         </input-block>
+        <!-- Drawing a crank as a disc is a picture, not a declaration that the
+             part is one. Said here, next to the two numbers it would otherwise
+             be reasonable to assume it had changed. -->
+        @if (activeSrv.selectedLink.isCircle) {
+          <p class="shapeNote">
+            Drawn as a disc. These two still follow the link's joints, not the
+            circle — set Rotational Inertia by hand for a real flywheel.
+          </p>
+        }
         </div>
       </collapsible-subseciton>
       @if (activeSrv.selectedLink.isCompound) {

--- a/src/app/component/edit-panel/edit-panel.component.html
+++ b/src/app/component/edit-panel/edit-panel.component.html
@@ -483,27 +483,32 @@
              The label follows what is actually on the canvas, not the stored
              choice: a disc whose ground has since been removed is drawn as a
              bar, and a button reading "Make Bar" over a bar is a puzzle. -->
-        <button-block
-          [customIcon]="drawnAsDisc() ? 'make_bar' : 'make_circular'"
-          [disabled]="!activeSrv.selectedLink.canBeCircular()"
-          (click)="mechanismService.toggleLinkCircular()"
-          [tooltip]="
-            drawnAsDisc()
-              ? 'Draw this link as an ordinary bar between its joints.'
-              : 'Draw this link as the disc it sweeps, centred on its fixed pin. Its mass and rotational inertia are unchanged.'
-          "
+        <!-- The reason it cannot be pressed is carried by this wrapper, not by
+             the button: a disabled button receives no pointer events, so its
+             own tooltip would never open — the one explanation of why it is
+             greyed out would be the one nobody could reach. The wrapper is
+             still hoverable, and the stylesheet takes the disabled button out
+             of the way so the hover lands here. -->
+        <div
+          class="shapeToggle"
+          [matTooltip]="whyNotCircular()"
+          [matTooltipDisabled]="activeSrv.selectedLink.canBeCircular()"
+          [matTooltipShowDelay]="400"
+          matTooltipPosition="above"
         >
-          {{ drawnAsDisc() ? 'Make Bar' : 'Make Circular' }}
-        </button-block>
-        <!-- Said in the panel rather than left to the button's tooltip: a
-             disabled button receives no pointer events, so its tooltip never
-             opens and the one explanation of why it cannot be pressed is the
-             one nobody can reach. -->
-        @if (!activeSrv.selectedLink.canBeCircular()) {
-          <p class="shapeNote">
-            {{ whyNotCircular() }}
-          </p>
-        }
+          <button-block
+            [customIcon]="drawnAsDisc() ? 'make_bar' : 'make_circular'"
+            [disabled]="!activeSrv.selectedLink.canBeCircular()"
+            (click)="mechanismService.toggleLinkCircular()"
+            [tooltip]="
+              drawnAsDisc()
+                ? 'Draw this link as an ordinary bar between its joints.'
+                : 'Draw this link as the disc it sweeps, centred on its fixed pin. Its mass and rotational inertia are unchanged.'
+            "
+          >
+            {{ drawnAsDisc() ? 'Make Bar' : 'Make Circular' }}
+          </button-block>
+        </div>
       </collapsible-subseciton>
       <collapsible-subseciton
         titleLabel="Mass Settings"

--- a/src/app/component/edit-panel/edit-panel.component.html
+++ b/src/app/component/edit-panel/edit-panel.component.html
@@ -478,19 +478,32 @@
         <!-- The same choice the right-click menu offers, in the section that
              collects how this link is drawn. Disabled rather than hidden here:
              the panel is describing the link you selected, so the option is
-             worth naming along with why it is not available. -->
+             worth naming along with why it is not available.
+
+             The label follows what is actually on the canvas, not the stored
+             choice: a disc whose ground has since been removed is drawn as a
+             bar, and a button reading "Make Bar" over a bar is a puzzle. -->
         <button-block
-          [customIcon]="activeSrv.selectedLink.isCircle ? 'make_bar' : 'make_circular'"
+          [customIcon]="drawnAsDisc() ? 'make_bar' : 'make_circular'"
           [disabled]="!activeSrv.selectedLink.canBeCircular()"
           (click)="mechanismService.toggleLinkCircular()"
           [tooltip]="
-            activeSrv.selectedLink.canBeCircular()
-              ? 'Draw this link as the disc it sweeps, centred on its fixed pin. Its mass and rotational inertia are unchanged.'
-              : 'Only a link with exactly one fixed pin can be drawn as a disc — that pin is what the disc is centred on.'
+            drawnAsDisc()
+              ? 'Draw this link as an ordinary bar between its joints.'
+              : 'Draw this link as the disc it sweeps, centred on its fixed pin. Its mass and rotational inertia are unchanged.'
           "
         >
-          {{ activeSrv.selectedLink.isCircle ? 'Make Bar' : 'Make Circular' }}
+          {{ drawnAsDisc() ? 'Make Bar' : 'Make Circular' }}
         </button-block>
+        <!-- Said in the panel rather than left to the button's tooltip: a
+             disabled button receives no pointer events, so its tooltip never
+             opens and the one explanation of why it cannot be pressed is the
+             one nobody can reach. -->
+        @if (!activeSrv.selectedLink.canBeCircular()) {
+          <p class="shapeNote">
+            {{ whyNotCircular() }}
+          </p>
+        }
       </collapsible-subseciton>
       <collapsible-subseciton
         titleLabel="Mass Settings"
@@ -593,7 +606,7 @@
                part is one. Said here, next to the two numbers it would otherwise
                be reasonable to assume it had changed — and only here, because
                with no mass there are no such numbers to mislead anyone. -->
-          @if (activeSrv.selectedLink.isCircle) {
+          @if (drawnAsDisc()) {
             <p class="shapeNote">
               Drawn as a disc. These two still follow the link's joints, not the
               circle — set Rotational Inertia by hand for a real flywheel.

--- a/src/app/component/edit-panel/edit-panel.component.html
+++ b/src/app/component/edit-panel/edit-panel.component.html
@@ -530,16 +530,27 @@
           </div>
           <div class="dotRow">
             <span class="dotRowLabel">Center of Mass</span>
+            <!-- Marked on the options, not with [value] on the select. Setting
+                 the select's value only takes if its options already exist,
+                 and these are rebuilt whenever the panel re-renders this block
+                 — a different link selected, a mass edited — after which the
+                 binding is unchanged and so is never re-applied, leaving the
+                 control reading Centroid over a link held some other way. An
+                 option that knows itself to be the selected one cannot drift. -->
             <select
               class="comFrameSelect"
-              [value]="comFrame"
               (change)="setComFrame($any($event.target).value)"
               title="What the center of mass is held against while you edit, and the frame the two numbers below are read in. Centroid rides the link; Global grid keeps its place on the drawing; a joint follows that pin alone. Once the mechanism runs it rides the link either way."
             >
-              <option value="centroid">Centroid</option>
-              <option value="grid">Global grid</option>
+              <option value="centroid" [selected]="comFrame === 'centroid'">Centroid</option>
+              <option value="grid" [selected]="comFrame === 'grid'">Global grid</option>
               @for (joint of activeSrv.selectedLink.joints; track joint.id) {
-                <option [value]="'joint:' + joint.id">Joint {{ joint.name || joint.id }}</option>
+                <option
+                  [value]="'joint:' + joint.id"
+                  [selected]="comFrame === 'joint:' + joint.id"
+                >
+                  Joint {{ joint.name || joint.id }}
+                </option>
               }
             </select>
           </div>

--- a/src/app/component/edit-panel/edit-panel.component.html
+++ b/src/app/component/edit-panel/edit-panel.component.html
@@ -475,6 +475,22 @@
         (closed)="sectionExpanded['LVisual'] = false"
       >
         <color-picker type="link" [link]="activeSrv.selectedLink">Link Color</color-picker>
+        <!-- The same choice the right-click menu offers, in the section that
+             collects how this link is drawn. Disabled rather than hidden here:
+             the panel is describing the link you selected, so the option is
+             worth naming along with why it is not available. -->
+        <button-block
+          [customIcon]="activeSrv.selectedLink.isCircle ? 'make_bar' : 'make_circular'"
+          [disabled]="!activeSrv.selectedLink.canBeCircular()"
+          (click)="mechanismService.toggleLinkCircular()"
+          [tooltip]="
+            activeSrv.selectedLink.canBeCircular()
+              ? 'Draw this link as the disc it sweeps, centred on its fixed pin. Its mass and rotational inertia are unchanged.'
+              : 'Only a link with exactly one fixed pin can be drawn as a disc — that pin is what the disc is centred on.'
+          "
+        >
+          {{ activeSrv.selectedLink.isCircle ? 'Make Bar' : 'Make Circular' }}
+        </button-block>
       </collapsible-subseciton>
       <collapsible-subseciton
         titleLabel="Mass Settings"
@@ -489,86 +505,89 @@
           tooltip="The mass used by force analysis. Zero is an idealized massless bar: gravity and inertia skip it, and rotational inertia reads zero."
           >Mass</input-block
         >
-        <!-- One legend for the two derived fields below. It sits under Mass —
-             which is always typed — so it introduces exactly the fields it
-             governs: grey behind a hollow dot follows the shape, ink behind a
-             filled one was set by hand and carries a ✕ to hand it back. -->
-        <div class="dotLegend" [class.off]="!(activeSrv.selectedLink.mass > 0)">
-          <span class="dot"></span> from shape
-          <span class="dot filled"></span> set by you
-          <button
-            type="button"
-            class="resetAll"
-            [disabled]="!activeSrv.selectedLink.moiIsCustom && !activeSrv.selectedLink.comIsCustom"
-            (click)="useUniformBody()"
-          >
-            Reset all
-          </button>
-        </div>
-        <div class="dotRow" [class.off]="!(activeSrv.selectedLink.mass > 0)">
-          <span class="dotRowLabel">Center of Mass</span>
-          <select
-            class="comFrameSelect"
-            [value]="comFrame"
-            [disabled]="!(activeSrv.selectedLink.mass > 0)"
-            (change)="setComFrame($any($event.target).value)"
-            title="The frame the two numbers below are typed and read in. Stored against the link, whichever you pick."
-          >
-            <option value="centroid">Centroid</option>
-            <option value="grid">Global grid</option>
-            @for (joint of activeSrv.selectedLink.joints; track joint.id) {
-              <option [value]="'joint:' + joint.id">Joint {{ joint.name || joint.id }}</option>
-            }
-          </select>
-        </div>
-        <!-- Each field wears the pair's state, as the mock draws it. -->
-        <div
-          class="comPairRow"
-          [class.derived]="!activeSrv.selectedLink.comIsCustom"
-          [class.off]="!(activeSrv.selectedLink.mass > 0)"
-        >
-          <span class="axisTag">X</span>
-          <state-input
+        <!-- Everything below Mass describes how that mass is distributed, so on
+             a massless bar there is nothing for any of it to describe: gravity
+             and inertia skip the link entirely and the numbers cannot change an
+             answer. They used to be shown greyed, which asks the reader to
+             work out that a whole section is inert. Give it a mass and they
+             come back. -->
+        @if (activeSrv.selectedLink.mass > 0) {
+          <!-- One legend for the two derived fields below. It sits under Mass —
+               which is always typed — so it introduces exactly the fields it
+               governs: grey behind a hollow dot follows the shape, ink behind a
+               filled one was set by hand and carries a ✕ to hand it back. -->
+          <div class="dotLegend">
+            <span class="dot"></span> from shape
+            <span class="dot filled"></span> set by you
+            <button
+              type="button"
+              class="resetAll"
+              [disabled]="!activeSrv.selectedLink.moiIsCustom && !activeSrv.selectedLink.comIsCustom"
+              (click)="useUniformBody()"
+            >
+              Reset all
+            </button>
+          </div>
+          <div class="dotRow">
+            <span class="dotRowLabel">Center of Mass</span>
+            <select
+              class="comFrameSelect"
+              [value]="comFrame"
+              (change)="setComFrame($any($event.target).value)"
+              title="What the center of mass is held against while you edit, and the frame the two numbers below are read in. Centroid rides the link; Global grid keeps its place on the drawing; a joint follows that pin alone. Once the mechanism runs it rides the link either way."
+            >
+              <option value="centroid">Centroid</option>
+              <option value="grid">Global grid</option>
+              @for (joint of activeSrv.selectedLink.joints; track joint.id) {
+                <option [value]="'joint:' + joint.id">Joint {{ joint.name || joint.id }}</option>
+              }
+            </select>
+          </div>
+          <!-- Each field wears the pair's state, as the mock draws it. -->
+          <div class="comPairRow" [class.derived]="!activeSrv.selectedLink.comIsCustom">
+            <span class="axisTag">X</span>
+            <state-input
+              [formGroup]="linkForm"
+              _formControl="comX"
+              [state]="activeSrv.selectedLink.comIsCustom ? 'custom' : 'auto'"
+              clearTitle="Back to the shape's centroid"
+              (cleared)="useUniformBodyCoM()"
+              (hovered)="setComPreview('x', $event)"
+            />
+            <span class="axisTag">Y</span>
+            <state-input
+              [formGroup]="linkForm"
+              _formControl="comY"
+              [state]="activeSrv.selectedLink.comIsCustom ? 'custom' : 'auto'"
+              clearTitle="Back to the shape's centroid"
+              (cleared)="useUniformBodyCoM()"
+              (hovered)="setComPreview('y', $event)"
+            />
+          </div>
+          <input-block
             [formGroup]="linkForm"
-            _formControl="comX"
-            [state]="activeSrv.selectedLink.comIsCustom ? 'custom' : 'auto'"
-            clearTitle="Back to the shape's centroid"
-            (cleared)="useUniformBodyCoM()"
-            (hovered)="setComPreview('x', $event)"
-          />
-          <span class="axisTag">Y</span>
-          <state-input
-            [formGroup]="linkForm"
-            _formControl="comY"
-            [state]="activeSrv.selectedLink.comIsCustom ? 'custom' : 'auto'"
-            clearTitle="Back to the shape's centroid"
-            (cleared)="useUniformBodyCoM()"
-            (hovered)="setComPreview('y', $event)"
-          />
-        </div>
-        <input-block
-          [formGroup]="linkForm"
-          _formControl="massMoI"
-          class="moiBlock"
-          tooltip="The mass moment of inertia about the link's center of mass. Derived from the shape as a uniform body until a value is typed."
-          [class.derived]="!activeSrv.selectedLink.moiIsCustom"
-          [class.off]="!(activeSrv.selectedLink.mass > 0)"
-          >Rotational Inertia
-          <span fieldSuffix class="stateSuffix" [class.off]="!(activeSrv.selectedLink.mass > 0)">
-            <span class="dot" [class.filled]="activeSrv.selectedLink.moiIsCustom"></span>
-            @if (activeSrv.selectedLink.moiIsCustom) {
-              <button type="button" class="clearDot" title="Back to the shape's own inertia" (click)="useUniformBodyMoI()">&#10005;</button>
-            }
-          </span>
-        </input-block>
-        <!-- Drawing a crank as a disc is a picture, not a declaration that the
-             part is one. Said here, next to the two numbers it would otherwise
-             be reasonable to assume it had changed. -->
-        @if (activeSrv.selectedLink.isCircle) {
-          <p class="shapeNote">
-            Drawn as a disc. These two still follow the link's joints, not the
-            circle — set Rotational Inertia by hand for a real flywheel.
-          </p>
+            _formControl="massMoI"
+            class="moiBlock"
+            tooltip="The mass moment of inertia about the link's center of mass. Derived from the shape as a uniform body until a value is typed."
+            [class.derived]="!activeSrv.selectedLink.moiIsCustom"
+            >Rotational Inertia
+            <span fieldSuffix class="stateSuffix">
+              <span class="dot" [class.filled]="activeSrv.selectedLink.moiIsCustom"></span>
+              @if (activeSrv.selectedLink.moiIsCustom) {
+                <button type="button" class="clearDot" title="Back to the shape's own inertia" (click)="useUniformBodyMoI()">&#10005;</button>
+              }
+            </span>
+          </input-block>
+          <!-- Drawing a crank as a disc is a picture, not a declaration that the
+               part is one. Said here, next to the two numbers it would otherwise
+               be reasonable to assume it had changed — and only here, because
+               with no mass there are no such numbers to mislead anyone. -->
+          @if (activeSrv.selectedLink.isCircle) {
+            <p class="shapeNote">
+              Drawn as a disc. These two still follow the link's joints, not the
+              circle — set Rotational Inertia by hand for a real flywheel.
+            </p>
+          }
         }
         </div>
       </collapsible-subseciton>

--- a/src/app/component/edit-panel/edit-panel.component.scss
+++ b/src/app/component/edit-panel/edit-panel.component.scss
@@ -219,6 +219,15 @@
   }
 }
 
+/* Sits under the two derived fields it qualifies, in the legend's own grey so
+   it reads as the same aside rather than as a warning about a problem. */
+.massArea .shapeNote {
+  margin: 6px 0 0;
+  font-size: 10.5px;
+  line-height: 1.35;
+  color: rgba(0, 0, 0, 0.55);
+}
+
 .massArea .dot {
   display: inline-block;
   width: 4px;

--- a/src/app/component/edit-panel/edit-panel.component.scss
+++ b/src/app/component/edit-panel/edit-panel.component.scss
@@ -212,9 +212,13 @@
 
 }
 
-/* Sits under the two derived fields it qualifies, in the legend's own grey so
-   it reads as the same aside rather than as a warning about a problem. */
-.massArea .shapeNote {
+/* Sits under the control it qualifies — the shape button, or the two derived
+   mass fields — in the legend's own grey, so it reads as the same kind of aside
+   rather than as a warning about a problem. Not scoped to the mass area: the
+   reason a link cannot be drawn as a disc belongs beside the button that is
+   greyed out, and a disabled button takes no pointer events, so its own tooltip
+   is unreachable. */
+.shapeNote {
   margin: 6px 0 0;
   font-size: 10.5px;
   line-height: 1.35;

--- a/src/app/component/edit-panel/edit-panel.component.scss
+++ b/src/app/component/edit-panel/edit-panel.component.scss
@@ -212,12 +212,16 @@
 
 }
 
-/* Sits under the control it qualifies — the shape button, or the two derived
-   mass fields — in the legend's own grey, so it reads as the same kind of aside
-   rather than as a warning about a problem. Not scoped to the mass area: the
-   reason a link cannot be drawn as a disc belongs beside the button that is
-   greyed out, and a disabled button takes no pointer events, so its own tooltip
-   is unreachable. */
+/* A disabled button is not a hover target, so the pointer would fall through to
+   nothing and the wrapper's tooltip would never open either. Taking the button
+   out of the way explicitly lets the hover land on the wrapper, which is what
+   carries the explanation. */
+.shapeToggle:has(button:disabled) button {
+  pointer-events: none;
+}
+
+/* Sits under the two derived mass fields it qualifies, in the legend's own grey
+   so it reads as the same aside rather than as a warning about a problem. */
 .shapeNote {
   margin: 6px 0 0;
   font-size: 10.5px;

--- a/src/app/component/edit-panel/edit-panel.component.scss
+++ b/src/app/component/edit-panel/edit-panel.component.scss
@@ -210,13 +210,6 @@
     &:disabled { color: rgba(0, 0, 0, 0.3); cursor: default; }
   }
 
-  /* A massless body derives nothing, so the legend has nothing to explain. */
-  &.off {
-    color: rgba(0, 0, 0, 0.32);
-
-    .dot { border-color: rgba(0, 0, 0, 0.2); }
-    .dot.filled { background: rgba(0, 0, 0, 0.2); border-color: rgba(0, 0, 0, 0.2); }
-  }
 }
 
 /* Sits under the two derived fields it qualifies, in the legend's own grey so
@@ -282,7 +275,6 @@
   gap: 5px;
   margin-left: 4px;
 
-  &.off .dot { border-color: rgba(0, 0, 0, 0.2); }
 
   .clearDot {
     border: none;
@@ -371,31 +363,6 @@
   color: rgba(0, 0, 0, 0.5);
 }
 
-/* Massless: values and labels dim with the group. The id out-ranks the
-   derived-ink rule, which otherwise holds the values at reading strength. */
-.massArea #input-block .customInput:disabled {
-  color: rgba(0, 0, 0, 0.32);
-}
-.massArea .dotRow.off .dotRowLabel,
-.massArea input-block.off #input-block .label {
-  color: rgba(0, 0, 0, 0.32);
-}
-.massArea .comPairRow.off .axisTag {
-  color: rgba(0, 0, 0, 0.3);
-}
-
-/* Massless: the pair's markers grey out with the fields they mark. */
-.massArea .comPairRow.off .state-dot {
-  border-color: rgba(0, 0, 0, 0.2);
-}
-.massArea .comPairRow.off .state-dot.filled {
-  background: rgba(0, 0, 0, 0.2);
-  border-color: rgba(0, 0, 0, 0.2);
-}
-.massArea .comPairRow.off .state-clear {
-  color: rgba(0, 0, 0, 0.25);
-  pointer-events: none;
-}
 
 /* The mock's one field column: Mass, the frame select and Rotational
    Inertia share one width, one left edge and one right edge — the centre

--- a/src/app/component/edit-panel/edit-panel.component.ts
+++ b/src/app/component/edit-panel/edit-panel.component.ts
@@ -1661,6 +1661,42 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
   }
 
   /**
+   * Whether the selected link is on the canvas as a disc right now.
+   *
+   * Not the same question as "was it asked to be one": the choice is kept
+   * through a ground being removed, so that putting the ground back brings the
+   * disc back rather than making someone ask twice. In between, the link is
+   * drawn as a bar, and everything a person can see about it should agree.
+   */
+  drawnAsDisc(): boolean {
+    const link = this.activeSrv.selectedLink;
+    return !!link?.isCircle && link.canBeCircular();
+  }
+
+  /** Why Make Circular is unavailable, in terms of this particular link. */
+  whyNotCircular(): string {
+    const link = this.activeSrv.selectedLink;
+    const grounded = link.joints.filter(
+      (joint) => joint instanceof RealJoint && joint.ground && !(joint instanceof PrisJoint)
+    );
+    const held = link.isCircle ? 'Drawn as a bar: a' : 'A';
+    if (link.subset.length > 0) {
+      return `${held} disc is centred on one fixed pin, and a welded compound is drawn from the
+        shapes of its parts. Unweld it to draw a part of it as a disc.`;
+    }
+    if (grounded.length === 0) {
+      return `${held} disc is centred on the pin its link turns about, and this link has no fixed
+        pin. Ground one of its joints to draw it as a disc.`;
+    }
+    if (grounded.length > 1) {
+      return `${held} disc is centred on the pin its link turns about, and this link is fixed at
+        ${grounded.length} joints, so it does not turn about any of them.`;
+    }
+    return `${held} disc is centred on a fixed revolute pin; this link's fixed joint is a slider,
+      which anchors a slot rather than a pivot.`;
+  }
+
+  /**
    * The frame the Center of Mass is both typed in and held against, read off
    * the selected link rather than remembered here — it is the link's property,
    * so selecting another link shows that link's answer and a reloaded drawing

--- a/src/app/component/edit-panel/edit-panel.component.ts
+++ b/src/app/component/edit-panel/edit-panel.component.ts
@@ -63,6 +63,7 @@ import { InputComponent } from '../BLOCKS/input/input.component';
 import { ColorPickerComponent } from '../BLOCKS/color-picker/color-picker.component';
 import { DualButtonComponent } from '../BLOCKS/dual-button/dual-button.component';
 import { RadioComponent } from '../BLOCKS/radio/radio.component';
+import { MatTooltip } from '@angular/material/tooltip';
 
 /**
  * Input Settings unit choices, in the order the picker shows them. The labels
@@ -82,6 +83,7 @@ const INPUT_SPEED_UNITS = [
   imports: [
     PanelSectionCollapsibleComponent,
     TitleBlock,
+    MatTooltip,
     MatIcon,
     SubtitleComponent,
     StateInputComponent,

--- a/src/app/component/edit-panel/edit-panel.component.ts
+++ b/src/app/component/edit-panel/edit-panel.component.ts
@@ -1661,14 +1661,31 @@ export class EditPanelComponent implements OnInit, AfterContentInit, OnDestroy {
   }
 
   /**
-   * The frame the Center of Mass fields are typed and read in. Display-side
-   * only: whatever is chosen, the point is stored against the link itself
-   * (see RealLink.placeCustomCoM), so the numbers here are a view of it.
+   * The frame the Center of Mass is both typed in and held against, read off
+   * the selected link rather than remembered here — it is the link's property,
+   * so selecting another link shows that link's answer and a reloaded drawing
+   * shows the one it was saved with.
    */
-  comFrame: string = 'centroid';
+  get comFrame(): string {
+    const anchor = this.activeSrv.selectedLink?.comAnchor ?? 'centroid';
+    if (anchor === 'grid' || anchor === 'centroid') return anchor;
+    return 'joint:' + anchor.joint;
+  }
 
   setComFrame(frame: string): void {
-    this.comFrame = frame;
+    const link = this.activeSrv.selectedLink;
+    if (!link) return;
+    link.comAnchor =
+      frame === 'grid'
+        ? 'grid'
+        : frame.startsWith('joint:')
+          ? { joint: frame.slice('joint:'.length) }
+          : 'centroid';
+    // Re-read the offsets against the new anchor before anything moves, so
+    // choosing a frame re-describes where the point already is instead of
+    // moving it there.
+    link.captureComOffset();
+    this.mechanismService.updateMechanism(true);
     this.refreshDerivedMassFields();
   }
 

--- a/src/app/component/new-grid/new-grid.component.ts
+++ b/src/app/component/new-grid/new-grid.component.ts
@@ -488,6 +488,20 @@ export class NewGridComponent implements OnDestroy {
             weldedLinkFilletSelected
           )
         );
+        // Offered only where there is a pin to draw the disc about — a crank.
+        // On anything else the item would have to explain why it does nothing,
+        // and a menu that lists actions it will refuse is worse than one that
+        // lists the actions it has.
+        if ((this.lastRightClick as RealLink).canBeCircular()) {
+          const drawnRound = (this.lastRightClick as RealLink).isCircle;
+          this.cMenuItems.push(
+            new cMenuItem(
+              drawnRound ? 'Make Bar' : 'Make Circular',
+              this.mechanismSrv.toggleLinkCircular.bind(this.mechanismSrv),
+              drawnRound ? 'make_bar' : 'make_circular'
+            )
+          );
+        }
         this.cMenuItems.push(this.lockMenuItem(this.lastRightClick as RealLink, 'Link'));
         break;
       }

--- a/src/app/component/synthesis-panel/synthesis-panel.component.html
+++ b/src/app/component/synthesis-panel/synthesis-panel.component.html
@@ -69,6 +69,40 @@
 
       <mat-divider></mat-divider>
 
+      <!-- Driving the linkage. Only once there is one: with fewer than three
+           poses these act on nothing, and a row of controls that quietly do
+           nothing is worse than a row that is not there yet. -->
+      @if (hasLinkage()) {
+        <subtitle-block>Drive</subtitle-block>
+        <button-block
+          (click)="swapDrivePin()"
+          customIcon="switch_force_dir"
+          tooltip="Drive the linkage from its other fixed pin. A four-bar that will not turn from one ground pin often turns freely from the other."
+        >
+          Swap Drive Pin
+        </button-block>
+        <button-block
+          (click)="toggleDriver()"
+          [icon]="synthesisBuilder.driverWanted ? undefined : 'add'"
+          [customIcon]="synthesisBuilder.driverWanted ? 'remove' : undefined"
+          [color]="synthesisBuilder.driverWanted ? 'warn' : 'primary'"
+          tooltip="Add a crank and coupler sized so one full turn walks the linkage through all three poses, making it a six-bar a motor can run."
+        >
+          {{ synthesisBuilder.driverWanted ? 'Remove Driver' : 'Add Driver (Six-Bar)' }}
+        </button-block>
+        @if (synthesisBuilder.driverRefusal) {
+          <p class="driverRefusal">{{ synthesisBuilder.driverRefusal }}</p>
+        }
+        <button-block
+          (click)="evaluatePoses()"
+          customIcon="show_path"
+          tooltip="Re-check which poses the linkage still reaches. Synthesis does this as it builds; use it after editing the linkage by hand."
+        >
+          Evaluate Poses
+        </button-block>
+        <mat-divider></mat-divider>
+      }
+
       <!--        Generate Linkage-->
 
       <button-block

--- a/src/app/component/synthesis-panel/synthesis-panel.component.scss
+++ b/src/app/component/synthesis-panel/synthesis-panel.component.scss
@@ -90,3 +90,16 @@
   flex-direction: column;
   gap: 10px;
 }
+
+/* Why no driver could be fitted, sitting under the button that tried. Warm
+   rather than red: the four-bar is still there and still good, so this is an
+   explanation of what did not happen, not a report of something broken. */
+.driverRefusal {
+  margin: 6px 2px 10px;
+  padding: 8px 10px;
+  border-left: 3px solid #f5a623;
+  background: rgba(245, 166, 35, 0.08);
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: rgba(0, 0, 0, 0.7);
+}

--- a/src/app/component/synthesis-panel/synthesis-panel.component.ts
+++ b/src/app/component/synthesis-panel/synthesis-panel.component.ts
@@ -8,6 +8,7 @@ import { SynthesisBuilderService } from 'src/app/services/synthesis/synthesis-bu
 import { NumberUnitParserService } from 'src/app/services/number-unit-parser.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { SynthesisStatus } from 'src/app/services/synthesis/synthesis-constants';
+import { MODEL_SCALE } from 'src/app/model/render-scale';
 import { SvgGridService } from '../../services/svg-grid.service';
 import { ColorService } from '../../services/color.service';
 import { PanelSectionComponent } from '../BLOCKS/panel-section/panel-section.component';
@@ -380,20 +381,22 @@ export class SynthesisPanelComponent implements OnInit {
   }
 
   checkQuality(quality: number[]) {
+    // In model units, like the distances it is comparing against.
+    const POSE_REACHED = 0.09 * MODEL_SCALE;
     let positionMatches: string[] = ['Position 1', 'Position 2', 'Position 3'];
-    if (quality[0] >= 0.09 || quality[1] >= 0.09) {
+    if (quality[0] >= POSE_REACHED || quality[1] >= POSE_REACHED) {
       positionMatches[0] = 'No Match';
       this.synthesisBuilder.poses[1].status = SynthesisStatus.INVALID;
     } else {
       this.synthesisBuilder.poses[1].status = SynthesisStatus.VALID;
     }
-    if (quality[3] >= 0.09 || quality[4] >= 0.09) {
+    if (quality[3] >= POSE_REACHED || quality[4] >= POSE_REACHED) {
       positionMatches[1] = 'No Match';
       this.synthesisBuilder.poses[2].status = SynthesisStatus.INVALID;
     } else {
       this.synthesisBuilder.poses[2].status = SynthesisStatus.VALID;
     }
-    if (quality[6] >= 0.09 || quality[7] >= 0.09) {
+    if (quality[6] >= POSE_REACHED || quality[7] >= POSE_REACHED) {
       positionMatches[2] = 'No Match';
       this.synthesisBuilder.poses[3].status = SynthesisStatus.INVALID;
     } else {
@@ -407,6 +410,14 @@ export class SynthesisPanelComponent implements OnInit {
     //get position analysis data
     //joint B, Joint C,
     //compare that with poses
+
+    // Both tolerances a person deals with -- the one typed into the panel and
+    // the 0.09 below -- are lengths in the units the grid is labelled in. Every
+    // distance measured here is between model coordinates, which are those
+    // units times MODEL_SCALE. Comparing the two directly meant a pose counted
+    // as reached only when it was hit to the last decimal place, so all three
+    // marks read "no match" on linkages that pass straight through the poses.
+    const tolerance = qualityOfSyn * MODEL_SCALE;
 
     let quality1_b: number = 999;
     let quality2_b: number = 999;
@@ -456,27 +467,27 @@ export class SynthesisPanelComponent implements OnInit {
       //need to check if exact match
       //need to extract time step.
 
-      if (pos1Value_b < qualityOfSyn && pos1Value_c < qualityOfSyn && index == 1) {
+      if (pos1Value_b < tolerance && pos1Value_c < tolerance && index == 1) {
         quality1_b = pos1Value_b;
         quality1_c = pos1Value_c;
         pos1TimeStep = index;
-      } else if (pos1Value_b < qualityOfSyn && pos1Value_c < qualityOfSyn && index > 1) {
+      } else if (pos1Value_b < tolerance && pos1Value_c < tolerance && index > 1) {
         quality1_b = pos1Value_b;
         quality1_c = pos1Value_c;
         pos1TimeStep = index;
-      } else if (pos2Value_b < qualityOfSyn && pos2Value_c < qualityOfSyn && index == 1) {
+      } else if (pos2Value_b < tolerance && pos2Value_c < tolerance && index == 1) {
         quality2_b = pos2Value_b;
         quality2_c = pos2Value_c;
         pos2TimeStep = index;
-      } else if (pos2Value_b < qualityOfSyn && pos2Value_c < qualityOfSyn && index > 1) {
+      } else if (pos2Value_b < tolerance && pos2Value_c < tolerance && index > 1) {
         quality2_b = pos2Value_b;
         quality2_c = pos2Value_c;
         pos2TimeStep = index;
-      } else if (pos3Value_b < qualityOfSyn && pos3Value_c < qualityOfSyn && index == 1) {
+      } else if (pos3Value_b < tolerance && pos3Value_c < tolerance && index == 1) {
         quality3_b = pos3Value_b;
         quality3_c = pos3Value_c;
         pos3TimeStep = index;
-      } else if (pos3Value_b < qualityOfSyn && pos3Value_c < qualityOfSyn && index > 1) {
+      } else if (pos3Value_b < tolerance && pos3Value_c < tolerance && index > 1) {
         quality3_b = pos3Value_b;
         quality3_c = pos3Value_c;
         pos3TimeStep = index;
@@ -509,15 +520,15 @@ export class SynthesisPanelComponent implements OnInit {
             Math.pow(jointC_x - posCoords[5].x, 2) + Math.pow(jointC_y - posCoords[5].y, 2)
           );
 
-          if (pos1Value_b < qualityOfSyn && pos1Value_c < qualityOfSyn) {
+          if (pos1Value_b < tolerance && pos1Value_c < tolerance) {
             quality1_b = pos1Value_b;
             quality1_c = pos1Value_c;
             pos1TimeStep = index - 0.5;
-          } else if (pos2Value_b < qualityOfSyn && pos2Value_c < qualityOfSyn) {
+          } else if (pos2Value_b < tolerance && pos2Value_c < tolerance) {
             quality2_b = pos2Value_b;
             quality2_c = pos2Value_c;
             pos2TimeStep = index - 0.5;
-          } else if (pos3Value_b < qualityOfSyn && pos3Value_c < qualityOfSyn) {
+          } else if (pos3Value_b < tolerance && pos3Value_c < tolerance) {
             quality3_b = pos3Value_b;
             quality3_c = pos3Value_c;
             pos3TimeStep = index - 0.5;

--- a/src/app/component/synthesis-panel/synthesis-panel.component.ts
+++ b/src/app/component/synthesis-panel/synthesis-panel.component.ts
@@ -8,6 +8,7 @@ import { SynthesisBuilderService } from 'src/app/services/synthesis/synthesis-bu
 import { NumberUnitParserService } from 'src/app/services/number-unit-parser.service';
 import { SettingsService } from 'src/app/services/settings.service';
 import { SynthesisStatus } from 'src/app/services/synthesis/synthesis-constants';
+import { driverDyadFor } from 'src/app/services/synthesis/driver-dyad';
 import { MODEL_SCALE } from 'src/app/model/render-scale';
 import { SvgGridService } from '../../services/svg-grid.service';
 import { ColorService } from '../../services/color.service';
@@ -265,13 +266,65 @@ export class SynthesisPanelComponent implements OnInit {
     this.synthesisBuilder.synthesisedIds = { joints: [], links: [] };
   }
 
-  /** Four ids nothing on the grid is already using, in order. */
-  private nextFourLetters(): string[] {
+  /** As many ids as asked for, none of which anything on the grid is using. */
+  private nextLetters(count: number): string[] {
     const taken: string[] = [];
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < count; i++) {
       taken.push(this.mechanismSrv.determineNextLetter(taken));
     }
     return taken;
+  }
+
+  /** Whether there is a linkage on the grid for the driver controls to act on. */
+  hasLinkage(): boolean {
+    return this.synthesisBuilder.isFullyDefined();
+  }
+
+  /**
+   * Add a driver to the four-bar, or take it off again.
+   *
+   * Both go through a full re-synthesis rather than editing what is on the
+   * grid, because the drive pin and the driver change how the four-bar itself
+   * is built -- which of its pins is the input -- and re-running is the only
+   * path that cannot leave the two disagreeing.
+   */
+  toggleDriver(): void {
+    this.synthesisBuilder.driverWanted = !this.synthesisBuilder.driverWanted;
+    if (this.hasLinkage()) this.synthesisFunction();
+  }
+
+  /** Drive the linkage from its other ground pin. */
+  swapDrivePin(): void {
+    this.synthesisBuilder.driveOnFarPin = !this.synthesisBuilder.driveOnFarPin;
+    if (this.hasLinkage()) this.synthesisFunction();
+  }
+
+  /**
+   * Score the poses against the linkage as it now stands.
+   *
+   * Synthesis scores its own answer as it builds it, so this says nothing new
+   * about an untouched linkage -- it is for after the drawing has been edited
+   * by hand, when the marks on the poses are describing a linkage that no
+   * longer exists.
+   */
+  evaluatePoses(): void {
+    const built = this.mechanismSrv.joints.find(
+      (joint) => joint.id === this.synthesisBuilder.synthesisedIds.joints[0]
+    );
+    const solved = built ? this.mechanismSrv.mechanismContaining(built) : undefined;
+    const poseCoords = [1, 2, 3].flatMap((i) => [
+      this.synthesisBuilder.poses[i].posBack,
+      this.synthesisBuilder.poses[i].posFront,
+    ]);
+    this.checkQuality(
+      solved
+        ? this.compareTheQualityofSynthesis(
+            solved.joints,
+            poseCoords,
+            Number(this.synthesisForm.value.quality)
+          )
+        : [999, 999, 999, 999, 999, 999, 999, 999, 999]
+    );
   }
 
   synthesisFunction() {
@@ -306,12 +359,18 @@ export class SynthesisPanelComponent implements OnInit {
     // Not A, B, C, D: those letters are taken as soon as there is anything else
     // on the grid, and two joints with one id is not a mechanism, it is a bug
     // waiting for the codec to find it.
-    const [idA, idB, idC, idD] = this.nextFourLetters();
+    const [idA, idB, idC, idD, idE, idF] = this.nextLetters(6);
 
-    let joint1 = new RevJoint(idA, firstPoint.x, firstPoint.y, true, true);
+    // Which pin the motor sits on is decided here rather than moved afterwards:
+    // with a driver on the linkage neither ground pin is the input at all, and
+    // without one it is whichever the drive-pin choice names.
+    const far = this.synthesisBuilder.driveOnFarPin;
+    const drivenDirectly = !this.synthesisBuilder.driverWanted;
+
+    let joint1 = new RevJoint(idA, firstPoint.x, firstPoint.y, drivenDirectly && !far, true);
     let joint2 = new RevJoint(idB, secondPoint.x, secondPoint.y, false, false);
     let joint3 = new RevJoint(idC, thirdPoint.x, thirdPoint.y, false, false);
-    let joint4 = new RevJoint(idD, fourthPoint.x, fourthPoint.y, false, true);
+    let joint4 = new RevJoint(idD, fourthPoint.x, fourthPoint.y, drivenDirectly && far, true);
 
     joint1.connectedJoints.push(joint2);
     joint2.connectedJoints.push(joint1, joint3);
@@ -332,6 +391,49 @@ export class SynthesisPanelComponent implements OnInit {
 
     const madeJoints = [joint1, joint2, joint3, joint4];
     const madeLinks = [link1, link2, link3];
+
+    // Built into the linkage, not added to it afterwards, so that one solve
+    // sees the finished six-bar and the driver survives the next pose change.
+    this.synthesisBuilder.driverRefusal = undefined;
+    if (this.synthesisBuilder.driverWanted) {
+      const pivot = far ? fourthPoint : firstPoint;
+      const drivenPin = far ? joint3 : joint2;
+      const drivenAt = far
+        ? [pose1_coord2, pose2_coord2, pose3_coord2]
+        : [pose1_coord1, pose2_coord1, pose3_coord1];
+
+      const sized = driverDyadFor(pivot, drivenAt);
+      if ('refusal' in sized) {
+        // The four-bar still stands, and still passes through the poses — it
+        // is only the motor that could not be fitted. Left drivable by hand so
+        // the drawing is not made useless by the refusal.
+        this.synthesisBuilder.driverRefusal = sized.refusal;
+        (far ? joint4 : joint1).input = true;
+      } else {
+        // The two lengths the sizing solved for are the distances between these
+        // three points, so placing the pins is all it takes to realise them.
+        const { ground, elbow } = sized.dyad;
+        const motor = new RevJoint(idE, ground.x, ground.y, true, true);
+        const knee = new RevJoint(idF, elbow.x, elbow.y, false, false);
+
+        motor.connectedJoints.push(knee);
+        knee.connectedJoints.push(motor, drivenPin);
+        drivenPin.connectedJoints.push(knee);
+
+        const driverCrank = new RealLink(idE + idF, [motor, knee]);
+        driverCrank.fill = this.colorService.getLinkColorFromIndex(2);
+        const driverCoupler = new RealLink(idF + drivenPin.id, [knee, drivenPin]);
+        driverCoupler.fill = this.colorService.getLinkColorFromIndex(3);
+
+        motor.links.push(driverCrank);
+        knee.links.push(driverCrank, driverCoupler);
+        drivenPin.links.push(driverCoupler);
+
+        madeJoints.push(motor, knee);
+        madeLinks.push(driverCrank, driverCoupler);
+      }
+    }
+
     this.mechanismSrv.mergeToJoints(madeJoints);
     this.mechanismSrv.mergeToLinks(madeLinks);
     this.synthesisBuilder.synthesisedIds = {

--- a/src/app/model/link.circular.spec.ts
+++ b/src/app/model/link.circular.spec.ts
@@ -1,0 +1,132 @@
+import { RealLink } from './link';
+import { PrisJoint, RevJoint } from './joint';
+import { SettingsService } from '../services/settings.service';
+
+/**
+ * A crank drawn as the disc it sweeps.
+ *
+ * The rule the drawing rests on is that a disc needs a centre, and the only
+ * centre a link can offer without being asked is the one pin it turns about.
+ * Everything here is about that rule holding when the mechanism changes under
+ * it -- the flag outlives a ground being removed, so the answer has to come
+ * from the joints every time rather than from what was true when it was set.
+ */
+
+/** A grounded crank: pin at the origin, throw out to (3, 4) -- a reach of 5. */
+function crank(): { link: RealLink; ground: RevJoint; throwPin: RevJoint } {
+  const ground = new RevJoint('A', 0, 0, false, true);
+  const throwPin = new RevJoint('B', 3, 4);
+  return { link: new RealLink('AB', [ground, throwPin]), ground, throwPin };
+}
+
+/** Every number in a path string, in the order it is written. */
+function numbersIn(path: string): number[] {
+  return (path.match(/-?\d+(\.\d+)?/g) ?? []).map(Number);
+}
+
+describe('a link drawn as a circle', () => {
+  beforeEach(() => {
+    SettingsService._objectScale.next(1);
+  });
+
+  it('is offered on a grounded crank and nowhere else', () => {
+    expect(crank().link.canBeCircular()).toBe(true);
+
+    // No ground: a coupler has no fixed centre, so no disc to draw about.
+    const floating = new RealLink('AB', [new RevJoint('A', 0, 0), new RevJoint('B', 3, 4)]);
+    expect(floating.canBeCircular()).toBe(false);
+
+    // Two grounds: a frame, which does not turn at all.
+    const frame = new RealLink('AB', [
+      new RevJoint('A', 0, 0, false, true),
+      new RevJoint('B', 3, 4, false, true),
+    ]);
+    expect(frame.canBeCircular()).toBe(false);
+
+    // A grounded slot anchors a slide, not a pivot.
+    const slotted = new RealLink('AB', [
+      new PrisJoint('A', 0, 0, false, true),
+      new RevJoint('B', 3, 4),
+    ]);
+    expect(slotted.canBeCircular()).toBe(false);
+  });
+
+  it('draws a disc on the ground pin, wide enough to hold every joint', () => {
+    const { link, ground } = crank();
+    link.isCircle = true;
+    link.reComputeDPath();
+
+    expect(link.d).toMatch(/^M /);
+    expect(link.d).not.toMatch(/NaN|Infinity/);
+
+    // Two semicircle arcs of one radius: reach plus the half-width every bar's
+    // end cap is already drawn with, so the disc covers what the bar covered.
+    const radius = 5 + SettingsService.objectScale / 4;
+    const numbers = numbersIn(link.d);
+    expect(numbers[0]).toBeCloseTo(ground.x - radius, 6);
+    expect(numbers[1]).toBeCloseTo(ground.y, 6);
+    expect(link.d.match(/A /g)?.length).toBe(2);
+
+    // A disc has no edges, so there is nothing to attach a joint along.
+    expect(link.externalLines).toEqual([]);
+    expect(link.initialExternalLines).toEqual([]);
+  });
+
+  it('grows to cover a tracer point added past the throw', () => {
+    const { link, ground } = crank();
+    link.isCircle = true;
+    link.joints.push(new RevJoint('C', 0, 9));
+    link.reComputeDPath();
+
+    const radius = 9 + SettingsService.objectScale / 4;
+    expect(numbersIn(link.d)[0]).toBeCloseTo(ground.x - radius, 6);
+  });
+
+  it('comes back as a bar when the ground it was centred on is removed', () => {
+    const { link, ground } = crank();
+    link.isCircle = true;
+    link.reComputeDPath();
+    const asDisc = link.d;
+
+    ground.ground = false;
+    link.reComputeDPath();
+    expect(link.d).not.toBe(asDisc);
+    expect(link.canBeCircular()).toBe(false);
+    // The bar has edges again, which is how the rest of the app knows it can
+    // hang a joint on one.
+    expect(link.externalLines.length).toBeGreaterThan(0);
+
+    // The choice was not thrown away, only ignored: grounding it again is
+    // enough to get the disc back, without having to ask for it a second time.
+    ground.ground = true;
+    link.reComputeDPath();
+    expect(link.d).toBe(asDisc);
+  });
+
+  it('is inherited by the copy of a link, so every solved frame is a disc too', () => {
+    const { link } = crank();
+    link.isCircle = true;
+    link.reComputeDPath();
+
+    // What Mechanism does per timestep: rebuild the link against moved joints,
+    // handing the previous one in as the source of its visual geometry.
+    const moved = new RealLink(
+      'AB',
+      [new RevJoint('A', 0, 0, false, true), new RevJoint('B', -4, 3)],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      link
+    );
+    expect(moved.isCircle).toBe(true);
+
+    // The same circle, though not the same string: the copy is the original
+    // rigidly rotated, so the path now starts at a different point of the same
+    // rim. Centre and radius are what "the same disc" means.
+    const turned = numbersIn(moved.d);
+    const radius = 5 + SettingsService.objectScale / 4;
+    expect(turned[2]).toBeCloseTo(radius, 6);
+    expect(Math.hypot(turned[0], turned[1])).toBeCloseTo(radius, 6);
+  });
+});

--- a/src/app/model/link.circular.spec.ts
+++ b/src/app/model/link.circular.spec.ts
@@ -65,7 +65,11 @@ describe('a link drawn as a circle', () => {
     const numbers = numbersIn(link.d);
     expect(numbers[0]).toBeCloseTo(ground.x - radius, 6);
     expect(numbers[1]).toBeCloseTo(ground.y, 6);
+    // Two arcs and no straight edge. The arc count alone proves nothing — an
+    // ordinary two-joint bar is also drawn with exactly two, one per end cap —
+    // so what separates a disc from a bar is that a disc has no sides.
     expect(link.d.match(/A /g)?.length).toBe(2);
+    expect(link.d).not.toMatch(/ L /);
 
     // A disc has no edges, so there is nothing to attach a joint along.
     expect(link.externalLines).toEqual([]);
@@ -90,8 +94,11 @@ describe('a link drawn as a circle', () => {
 
     ground.ground = false;
     link.reComputeDPath();
-    expect(link.d).not.toBe(asDisc);
     expect(link.canBeCircular()).toBe(false);
+    // A bar, stated as geometry rather than as "not the string it was": it has
+    // sides, which a disc never does, and it says so itself.
+    expect(link.d).toMatch(/ L /);
+    expect(link.drawnAsDisc).toBe(false);
     // The bar has edges again, which is how the rest of the app knows it can
     // hang a joint on one.
     expect(link.externalLines.length).toBeGreaterThan(0);

--- a/src/app/model/link.com-anchor.spec.ts
+++ b/src/app/model/link.com-anchor.spec.ts
@@ -1,0 +1,153 @@
+import { RealLink } from './link';
+import { RevJoint } from './joint';
+import { Coord } from './coord';
+import { SettingsService } from '../services/settings.service';
+
+/**
+ * What a hand-placed centre of mass is held against while the mechanism is
+ * being edited.
+ *
+ * The three answers differ only when the link moves, so every test here places
+ * the point, moves something, and asks where the point went. `customCoMFromOffset`
+ * is what MechanismService consults on each update, so it stands in for "the
+ * user dragged something" throughout.
+ */
+
+/** A bar from (0,0) to (10,0), with its centre of mass placed at (4,3). */
+function bar(): { link: RealLink; a: RevJoint; b: RevJoint } {
+  const a = new RevJoint('A', 0, 0);
+  const b = new RevJoint('B', 10, 0);
+  const link = new RealLink('AB', [a, b], 1);
+  link.placeCustomCoM({ x: 4, y: 3 });
+  return { link, a, b };
+}
+
+/**
+ * What MechanismService does at the end of every update: resolve the point
+ * against its anchor and write it back. Without this the link's own CoM is the
+ * one from before the move, and `captureComOffset` -- which measures from
+ * wherever the CoM currently is -- would capture a stale point. Every move
+ * below ends here, because in the app every move does.
+ */
+function settle(link: RealLink): void {
+  const placed = link.customCoMFromOffset();
+  if (placed) link.CoM = placed;
+}
+
+/** Slide the whole link by (dx, dy), as dragging its body would. */
+function shift(link: RealLink, dx: number, dy: number): void {
+  link.joints.forEach((joint) => {
+    joint.x += dx;
+    joint.y += dy;
+  });
+  settle(link);
+}
+
+/** Turn the link about joint A, which leaves A itself where it is. */
+function turnAboutA(link: RealLink, degrees: number): void {
+  const [pivot] = link.joints;
+  const angle = (degrees * Math.PI) / 180;
+  const origin = new Coord(pivot.x, pivot.y);
+  link.joints.forEach((joint) => {
+    const dx = joint.x - origin.x;
+    const dy = joint.y - origin.y;
+    joint.x = origin.x + dx * Math.cos(angle) - dy * Math.sin(angle);
+    joint.y = origin.y + dx * Math.sin(angle) + dy * Math.cos(angle);
+  });
+  settle(link);
+}
+
+describe('what a placed center of mass is held against', () => {
+  beforeEach(() => {
+    SettingsService._objectScale.next(1);
+  });
+
+  it('rides the link when held against the link, which is the standing default', () => {
+    const { link } = bar();
+    expect(link.comAnchor).toBe('centroid');
+
+    shift(link, 5, 2);
+    const moved = link.customCoMFromOffset()!;
+    expect(moved.x).toBeCloseTo(9, 6);
+    expect(moved.y).toBeCloseTo(5, 6);
+
+    // And turns with it: the point is a mark on the body.
+    const { link: second } = bar();
+    turnAboutA(second, 90);
+    const turned = second.customCoMFromOffset()!;
+    expect(turned.x).toBeCloseTo(-3, 6);
+    expect(turned.y).toBeCloseTo(4, 6);
+  });
+
+  it('stays on the drawing when held against the grid', () => {
+    const { link } = bar();
+    link.comAnchor = 'grid';
+    link.captureComOffset();
+
+    shift(link, 5, 2);
+    const afterDrag = link.customCoMFromOffset()!;
+    expect(afterDrag.x).toBeCloseTo(4, 6);
+    expect(afterDrag.y).toBeCloseTo(3, 6);
+
+    turnAboutA(link, 90);
+    const afterTurn = link.customCoMFromOffset()!;
+    expect(afterTurn.x).toBeCloseTo(4, 6);
+    expect(afterTurn.y).toBeCloseTo(3, 6);
+  });
+
+  it('follows one pin, and only that pin, when held against a joint', () => {
+    const { link, a, b } = bar();
+    link.comAnchor = { joint: 'A' };
+    link.captureComOffset();
+
+    // The far pin moving is not that pin moving.
+    b.x = 40;
+    settle(link);
+    const afterFarPin = link.customCoMFromOffset()!;
+    expect(afterFarPin.x).toBeCloseTo(4, 6);
+    expect(afterFarPin.y).toBeCloseTo(3, 6);
+
+    // Turning about A does not move A, so it does not move the point either.
+    turnAboutA(link, 90);
+    const afterTurn = link.customCoMFromOffset()!;
+    expect(afterTurn.x).toBeCloseTo(4, 6);
+    expect(afterTurn.y).toBeCloseTo(3, 6);
+
+    // Moving A carries it, keeping the same offset from the pin.
+    a.x += 1;
+    a.y -= 2;
+    settle(link);
+    const afterPin = link.customCoMFromOffset()!;
+    expect(afterPin.x).toBeCloseTo(5, 6);
+    expect(afterPin.y).toBeCloseTo(1, 6);
+  });
+
+  it('re-describes the point where it is rather than moving it, on switching anchor', () => {
+    const { link } = bar();
+    shift(link, 5, 2);
+    const before = link.customCoMFromOffset()!;
+
+    link.comAnchor = 'grid';
+    link.captureComOffset();
+    const after = link.customCoMFromOffset()!;
+
+    expect(after.x).toBeCloseTo(before.x, 6);
+    expect(after.y).toBeCloseTo(before.y, 6);
+  });
+
+  it('hands the point back to the link when its pin leaves', () => {
+    const { link } = bar();
+    link.comAnchor = { joint: 'B' };
+    link.captureComOffset();
+
+    // B is deleted or merged away. The point is still where it was put, so it
+    // stays there and goes back to riding the link -- not to a pin that is no
+    // longer on it, and not to wherever the missing pin last was.
+    link.joints = link.joints.filter((joint) => joint.id !== 'B');
+    settle(link);
+    const rescued = link.customCoMFromOffset()!;
+    expect(rescued.x).toBeCloseTo(4, 6);
+    expect(rescued.y).toBeCloseTo(3, 6);
+    expect(link.comAnchor).toBe('centroid');
+  });
+});

--- a/src/app/model/link.ts
+++ b/src/app/model/link.ts
@@ -30,6 +30,11 @@ export enum Shape {
   customShape = 'customShape',
 }
 
+/**
+ * What a hand-placed centre of mass is held against. See RealLink.comAnchor.
+ */
+export type ComAnchor = 'centroid' | 'grid' | { joint: string };
+
 export interface Bound {
   b1: Coord;
   b2: Coord;
@@ -181,6 +186,43 @@ export class RealLink extends Link {
   public comOffset?: { along: number; across: number; frame: [string, string] };
 
   /**
+   * What a hand-placed centre of mass is held against while the mechanism is
+   * being edited.
+   *
+   *   'centroid'  the link itself — the point rides every drag, turn and
+   *               deformation, which is `comOffset` above;
+   *   'grid'      the drawing — the point keeps its world coordinate, so moving
+   *               the link out from under it leaves it where it was put;
+   *   {joint}     one pin — the point follows that pin's position and nothing
+   *               else, so turning the link about it does not move it.
+   *
+   * Editing only. Once the mechanism runs, the centre of mass is a point of the
+   * body and rides it like any other: the solved timesteps carry it rigidly
+   * (Mechanism.transportPoint), which is what makes it a centre of mass at all
+   * rather than a mark on the page that inertia would be wrong about.
+   */
+  public comAnchor: ComAnchor = 'centroid';
+
+  /**
+   * Where the point sits relative to whatever `comAnchor` names, in world axes.
+   * Unused by the centroid anchor, which has `comOffset` to express the same
+   * thing in the link's own frame — the difference between the two is the whole
+   * point, so they cannot share one representation.
+   */
+  public comAnchorOffset?: { dx: number; dy: number };
+
+  /** The fixed point a non-centroid anchor measures from, if it still exists. */
+  private anchorPoint(): Coord | undefined {
+    // Read once into a local: inside the callback below, `this.comAnchor` is a
+    // mutable property again and narrowing does not reach it.
+    const anchor = this.comAnchor;
+    if (anchor === 'grid') return new Coord(0, 0);
+    if (anchor === 'centroid') return undefined;
+    const pin = this.joints.find((joint) => joint.id === anchor.joint);
+    return pin ? new Coord(pin.x, pin.y) : undefined;
+  }
+
+  /**
    * The link's own frame: origin at the uniform centroid, x̂ along the two
    * *named* joints — the farthest pair at capture time, so the axis is never
    * degenerate by accident and never silently reinterpreted when the joints
@@ -237,6 +279,9 @@ export class RealLink extends Link {
 
   /** Re-read the local offset from wherever the CoM currently is. */
   captureComOffset(): void {
+    // Both are captured every time, whichever anchor is in force: switching
+    // anchor in the panel must not need the point re-placed, and the anchor a
+    // link is not currently using is the one it will be using next.
     const frame = this.comFrame();
     const dx = this._CoM.x - frame.origin.x;
     const dy = this._CoM.y - frame.origin.y;
@@ -245,10 +290,26 @@ export class RealLink extends Link {
       across: -dx * frame.uy + dy * frame.ux,
       frame: frame.pair,
     };
+    const anchor = this.anchorPoint();
+    this.comAnchorOffset = anchor
+      ? { dx: this._CoM.x - anchor.x, dy: this._CoM.y - anchor.y }
+      : undefined;
   }
 
   /** Where the captured offset lands in today's geometry. */
   customCoMFromOffset(): Coord | undefined {
+    if (this.comAnchor !== 'centroid') {
+      const anchor = this.anchorPoint();
+      if (anchor && this.comAnchorOffset) {
+        return new Coord(anchor.x + this.comAnchorOffset.dx, anchor.y + this.comAnchorOffset.dy);
+      }
+      // The pin this was held against has left the link. Keep the point where
+      // it is and hand it back to the link, which is the one anchor every link
+      // always has -- rather than let it snap to a pin that is not there.
+      this.comAnchor = 'centroid';
+      this.captureComOffset();
+      return new Coord(this._CoM.x, this._CoM.y);
+    }
     if (!this.comOffset) return undefined;
     const frame = this.comFrame(this.comOffset.frame);
     if (!frame.ok) {

--- a/src/app/model/link.ts
+++ b/src/app/model/link.ts
@@ -155,6 +155,22 @@ export class RealLink extends Link {
   public moiIsCustom = false;
   public comIsCustom = false;
   /**
+   * Draw this link as the disc it sweeps rather than as a bar between its
+   * joints — the crank of an engine, drawn the way an engine draws it.
+   *
+   * A drawing choice and nothing more. Mass properties keep coming from the
+   * joint skeleton (see uniform-body.ts), so a link's moment of inertia does
+   * not change because someone changed its picture; the Edit panel says so
+   * where the numbers are, rather than leaving the difference to be guessed.
+   *
+   * Only a link with exactly one ground pin can honour it, because the disc
+   * is centred on the pin the link turns about and a link with no such pin
+   * has no centre to offer. `canBeCircular` is that question; the flag is
+   * simply ignored while the answer is no, so a link that loses its ground
+   * comes back as a bar and returns to a disc if it is grounded again.
+   */
+  public isCircle = false;
+  /**
    * A hand-placed centre of mass, held against the link's own frame: along
    * and across the unit direction joints[0]→joints[1], measured from the
    * uniform-body centroid. "Stored against the centroid" is what lets a
@@ -273,6 +289,13 @@ export class RealLink extends Link {
       this.subset = subSet;
     }
     this._CoM = CoM !== undefined ? CoM : RealLink.determineCenterOfMass(joints);
+    // Before the path is built, because being drawn as a disc is what decides
+    // what that path is. `visualSource` is the link this one is a copy of, so
+    // every solved timestep inherits the choice without each cloning site
+    // having to remember it.
+    if (visualSource !== undefined) {
+      this.isCircle = visualSource.isCircle;
+    }
     if (
       visualSource?.isVisualGeometryCurrent &&
       visualSource.joints.length >= 2 &&
@@ -460,6 +483,47 @@ export class RealLink extends Link {
     );
   }
 
+  /**
+   * The pin a circular link turns about, or nothing when it has no single one.
+   *
+   * Exactly one ground, and a revolute one: two grounds make a frame that does
+   * not turn at all, none makes a coupler with no fixed centre to draw about,
+   * and a prismatic ground anchors a slot rather than a pivot. Each of those
+   * would need a different answer to "centred where?", and a disc drawn about
+   * a guess is worse than the bar it replaced.
+   */
+  groundPivot(): Joint | undefined {
+    const pivots = this.joints.filter(
+      (joint) => joint instanceof RealJoint && joint.ground && !(joint instanceof PrisJoint)
+    );
+    return pivots.length === 1 ? pivots[0] : undefined;
+  }
+
+  /** Whether Make Circular has anything to act on. */
+  canBeCircular(): boolean {
+    return this.subset.length === 0 && this.groundPivot() !== undefined;
+  }
+
+  /**
+   * The disc a circular link is drawn as, or nothing when it is not one.
+   *
+   * Centred on the ground pin, and wide enough to reach the outermost joint's
+   * end cap — the same half-width every bar is drawn with — so the disc covers
+   * exactly the ground the bar covered and no pin ends up outside its own link.
+   */
+  private circularOutline(): string | undefined {
+    if (!this.isCircle) return undefined;
+    const centre = this.groundPivot();
+    if (centre === undefined) return undefined;
+    const reach = this.joints.reduce((far, joint) => Math.max(far, getDistance(centre, joint)), 0);
+    const radius = reach + SettingsService.objectScale / 4;
+    const { x, y } = centre;
+    return (
+      `M ${x - radius} ${y} A ${radius} ${radius} 0 0 1 ${x + radius} ${y} ` +
+      `A ${radius} ${radius} 0 0 1 ${x - radius} ${y} Z `
+    );
+  }
+
   getSimplePathString(): string {
     this.externalLines = [];
     let l = this;
@@ -473,6 +537,15 @@ export class RealLink extends Link {
       this.externalLines = [];
       this.initialExternalLines = [];
       return collapsed;
+    }
+    // A disc has no edges, so there is nothing for a joint to be attached
+    // along and nothing for the edit-hover to measure — the same empty answer
+    // the collapsed bar above gives, for the same reason.
+    const disc = this.circularOutline();
+    if (disc) {
+      this.externalLines = [];
+      this.initialExternalLines = [];
+      return disc;
     }
     const hullPoints = hull(points, Infinity) as number[][]; //Hull points find the convex hull (largest fence)
 

--- a/src/app/model/link.ts
+++ b/src/app/model/link.ts
@@ -175,6 +175,16 @@ export class RealLink extends Link {
    * comes back as a bar and returns to a disc if it is grounded again.
    */
   public isCircle = false;
+
+  /**
+   * Whether the outline currently held in `d` is a disc.
+   *
+   * `isCircle` is what was asked for; this is what was drawn. They part company
+   * whenever the link stops or starts qualifying — a ground removed, a ground
+   * put back — and since a path is only rebuilt when something asks it to, the
+   * difference between the two is exactly the signal that it needs rebuilding.
+   */
+  public drawnAsDisc = false;
   /**
    * A hand-placed centre of mass, held against the link's own frame: along
    * and across the unit direction joints[0]→joints[1], measured from the
@@ -450,6 +460,8 @@ export class RealLink extends Link {
   }
 
   getCompoundPathString(): string {
+    // A compound is drawn from the outlines of its parts, never as a disc.
+    this.drawnAsDisc = false;
     // A sealed cylinder's rod welded into this compound is drawn by the skin,
     // above the block; the compound repeating it drew the same bar twice, one
     // copy on the wrong side of the block. The leaf is recognised through its
@@ -587,6 +599,7 @@ export class RealLink extends Link {
 
   getSimplePathString(): string {
     this.externalLines = [];
+    this.drawnAsDisc = false;
     let l = this;
     // Draw link given the desiredJointIDs
     const allJoints = l.joints;
@@ -606,6 +619,7 @@ export class RealLink extends Link {
     if (disc) {
       this.externalLines = [];
       this.initialExternalLines = [];
+      this.drawnAsDisc = true;
       return disc;
     }
     const hullPoints = hull(points, Infinity) as number[][]; //Hull points find the convex hull (largest fence)

--- a/src/app/selected-tab.service.ts
+++ b/src/app/selected-tab.service.ts
@@ -95,6 +95,9 @@ export class SelectedTabService {
       // A fresh visit synthesises a new linkage rather than editing the one the
       // last visit left behind, so nothing here belongs to this one yet.
       this.synthesis.synthesisedIds = { joints: [], links: [] };
+      this.synthesis.driverWanted = false;
+      this.synthesis.driveOnFarPin = false;
+      this.synthesis.driverRefusal = undefined;
     } else if (previousTab === TabID.SYNTHESIZE && this.getCurrentTab() === TabID.EDIT) {
       // save mechanism state if modified in synthesis tab
       this.mechanism.save();

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -1876,6 +1876,24 @@ export class MechanismService {
     this.onMechUpdateState.next(2);
   }
 
+  /**
+   * Draw the selected link as the disc it sweeps, or as a bar again.
+   *
+   * The editable link's own outline is rebuilt here rather than left to the
+   * next update: the drawing on screen in Edit mode is this object, not a
+   * solved copy of it, so nothing else would redraw it until the mechanism
+   * moved. Saved, because it is a change to the drawing a person would expect
+   * to be able to undo.
+   */
+  toggleLinkCircular() {
+    const link = this.activeObjService.selectedLink;
+    if (!link.canBeCircular()) return;
+    link.isCircle = !link.isCircle;
+    link.reComputeDPath();
+    this.updateMechanism(true);
+    this.onMechUpdateState.next(2);
+  }
+
   addJointAtCOM() {
     let link = this.activeObjService.selectedLink;
     let com = link.CoM;

--- a/src/app/services/mechanism.service.ts
+++ b/src/app/services/mechanism.service.ts
@@ -2097,6 +2097,14 @@ export class MechanismService {
         link.massMoI = 0;
         link.moiIsCustom = false;
       }
+      // A link drawn as a disc that has since lost the pin the disc was centred
+      // on -- or been given one back. Nothing else would notice: an outline is
+      // only rebuilt when something asks it to, and grounding a joint asks
+      // about the joint. Left alone, a crank kept its disc after its ground was
+      // removed, and the panel and the canvas disagreed about what it was.
+      if (link.isCircle && link.drawnAsDisc !== link.canBeCircular()) {
+        link.reComputeDPath();
+      }
       if (link.comIsCustom) {
         // A placed point rides the link: re-derived from its stored offset
         // against the centroid, so drags, turns and deformations carry it.

--- a/src/app/services/svg-grid.service.ts
+++ b/src/app/services/svg-grid.service.ts
@@ -166,6 +166,7 @@ export class SvgGridService {
       customEventsHandler: eventsHandler,
     });
     this.guardAgainstStuckPan(root);
+    this.restoreMissingPointerDown(root);
     this.scaleToFitLinkage(false);
   }
 
@@ -266,6 +267,73 @@ export class SvgGridService {
         gestureLive = false;
         // Non-bubbling, so only the listeners on the root see it.
         root.dispatchEvent(new MouseEvent('mouseup', { bubbles: false }));
+      },
+      true
+    );
+  }
+
+  /**
+   * Give back the `pointerdown` Safari owes us after a native menu closes.
+   *
+   * The canvas is driven entirely by pointer events -- the root's own handler
+   * and every joint, link and force binding are `(pointerdown)` -- while
+   * svg-pan-zoom listens for `mousedown`. Normally the pair arrive together and
+   * in that order, so whichever one the gesture belongs to claims it.
+   *
+   * Safari breaks the pair exactly once after dismissing a native `<select>`
+   * popup: the next press arrives as a bare `mousedown` with no `pointerdown`
+   * before it. Traced from the failing gesture, the whole of it:
+   *
+   *     pointerdown SELECT, mousedown SELECT      (popup opens; no release)
+   *     mousedown path#AB                         (no pointerdown!)
+   *     pointerup path#AB, mouseup path#AB
+   *
+   * So the library saw a press the app never did: nothing armed a drag, and the
+   * canvas panned under a cursor that was holding a link. The press after that
+   * is paired again, which is why a click "wakes it up" and hides the cause.
+   *
+   * Rather than teach every binding to accept either event -- and then dedupe
+   * the pair on the browsers that send both -- put the missing event back at
+   * its source. Dispatched during capture, before the mousedown reaches
+   * anything, so handlers still see pointerdown first and in the right order;
+   * every existing binding then works as written.
+   */
+  private restoreMissingPointerDown(root: HTMLElement) {
+    let pressOpened = false;
+    const opened = () => (pressOpened = true);
+    const closed = () => (pressOpened = false);
+    root.addEventListener('pointerdown', opened, true);
+    root.addEventListener('pointerup', closed, true);
+    root.addEventListener('pointercancel', closed, true);
+    // Not every gesture ends in a pointerup -- a release outside the canvas
+    // ends one without it -- so the mouse release clears the flag too.
+    root.addEventListener('mouseup', closed, true);
+    root.addEventListener(
+      'mousedown',
+      (event: MouseEvent) => {
+        if (pressOpened) return;
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+        target.dispatchEvent(
+          new PointerEvent('pointerdown', {
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+            clientX: event.clientX,
+            clientY: event.clientY,
+            screenX: event.screenX,
+            screenY: event.screenY,
+            button: event.button,
+            buttons: event.buttons,
+            ctrlKey: event.ctrlKey,
+            shiftKey: event.shiftKey,
+            altKey: event.altKey,
+            metaKey: event.metaKey,
+            pointerId: 1,
+            pointerType: 'mouse',
+            isPrimary: true,
+          })
+        );
       },
       true
     );

--- a/src/app/services/synthesis/driver-dyad.spec.ts
+++ b/src/app/services/synthesis/driver-dyad.spec.ts
@@ -1,0 +1,122 @@
+import { Coord } from 'src/app/model/coord';
+import { driverDyadFor, DriverDyad } from './driver-dyad';
+
+/**
+ * The claim under test is not "a dyad came back" but "the dyad that came back
+ * drives the thing" — so every case here checks the delivered motion rather
+ * than the numbers the construction happened to produce.
+ *
+ * The driven pin rides a circle about the four-bar's ground pin, so its
+ * distance from the driver's ground is what the driver has to be able to
+ * match. A dyad reaches a pin position exactly when that distance lies between
+ * `coupler − crank` and `coupler + crank`, and it turns around where the
+ * distance stops climbing. Both are read straight off the geometry below.
+ */
+
+const pivot = new Coord(0, 0);
+const RADIUS = 4;
+
+function pinAt(degrees: number): Coord {
+  const radians = (degrees * Math.PI) / 180;
+  return new Coord(RADIUS * Math.cos(radians), RADIUS * Math.sin(radians));
+}
+
+function unwrap(result: ReturnType<typeof driverDyadFor>): DriverDyad {
+  if ('refusal' in result) throw new Error(`expected a dyad, got refusal: ${result.refusal}`);
+  return result.dyad;
+}
+
+/** How far the driven pin sits from the driver's ground, at that crank angle. */
+function reachTo(dyad: DriverDyad, degrees: number): number {
+  const pin = pinAt(degrees);
+  return Math.hypot(pin.x - dyad.ground.x, pin.y - dyad.ground.y);
+}
+
+describe('sizing the driver dyad for a synthesised four-bar', () => {
+  it('reaches every pose, and carries past the outer ones', () => {
+    const poses = [10, 55, 80];
+    const dyad = unwrap(driverDyadFor(pivot, poses.map(pinAt)));
+
+    const shortest = dyad.couplerLength - dyad.crankLength;
+    const longest = dyad.couplerLength + dyad.crankLength;
+    for (const pose of poses) {
+      const reach = reachTo(dyad, pose);
+      // Strictly inside, not merely within: a pose sitting on a turning point
+      // is reached at dead centre, where the six-bar has no velocity.
+      expect(reach).toBeGreaterThan(shortest);
+      expect(reach).toBeLessThan(longest);
+    }
+  });
+
+  it('turns around outside the poses rather than between them', () => {
+    // The failure this rules out: a driver whose stroke ends partway along the
+    // swing, so the four-bar reverses before reaching the last pose. It shows
+    // up as the reach climbing and then falling again inside the arc.
+    const dyad = unwrap(driverDyadFor(pivot, [10, 55, 80].map(pinAt)));
+
+    let previous = reachTo(dyad, 10);
+    for (let degrees = 10.5; degrees <= 80; degrees += 0.5) {
+      const reach = reachTo(dyad, degrees);
+      expect(reach).toBeLessThan(previous);
+      previous = reach;
+    }
+  });
+
+  it('assembles in the pose the linkage is drawn in', () => {
+    const dyad = unwrap(driverDyadFor(pivot, [10, 55, 80].map(pinAt)));
+    const first = pinAt(10);
+
+    expect(Math.hypot(dyad.elbow.x - dyad.ground.x, dyad.elbow.y - dyad.ground.y)).toBeCloseTo(
+      dyad.crankLength,
+      6
+    );
+    expect(Math.hypot(dyad.elbow.x - first.x, dyad.elbow.y - first.y)).toBeCloseTo(
+      dyad.couplerLength,
+      6
+    );
+  });
+
+  it('gives the crank a full turn to make, not a swing of its own', () => {
+    // A dyad only works as a driver if its own crank goes all the way round,
+    // which needs the crank shorter than the coupler by more than nothing.
+    const dyad = unwrap(driverDyadFor(pivot, [10, 55, 80].map(pinAt)));
+
+    expect(dyad.crankLength).toBeGreaterThan(0);
+    expect(dyad.couplerLength).toBeGreaterThan(dyad.crankLength);
+    const groundGap = Math.hypot(dyad.ground.x - pivot.x, dyad.ground.y - pivot.y);
+    expect(groundGap).toBeGreaterThan(dyad.crankLength);
+  });
+
+  it('handles poses given in any order, and across the wrap at zero', () => {
+    // The arc is found from the widest empty gap, so neither the order the
+    // poses arrive in nor where they straddle 0° should matter.
+    const jumbled = unwrap(driverDyadFor(pivot, [80, 10, 55].map(pinAt)));
+    const straight = unwrap(driverDyadFor(pivot, [10, 55, 80].map(pinAt)));
+    expect(jumbled.ground.x).toBeCloseTo(straight.ground.x, 9);
+    expect(jumbled.ground.y).toBeCloseTo(straight.ground.y, 9);
+
+    const wrapped = unwrap(driverDyadFor(pivot, [350, 20, 5].map(pinAt)));
+    const shortest = wrapped.couplerLength - wrapped.crankLength;
+    const longest = wrapped.couplerLength + wrapped.crankLength;
+    for (const pose of [350, 5, 20]) {
+      expect(reachTo(wrapped, pose)).toBeGreaterThan(shortest);
+      expect(reachTo(wrapped, pose)).toBeLessThan(longest);
+    }
+  });
+
+  it('says why when the swing is too wide for any one crank', () => {
+    // Past half a turn the two turning points cannot both be kept off the arc,
+    // whatever the placement — so this is a refusal, not a worse answer.
+    const tooWide = driverDyadFor(pivot, [0, 100, 200].map(pinAt));
+    expect('refusal' in tooWide).toBe(true);
+    if ('refusal' in tooWide) {
+      expect(tooWide.refusal).toContain('°');
+      expect(tooWide.refusal).toContain('swapping which pin drives');
+    }
+  });
+
+  it('says why when there is no crank to drive', () => {
+    const collapsed = driverDyadFor(pivot, [new Coord(0, 0), new Coord(0, 0)]);
+    expect('refusal' in collapsed).toBe(true);
+  });
+});

--- a/src/app/services/synthesis/driver-dyad.spec.ts
+++ b/src/app/services/synthesis/driver-dyad.spec.ts
@@ -119,4 +119,41 @@ describe('sizing the driver dyad for a synthesised four-bar', () => {
     const collapsed = driverDyadFor(pivot, [new Coord(0, 0), new Coord(0, 0)]);
     expect('refusal' in collapsed).toBe(true);
   });
+
+  it('builds the swings between the overtravel clamp and the ceiling', () => {
+    // The ceiling is 170°, and overtravel adds 8% of the span to it. Clamping
+    // that addition to what is left under the ceiling used to produce exactly
+    // the ceiling, which the check then refused -- so everything above
+    // 170/1.08 = 157.4° was turned away, including this 160° swing that the
+    // construction handles perfectly well.
+    const wide = unwrap(driverDyadFor(pivot, [0, 80, 160].map(pinAt)));
+
+    const shortest = wide.couplerLength - wide.crankLength;
+    const longest = wide.couplerLength + wide.crankLength;
+    for (const pose of [0, 80, 160]) {
+      expect(reachTo(wide, pose)).toBeGreaterThanOrEqual(shortest);
+      expect(reachTo(wide, pose)).toBeLessThanOrEqual(longest);
+    }
+    // And it still runs the whole way one way, which is the thing a driver is
+    // for: the ground is placed past the far end of the arc, so the reach
+    // falls from the first pose to the last without turning back.
+    let previous = reachTo(wide, 0);
+    for (let angle = 1; angle <= 160; angle += 1) {
+      const next = reachTo(wide, angle);
+      expect(next).toBeLessThan(previous);
+      previous = next;
+    }
+  });
+
+  it('refuses poses that stand still for standing still, not for turning', () => {
+    // Every pose at one angle leaves the whole circle empty. Measured modulo a
+    // turn that read as no gap at all, so the arc came back as a full turn and
+    // the reader was told the input had to swing 360°.
+    const still = driverDyadFor(pivot, [20, 20, 20].map(pinAt));
+    expect('refusal' in still).toBe(true);
+    if ('refusal' in still) {
+      expect(still.refusal).toContain('no motion');
+      expect(still.refusal).not.toContain('360');
+    }
+  });
 });

--- a/src/app/services/synthesis/driver-dyad.ts
+++ b/src/app/services/synthesis/driver-dyad.ts
@@ -93,11 +93,13 @@ export function driverDyadFor(pivot: Coord, drivenPin: Coord[]): DriverDyadResul
     return { refusal: 'These poses need no motion at the input, so there is nothing to drive.' };
   }
 
-  // Overtravel first, then the ceiling: a swing that only breaches it once the
-  // margin is added is still buildable, just without the full margin.
-  const margin = Math.min((span * OVERTRAVEL) / 2, Math.max(0, (WIDEST_SWING - span) / 2));
-  const swing = span + 2 * margin;
-  if (swing >= WIDEST_SWING) {
+  // The ceiling is on the arc the poses themselves ask for. Overtravel is
+  // added after it and clamped to what is left, which is what makes the
+  // clamping safe -- asked of the swing instead, the two fought: any span wide
+  // enough for the clamp to bite came out at exactly WIDEST_SWING and was
+  // refused by the very next line, so the real ceiling stood at 170/1.08, and
+  // a 160° swing well inside the documented limit was turned away.
+  if (span >= WIDEST_SWING) {
     return {
       refusal:
         `The input has to swing ${Math.round((span * 180) / Math.PI)}° between these poses, ` +
@@ -105,6 +107,8 @@ export function driverDyadFor(pivot: Coord, drivenPin: Coord[]): DriverDyadResul
         'to the others, or swapping which pin drives, brings it back in reach.',
     };
   }
+  const margin = Math.min((span * OVERTRAVEL) / 2, (WIDEST_SWING - span) / 2);
+  const swing = span + 2 * margin;
 
   const from = start - margin;
   const to = start + span + margin;
@@ -190,13 +194,22 @@ function smallestArcContaining(angles: number[]): { start: number; span: number 
   const sorted = angles.map((angle) => ((angle % TAU) + TAU) % TAU).sort((a, b) => a - b);
   let widest = -1;
   let after = 0;
-  for (let i = 0; i < sorted.length; i++) {
-    const next = sorted[(i + 1) % sorted.length];
-    const gap = (((next - sorted[i]) % TAU) + TAU) % TAU;
+  for (let i = 0; i + 1 < sorted.length; i++) {
+    const gap = sorted[i + 1] - sorted[i];
     if (gap > widest) {
       widest = gap;
-      after = (i + 1) % sorted.length;
+      after = i + 1;
     }
+  }
+  // The wrap from the last angle back to the first, measured directly rather
+  // than modulo a turn: poses that all sit at one angle leave the whole circle
+  // empty, and a modulo reads that as no gap at all -- which came back as an
+  // arc of a full turn, and refused three identical poses for asking the input
+  // to swing 360° instead of for asking it to stand still.
+  const wrap = TAU - (sorted[sorted.length - 1] - sorted[0]);
+  if (wrap > widest) {
+    widest = wrap;
+    after = 0;
   }
   return { start: sorted[after], span: TAU - widest };
 }

--- a/src/app/services/synthesis/driver-dyad.ts
+++ b/src/app/services/synthesis/driver-dyad.ts
@@ -1,0 +1,202 @@
+import { Coord } from 'src/app/model/coord';
+
+/**
+ * Sizing the two-bar driver that turns a synthesised four-bar into a six-bar
+ * an ordinary motor can run.
+ *
+ * Three-position synthesis answers "what linkage passes through these poses",
+ * not "what linkage can be driven through them". The four-bar it produces is
+ * usually a double-rocker: its input pin swings across an arc and stops, so
+ * there is no crank on it to attach a motor to. The classical repair is to
+ * drive it indirectly — plant a second ground pin, put a fully rotating crank
+ * on it, and couple that crank to the four-bar's input pin. One turn of the
+ * new crank then walks the four-bar across its arc and back.
+ *
+ * The sizing is closed-form, which is the whole reason to do it this way
+ * rather than by placing the parts near where they look right. Writing D for
+ * the distance between the two ground pins, R for the four-bar's input crank,
+ * and Δ for the arc its pin has to cover, the driven pin's distance from the
+ * new ground is
+ *
+ *     d(θ)² = D² + R² − 2·D·R·cos(θ − φ)
+ *
+ * which is largest and smallest exactly where the driver folds straight and
+ * doubles back. Setting
+ *
+ *     coupler + crank = max d       coupler − crank = min d
+ *
+ * puts those two turning points precisely at the ends of the arc, so a full
+ * rotation delivers that swing and no more. Nothing here is fitted or
+ * searched; if a dyad is reported, it drives the four-bar.
+ */
+
+const TAU = Math.PI * 2;
+
+/** How far past the outermost poses the driver carries the linkage, as a
+ *  fraction of the arc between them. Poses sitting exactly at the turning
+ *  points would be reached only at dead centre, where the six-bar has no
+ *  velocity and drawing it looks like a stall. */
+const OVERTRAVEL = 0.08;
+
+/** Beyond this the construction has no room left (see `place`). */
+const WIDEST_SWING = (170 * Math.PI) / 180;
+
+/**
+ * How far the new ground pin sits from the four-bar's, in input-crank lengths.
+ *
+ * Free in the sense that any placement outside the swept directions delivers
+ * the swing, so it is chosen for the drawing rather than for the mathematics.
+ * Closer keeps the machine compact, which matters more than it sounds: three
+ * position synthesis can put a four-bar's pivots a long way from the poses, the
+ * driver hangs off one of those pivots, and the result is easily several times
+ * the size of the region anyone is looking at. It cannot go arbitrarily close —
+ * `coupler − crank` shrinks with it, and at zero the driver would fold through
+ * its own ground pin and stall there. At this distance even the widest
+ * buildable swing leaves that gap at about half the four-bar's crank.
+ */
+const GROUND_SPACING = 1.5;
+
+export interface DriverDyad {
+  /** The new ground pin, which carries the input crank. */
+  ground: Coord;
+  /** The pin between crank and coupler, placed for the pose the drawing is in. */
+  elbow: Coord;
+  crankLength: number;
+  couplerLength: number;
+  /** The swing this dyad delivers, in radians — for reporting, not for solving. */
+  swing: number;
+}
+
+export type DriverDyadResult = { dyad: DriverDyad } | { refusal: string };
+
+/**
+ * The driver for a four-bar whose input pin visits `drivenPin` positions about
+ * `pivot`, or the reason there is none.
+ *
+ * @param pivot      the four-bar's fixed input pin
+ * @param drivenPin  where its moving input pin sits at each pose, the first of
+ *                   which is the pose the drawing is currently assembled in
+ */
+export function driverDyadFor(pivot: Coord, drivenPin: Coord[]): DriverDyadResult {
+  if (drivenPin.length < 2) {
+    return { refusal: 'A driver needs at least two poses to know what swing to deliver.' };
+  }
+
+  const radius = distance(pivot, drivenPin[0]);
+  if (!(radius > 0)) {
+    return { refusal: 'The four-bar has no input crank to drive: its two pins are in one place.' };
+  }
+
+  const angles = drivenPin.map((pin) => Math.atan2(pin.y - pivot.y, pin.x - pivot.x));
+  const { start, span } = smallestArcContaining(angles);
+  if (!(span > 0)) {
+    return { refusal: 'These poses need no motion at the input, so there is nothing to drive.' };
+  }
+
+  // Overtravel first, then the ceiling: a swing that only breaches it once the
+  // margin is added is still buildable, just without the full margin.
+  const margin = Math.min((span * OVERTRAVEL) / 2, Math.max(0, (WIDEST_SWING - span) / 2));
+  const swing = span + 2 * margin;
+  if (swing >= WIDEST_SWING) {
+    return {
+      refusal:
+        `The input has to swing ${Math.round((span * 180) / Math.PI)}° between these poses, ` +
+        'which is more than a single driver crank can deliver. Moving the middle pose closer ' +
+        'to the others, or swapping which pin drives, brings it back in reach.',
+    };
+  }
+
+  const from = start - margin;
+  const to = start + span + margin;
+  const ground = place(pivot, radius, from, to);
+
+  // The two turning points, by construction the far and near ends of the
+  // swing — the arc was placed so that d(θ) climbs the whole way between them.
+  const far = distance(ground, on(pivot, radius, from));
+  const near = distance(ground, on(pivot, radius, to));
+  const crankLength = (far - near) / 2;
+  const couplerLength = (far + near) / 2;
+  if (!(crankLength > 0) || !(couplerLength > crankLength)) {
+    return { refusal: 'No driver crank fits this swing without passing through its own ground.' };
+  }
+
+  // The elbow for the pose actually on the drawing, which is somewhere inside
+  // the swing rather than at either end, so it has to be intersected for.
+  const elbow = elbowAt(ground, crankLength, drivenPin[0], couplerLength);
+  if (elbow === undefined) {
+    return { refusal: 'The driver cannot be assembled in the pose the linkage is drawn in.' };
+  }
+
+  return { dyad: { ground, elbow, crankLength, couplerLength, swing } };
+}
+
+/**
+ * Where to plant the new ground pin.
+ *
+ * d(θ) rises and falls once per turn, with its turning points on the line
+ * through the two ground pins. Put that line anywhere the input pin actually
+ * travels and the pin would reverse mid-swing — the driver would reach an end
+ * of its stroke partway along, and the four-bar would never see the rest. Both
+ * ends of the line have to miss the swept arc, and since they are half a turn
+ * apart, the arc has to be under half a turn for any placement to exist.
+ *
+ * Of the placements that work, this takes the middle of the clear run just past
+ * the arc's end: the furthest from either edge, so rounding cannot land the
+ * turning point inside the swing.
+ */
+function place(pivot: Coord, radius: number, from: number, to: number): Coord {
+  const clearance = Math.PI - (to - from);
+  const direction = to + clearance / 2;
+  return new Coord(
+    pivot.x + GROUND_SPACING * radius * Math.cos(direction),
+    pivot.y + GROUND_SPACING * radius * Math.sin(direction)
+  );
+}
+
+/**
+ * The elbow pin: `crank` from the ground, `coupler` from the driven pin.
+ *
+ * Two such points exist — the driver's two assembly modes, mirrored across the
+ * line between those pins. They deliver the same motion, so this takes the
+ * left-hand one and says so, rather than leaving the choice to the sign that
+ * happens to come out of the square root.
+ */
+function elbowAt(ground: Coord, crank: number, driven: Coord, coupler: number): Coord | undefined {
+  const span = distance(ground, driven);
+  if (span === 0 || span > crank + coupler || span < Math.abs(coupler - crank)) {
+    return undefined;
+  }
+  const along = (span * span + crank * crank - coupler * coupler) / (2 * span);
+  const across = Math.sqrt(Math.max(0, crank * crank - along * along));
+  const ux = (driven.x - ground.x) / span;
+  const uy = (driven.y - ground.y) / span;
+  return new Coord(ground.x + along * ux - across * uy, ground.y + along * uy + across * ux);
+}
+
+/** The point at `angle` on the circle of `radius` about `centre`. */
+function on(centre: Coord, radius: number, angle: number): Coord {
+  return new Coord(centre.x + radius * Math.cos(angle), centre.y + radius * Math.sin(angle));
+}
+
+function distance(a: Coord, b: Coord): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+/**
+ * The shortest arc holding every angle: found as the complement of the widest
+ * empty gap between neighbours, which is the one stretch nothing has to cross.
+ */
+function smallestArcContaining(angles: number[]): { start: number; span: number } {
+  const sorted = angles.map((angle) => ((angle % TAU) + TAU) % TAU).sort((a, b) => a - b);
+  let widest = -1;
+  let after = 0;
+  for (let i = 0; i < sorted.length; i++) {
+    const next = sorted[(i + 1) % sorted.length];
+    const gap = (((next - sorted[i]) % TAU) + TAU) % TAU;
+    if (gap > widest) {
+      widest = gap;
+      after = (i + 1) % sorted.length;
+    }
+  }
+  return { start: sorted[after], span: TAU - widest };
+}

--- a/src/app/services/synthesis/synthesis-builder.service.ts
+++ b/src/app/services/synthesis/synthesis-builder.service.ts
@@ -38,6 +38,22 @@ export class SynthesisBuilderService {
    */
   public synthesisedIds: { joints: string[]; links: string[] } = { joints: [], links: [] };
 
+  /**
+   * Whether the linkage should be built with a driver on it, and which of its
+   * two ground pins the drive belongs to.
+   *
+   * Held as intent rather than applied to the drawing, because synthesis re-runs
+   * from scratch on every change to a pose: a driver bolted on afterwards would
+   * be thrown away by the next nudge of a coordinate, and a drive pin moved by
+   * hand would move back. Both are read at build time instead, so they survive
+   * every rebuild and there is only ever one way the linkage came to be.
+   */
+  public driverWanted: boolean = false;
+  public driveOnFarPin: boolean = false;
+
+  /** Why the last build could not fit a driver, for the panel to show. */
+  public driverRefusal: string | undefined;
+
   _COR: COR;
   _length: number; // length of the end-effector link
   _selectedPose: number; // currently selected pose (1-3)

--- a/src/app/services/transcoding/mechanism-builder.ts
+++ b/src/app/services/transcoding/mechanism-builder.ts
@@ -289,6 +289,17 @@ export class MechanismBuilder {
       }
     });
 
+    // What each hand-placed centre of mass is held against. The offsets it
+    // needs are captured from the decoded coordinate on the first update, the
+    // same way the centroid anchor already works -- the URL carries where the
+    // point is, and the anchor says what it is measured from.
+    this.transcoder.getComAnchors().forEach((entry) => {
+      const [reference, jointID] = entry.substring(2).split('~');
+      const link = this.getLinkByID(links, reference);
+      if (!(link instanceof RealLink)) return;
+      link.comAnchor = entry.charAt(1) === 'G' ? 'grid' : { joint: jointID };
+    });
+
     // A sealed cylinder's parts always follow their own shapes. Nothing that
     // shipped ever let anyone choose their inertia or centres — the values in
     // circulating URLs are fixture defaults — so decoding migrates the parts

--- a/src/app/services/transcoding/mechanism-builder.ts
+++ b/src/app/services/transcoding/mechanism-builder.ts
@@ -100,6 +100,14 @@ export class MechanismBuilder {
       link.moiIsCustom = linkData.moiIsCustom;
       link.comIsCustom = linkData.comIsCustom;
       link.fill = linkData.color;
+      // The joints are all built before any link is (they have to be — a link
+      // is named by the ones it holds), so the ground pin a disc is centred on
+      // is already known here and the outline can be built for real rather
+      // than as a bar to be corrected on the next update.
+      if (linkData.isCircle) {
+        link.isCircle = true;
+        link.reComputeDPath();
+      }
     } else {
       link = new SliderBlock(linkData.id, jointsOnLink, linkData.mass);
     }

--- a/src/app/services/transcoding/string-transcoder.ts
+++ b/src/app/services/transcoding/string-transcoder.ts
@@ -444,11 +444,20 @@ export class StringTranscoder extends GenericTranscoder {
       '.' +
       activeObjString;
 
-    // Written only when something is locked, so a lock-free URL stays
-    // byte-identical to one written before locks existed — the same bargain
-    // the slot triple and the per-joint drive speed struck.
-    if (this.lockedIds.length > 0) {
-      fullString += '.' + this.lockedIds.join(',');
+    // Written only when there is something to say, so a URL with no locks and
+    // no re-anchored centre of mass stays byte-identical to one written before
+    // either existed — the same bargain the slot triple and the per-joint
+    // drive speed struck.
+    //
+    // Centre-of-mass anchors share this section rather than opening a second
+    // one, because they are the same shape of thing: a tagged reference to an
+    // object the URL already carries. Their tag is 'C', which no lock uses, so
+    // the two are told apart on the way in and neither can be mistaken for the
+    // other. 'CG<link>' holds the point on the drawing; 'CJ<link>~<joint>'
+    // holds it on one pin, '~' being a character no id can contain.
+    const trailing = [...this.lockedIds, ...this.comAnchors];
+    if (trailing.length > 0) {
+      fullString += '.' + trailing.join(',');
     }
 
     // add checksum character in the end
@@ -558,11 +567,15 @@ export class StringTranscoder extends GenericTranscoder {
     let activeType = sd.isEmpty() ? 'N' : sd.nextCharacter();
     let activeID = sd.isEmpty() ? '' : sd.nextToken('.');
 
-    // The lock section: type-tagged ids, absent on every URL written before
+    // The trailing section: type-tagged ids, absent on every URL written before
     // locks existed — and "absent" simply means the disassembler is empty.
+    // 'C' entries are centre-of-mass anchors and go to their own list, so the
+    // lock validator below never has to know they exist.
     while (!sd.isEmpty()) {
-      let lockedId = sd.nextToken(',');
-      if (lockedId !== '') this.lockedIds.push(lockedId);
+      let entry = sd.nextToken(',');
+      if (entry === '') continue;
+      if (entry.charAt(0) === 'C') this.comAnchors.push(entry);
+      else this.lockedIds.push(entry);
     }
 
     let typeEnum;
@@ -668,6 +681,28 @@ export class StringTranscoder extends GenericTranscoder {
         (tag === 'F' && forceIDs.has(id));
       if (!resolves) {
         throw new Error('URL locks an object it does not contain');
+      }
+    });
+    this.validateDecodedComAnchors(linkIDs);
+  }
+
+  /**
+   * Every anchor must name a link this URL carries, and a pin anchor must name
+   * a joint of that same link — anchoring to a pin the link does not hold has
+   * no meaning, and would silently fall back to the centroid on first use.
+   */
+  private validateDecodedComAnchors(linkIDs: Set<string>): void {
+    this.comAnchors.forEach((entry) => {
+      const [reference, jointID] = entry.substring(2).split('~');
+      const link = this.links.find((candidate) => candidate.id === reference);
+      const resolves =
+        linkIDs.has(reference) &&
+        link !== undefined &&
+        (entry.charAt(1) === 'G'
+          ? jointID === undefined
+          : entry.charAt(1) === 'J' && jointID !== undefined && link.jointIDs.includes(jointID));
+      if (!resolves) {
+        throw new Error('URL anchors a center of mass to something it does not contain');
       }
     });
   }

--- a/src/app/services/transcoding/string-transcoder.ts
+++ b/src/app/services/transcoding/string-transcoder.ts
@@ -160,36 +160,50 @@ export class StringTranscoder extends GenericTranscoder {
     This should on average be 26 + [number of joints] characters per link
     */
   /**
-   * The link record's leading character carries root-ness and the two
-   * auto/custom flags in one slot, because the record's tail is variable
-   * length and cannot take an appended field. 'Y'/'N' are the legacy pair and
-   * keep meaning what every old URL meant: values the author chose.
+   * The link record's leading character carries root-ness, the two auto/custom
+   * flags and whether the link is drawn as a disc, all in one slot, because the
+   * record's tail is variable length and cannot take an appended field. 'Y'/'N'
+   * are the legacy pair and keep meaning what every old URL meant: values the
+   * author chose, drawn as a bar.
    *
-   *   root:      Y = both custom   A = both auto   M = MoI auto   G = CoM auto
-   *   non-root:  N = both custom   a = both auto   m = MoI auto   g = CoM auto
+   *   bar,  root:      Y = both custom   A = both auto   M = MoI auto   G = CoM auto
+   *   bar,  non-root:  N = both custom   a = both auto   m = MoI auto   g = CoM auto
+   *   disc, root:      0 = both custom   1 = both auto   2 = MoI auto   3 = CoM auto
+   *   disc, non-root:  4 = both custom   5 = both auto   6 = MoI auto   7 = CoM auto
+   *
+   * Digits for the disc half so the two halves cannot be confused for one
+   * another by eye, and because no letter was left that did not already read as
+   * something else in this format. A drawing with no circular link in it still
+   * encodes to exactly the bytes it did before discs existed — the same bargain
+   * the lock section makes.
    */
-  private static readonly LINK_FLAG_CHARS: Record<string, [boolean, boolean, boolean]> = {
-    // char: [isRoot, moiIsCustom, comIsCustom]
-    Y: [true, true, true],
-    A: [true, false, false],
-    M: [true, false, true],
-    G: [true, true, false],
-    N: [false, true, true],
-    a: [false, false, false],
-    m: [false, false, true],
-    g: [false, true, false],
+  private static readonly LINK_FLAG_CHARS: Record<string, [boolean, boolean, boolean, boolean]> = {
+    // char: [isRoot, moiIsCustom, comIsCustom, isCircle]
+    Y: [true, true, true, false],
+    A: [true, false, false, false],
+    M: [true, false, true, false],
+    G: [true, true, false, false],
+    N: [false, true, true, false],
+    a: [false, false, false, false],
+    m: [false, false, true, false],
+    g: [false, true, false, false],
+    '0': [true, true, true, true],
+    '1': [true, false, false, true],
+    '2': [true, false, true, true],
+    '3': [true, true, false, true],
+    '4': [false, true, true, true],
+    '5': [false, false, false, true],
+    '6': [false, false, true, true],
+    '7': [false, true, false, true],
   };
 
   private encodeLink(link: LinkData): string {
-    const flagChar = (root: string[]): string =>
-      !link.moiIsCustom && !link.comIsCustom
-        ? root[1]
-        : !link.moiIsCustom
-          ? root[2]
-          : !link.comIsCustom
-            ? root[3]
-            : root[0];
-    let isRoot: string = link.isRoot ? flagChar(['Y', 'A', 'M', 'G']) : flagChar(['N', 'a', 'm', 'g']);
+    // Found in the same table the decoder reads, rather than written out a
+    // second time here: the two can then only agree.
+    const wanted = [link.isRoot, link.moiIsCustom, link.comIsCustom, link.isCircle];
+    const isRoot = Object.keys(StringTranscoder.LINK_FLAG_CHARS).find((candidate) =>
+      StringTranscoder.LINK_FLAG_CHARS[candidate].every((flag, i) => flag === wanted[i])
+    )!;
     let type: string = link.type == LINK_TYPE.REAL ? 'R' : 'P';
     let id = link.id;
     let massString = this.encodeDecimalNumber(link.mass);
@@ -243,7 +257,7 @@ export class StringTranscoder extends GenericTranscoder {
       // not quietly demote the link to a non-root nobody solves.
       throw new Error(`Unknown link flag character '${flagChar}'`);
     }
-    const [isRoot, moiIsCustom, comIsCustom] = flags;
+    const [isRoot, moiIsCustom, comIsCustom, isCircle] = flags;
     let type = sd.nextCharacter() === 'R' ? LINK_TYPE.REAL : LINK_TYPE.PISTON;
     let id = sd.nextToken();
     let name = sd.nextToken();
@@ -278,7 +292,8 @@ export class StringTranscoder extends GenericTranscoder {
       jointIDs,
       subsetLinkIDs,
       moiIsCustom,
-      comIsCustom
+      comIsCustom,
+      isCircle
     );
   }
 

--- a/src/app/services/transcoding/transcoder-data.ts
+++ b/src/app/services/transcoding/transcoder-data.ts
@@ -85,7 +85,9 @@ export class LinkData {
      * variable-length, so there is nowhere behind it to append to.
      */
     public moiIsCustom: boolean = true,
-    public comIsCustom: boolean = true
+    public comIsCustom: boolean = true,
+    /** Whether the link is drawn as the disc it sweeps. Legacy URLs: a bar. */
+    public isCircle: boolean = false
   ) {}
 }
 

--- a/src/app/services/transcoding/transcoder-interface.ts
+++ b/src/app/services/transcoding/transcoder-interface.ts
@@ -31,6 +31,12 @@ export abstract class GenericTranscoder {
    * locks existed.
    */
   protected lockedIds: string[] = [];
+  /**
+   * Which links hold their centre of mass against something other than
+   * themselves, as tagged references sharing the lock section. See
+   * StringTranscoder for the spelling.
+   */
+  protected comAnchors: string[] = [];
 
   // Initialize data dictionaries based on settings enums
   constructor() {
@@ -104,6 +110,14 @@ export abstract class GenericTranscoder {
 
   getLockedIds(): string[] {
     return this.lockedIds;
+  }
+
+  setComAnchors(anchors: string[]): void {
+    this.comAnchors = anchors;
+  }
+
+  getComAnchors(): string[] {
+    return this.comAnchors;
   }
 
   abstract decodeURL(url: string): void;

--- a/src/app/services/transcoding/url-circular-link.spec.ts
+++ b/src/app/services/transcoding/url-circular-link.spec.ts
@@ -64,7 +64,10 @@ describe('a circular link in the URL', () => {
     // Not merely flagged: built as the disc. Joints are decoded before links
     // are, so the ground pin is known and the outline never has to be a bar
     // first and corrected afterwards.
+    // No straight edge: a bar is drawn with two arcs too (its end caps), so
+    // counting arcs would not tell the two apart.
     expect(crank.d.match(/A /g)?.length).toBe(2);
+    expect(crank.d).not.toMatch(/ L /);
     expect(crank.externalLines).toEqual([]);
   });
 

--- a/src/app/services/transcoding/url-circular-link.spec.ts
+++ b/src/app/services/transcoding/url-circular-link.spec.ts
@@ -1,0 +1,93 @@
+import '../../model/joint';
+import { Joint, RevJoint } from '../../model/joint';
+import { Force } from '../../model/force';
+import { Link, RealLink } from '../../model/link';
+import { ActiveObjService } from '../active-obj.service';
+import { MechanismService } from '../mechanism.service';
+import { SettingsService } from '../settings.service';
+import { urlGeneratorFor } from '../../../test-utils/url-encoding';
+import { MechanismBuilder } from './mechanism-builder';
+import { StringTranscoder } from './string-transcoder';
+import { MODEL_SCALE } from '../../model/render-scale';
+
+/**
+ * Whether a link is drawn as a disc rides in the link record's leading
+ * character, alongside root-ness and the two auto/custom mass flags. There is
+ * nowhere behind it to append to -- the record's tail is a variable-length list
+ * of joint ids -- so the flag had to go into the one slot that is fixed width.
+ *
+ * The compatibility claim, and the reason it is worth stating in bytes: the
+ * eight legacy characters keep their exact meanings, and the eight new ones are
+ * reached only by a link someone actually asked to draw round. A drawing with
+ * no circular link in it therefore encodes to the same bytes it always did.
+ */
+
+const S = MODEL_SCALE;
+
+function source(round: boolean) {
+  const ground = new RevJoint('A', 0, 0, true, true);
+  const throwPin = new RevJoint('B', 2 * S, 0);
+  const crank = new RealLink('AB', [ground, throwPin], 1, 1);
+  [ground, throwPin].forEach((joint) => joint.links.push(crank));
+  ground.connectedJoints.push(throwPin);
+  throwPin.connectedJoints.push(ground);
+  crank.isCircle = round;
+  return { joints: [ground, throwPin], links: [crank], forces: [] as Force[] };
+}
+
+function encode(round: boolean): string {
+  return urlGeneratorFor(
+    { ...source(round), mechanismTimeStep: 0 } as unknown as MechanismService,
+    new SettingsService()
+  ).generateUrlQuery();
+}
+
+function decode(encoded: string): { joints: Joint[]; links: Link[] } {
+  const decoder = new StringTranscoder();
+  decoder.decodeURL(encoded);
+  const target = {
+    joints: [] as Joint[],
+    links: [] as Link[],
+    forces: [] as Force[],
+    mechanismTimeStep: 0,
+  } as unknown as MechanismService;
+  new MechanismBuilder(target, decoder, new SettingsService(), new ActiveObjService()).build(true);
+  return target;
+}
+
+describe('a circular link in the URL', () => {
+  it('round-trips the choice, and opens already drawn as a disc', () => {
+    const opened = decode(encode(true));
+    const crank = opened.links.find((link) => link.id === 'AB') as RealLink;
+
+    expect(crank.isCircle).toBe(true);
+    // Not merely flagged: built as the disc. Joints are decoded before links
+    // are, so the ground pin is known and the outline never has to be a bar
+    // first and corrected afterwards.
+    expect(crank.d.match(/A /g)?.length).toBe(2);
+    expect(crank.externalLines).toEqual([]);
+  });
+
+  it('leaves a drawing of ordinary bars byte-for-byte as it was', () => {
+    // One character differs between the two spellings, and it is the link
+    // record's first -- so nothing about the format moved.
+    const asBar = encode(false);
+    const asDisc = encode(true);
+
+    expect(asBar.length).toBe(asDisc.length);
+    const at = [...asBar].findIndex((char, i) => char !== asDisc[i]);
+    expect([...asBar].filter((char, i) => char !== asDisc[i]).length).toBe(1);
+    // 'A' is root with both mass properties following the shape; '1' is that
+    // same link, drawn round. The pairing is the table's, not this test's.
+    expect(asBar[at]).toBe('A');
+    expect(asDisc[at]).toBe('1');
+    expect(decode(asBar).links.every((link) => !(link as RealLink).isCircle)).toBe(true);
+  });
+
+  it('refuses a link flag character it does not know', () => {
+    // Fail closed, as the format already did: a record from some future
+    // spelling must reject the URL rather than decode as a link nobody drew.
+    const decoder = new StringTranscoder();
+    expect(() => decoder.decodeURL(encode(true).replace('1R', '$R'))).toThrow();
+  });
+});

--- a/src/app/services/transcoding/url-com-anchor.spec.ts
+++ b/src/app/services/transcoding/url-com-anchor.spec.ts
@@ -1,0 +1,115 @@
+import '../../model/joint';
+import { Joint, RevJoint } from '../../model/joint';
+import { Force } from '../../model/force';
+import { ComAnchor, Link, RealLink } from '../../model/link';
+import { ActiveObjService } from '../active-obj.service';
+import { MechanismService } from '../mechanism.service';
+import { SettingsService } from '../settings.service';
+import { urlGeneratorFor } from '../../../test-utils/url-encoding';
+import { MechanismBuilder } from './mechanism-builder';
+import { StringTranscoder } from './string-transcoder';
+import { MODEL_SCALE } from '../../model/render-scale';
+
+/**
+ * What a hand-placed centre of mass is held against travels in the same
+ * trailing section the lock marks use -- tagged references to objects the URL
+ * already carries, which is exactly what these are. The 'C' tag is one no lock
+ * uses, so the two share a list without either being able to read the other's
+ * entries.
+ *
+ * As with locks, the section is written only when there is something to say,
+ * so a drawing whose centres all ride their own links encodes to the bytes it
+ * did before any of this existed.
+ */
+
+const S = MODEL_SCALE;
+
+function source(anchor: ComAnchor | undefined) {
+  const a = new RevJoint('A', 0, 0, true, true);
+  const b = new RevJoint('B', 2 * S, 0);
+  const bar = new RealLink('AB', [a, b], 1, 1);
+  [a, b].forEach((joint) => joint.links.push(bar));
+  a.connectedJoints.push(b);
+  b.connectedJoints.push(a);
+  if (anchor !== undefined) {
+    bar.placeCustomCoM({ x: 0.5 * S, y: 0.25 * S });
+    bar.comAnchor = anchor;
+    bar.captureComOffset();
+  }
+  return { joints: [a, b], links: [bar], forces: [] as Force[] };
+}
+
+function encode(anchor: ComAnchor | undefined): string {
+  return urlGeneratorFor(
+    { ...source(anchor), mechanismTimeStep: 0 } as unknown as MechanismService,
+    new SettingsService()
+  ).generateUrlQuery();
+}
+
+function decode(encoded: string): { joints: Joint[]; links: Link[] } {
+  const decoder = new StringTranscoder();
+  decoder.decodeURL(encoded);
+  const target = {
+    joints: [] as Joint[],
+    links: [] as Link[],
+    forces: [] as Force[],
+    mechanismTimeStep: 0,
+  } as unknown as MechanismService;
+  new MechanismBuilder(target, decoder, new SettingsService(), new ActiveObjService()).build(true);
+  return target;
+}
+
+/** The URL minus its checksum character, which is a function of length alone. */
+function body(encoded: string): string {
+  return encoded.substring(0, encoded.length - 1);
+}
+
+describe('a center-of-mass anchor in the URL', () => {
+  it('round-trips holding the point on the drawing', () => {
+    const opened = decode(encode('grid'));
+    expect((opened.links[0] as RealLink).comAnchor).toBe('grid');
+  });
+
+  it('round-trips holding the point on one pin', () => {
+    const opened = decode(encode({ joint: 'B' }));
+    expect((opened.links[0] as RealLink).comAnchor).toEqual({ joint: 'B' });
+  });
+
+  it('writes nothing when every center rides its own link', () => {
+    // A hand-placed centre held the way one always was records nothing: that
+    // is the spelling every URL in circulation already has.
+    expect(body(encode('centroid'))).not.toContain('.C');
+
+    // The two that do record something record exactly one entry, and are
+    // otherwise the same bytes -- so nothing about the format moved.
+    expect(body(encode('grid'))).toBe(body(encode('centroid')) + '.CGAB');
+    expect(body(encode({ joint: 'B' }))).toBe(body(encode('centroid')) + '.CJAB~B');
+  });
+
+  it('sits alongside lock marks without either reading the other', () => {
+    const withBoth = source('grid');
+    withBoth.joints[0].locked = true;
+    const encoded = urlGeneratorFor(
+      { ...withBoth, mechanismTimeStep: 0 } as unknown as MechanismService,
+      new SettingsService()
+    ).generateUrlQuery();
+
+    expect(body(encoded)).toContain('.JA,CGAB');
+    const opened = decode(encoded);
+    expect((opened.joints.find((joint) => joint.id === 'A') as RevJoint).locked).toBe(true);
+    expect((opened.links[0] as RealLink).comAnchor).toBe('grid');
+  });
+
+  it('refuses an anchor on a pin the link does not hold', () => {
+    // Fail closed, as the lock section does: a reference that does not resolve
+    // would otherwise decode as a centre quietly held against nothing.
+    const decoder = new StringTranscoder();
+    expect(() => decoder.decodeURL(encode({ joint: 'B' }).replace('CJAB~B', 'CJAB~Z'))).toThrow();
+    expect(() => decoder.decodeURL(encode('grid').replace('CGAB', 'CGZZ'))).toThrow();
+  });
+
+  it('opens a URL written before anchors existed with every center on its link', () => {
+    const opened = decode(encode(undefined));
+    expect((opened.links[0] as RealLink).comAnchor).toBe('centroid');
+  });
+});

--- a/src/app/services/url-generation.service.ts
+++ b/src/app/services/url-generation.service.ts
@@ -100,7 +100,8 @@ export class UrlGenerationService {
           link.joints.map((joint) => joint.id),
           link.subset.map((subset) => subset.id),
           link.moiIsCustom,
-          link.comIsCustom
+          link.comIsCustom,
+          link.isCircle
         )
       );
     } else if (link instanceof SliderBlock) {

--- a/src/app/services/url-generation.service.ts
+++ b/src/app/services/url-generation.service.ts
@@ -185,6 +185,22 @@ export class UrlGenerationService {
         ...this.mechanism.forces.filter((force) => force.locked).map((force) => 'F' + force.id),
       ]);
 
+      // Where a hand-placed centre of mass is held. Only the links that answer
+      // something other than "against the link itself", which is the answer
+      // every link gave before this was a choice.
+      encoder.setComAnchors(
+        this.mechanism.links
+          .filter(
+            (link): link is RealLink =>
+              link instanceof RealLink && link.comIsCustom && link.comAnchor !== 'centroid'
+          )
+          .map((link) =>
+            link.comAnchor === 'grid'
+              ? 'CG' + link.id
+              : 'CJ' + link.id + '~' + (link.comAnchor as { joint: string }).joint
+          )
+      );
+
       // Encode global settings
       encoder.addEnumSetting(
         EnumSetting.LENGTH_UNIT,

--- a/src/assets/icons/make_bar.svg
+++ b/src/assets/icons/make_bar.svg
@@ -1,6 +1,6 @@
 <svg width='26' height='26' viewBox='0 0 26 26' fill='none' xmlns='http://www.w3.org/2000/svg'>
-  <path d='M5.17 15.17 L15.17 5.17 A4 4 0 0 1 20.83 10.83 L10.83 20.83 A4 4 0 0 1 5.17 15.17 Z'
-        stroke-width='2' stroke='currentColor' />
-  <circle cx='8' cy='18' r='2' fill='currentColor' />
-  <circle cx='18' cy='8' r='2' fill='currentColor' />
+  <line x1='4.879' y1='16.879' x2='16.879' y2='4.879' stroke-width='2' stroke='currentColor' />
+  <line x1='9.121' y1='21.121' x2='21.121' y2='9.121' stroke-width='2' stroke='currentColor' />
+  <circle cx='7' cy='19' r='3' stroke-width='2' stroke='currentColor' />
+  <circle cx='19' cy='7' r='3' stroke-width='2' stroke='currentColor' />
 </svg>

--- a/src/assets/icons/make_bar.svg
+++ b/src/assets/icons/make_bar.svg
@@ -1,0 +1,6 @@
+<svg width='26' height='26' viewBox='0 0 26 26' fill='none' xmlns='http://www.w3.org/2000/svg'>
+  <path d='M5.17 15.17 L15.17 5.17 A4 4 0 0 1 20.83 10.83 L10.83 20.83 A4 4 0 0 1 5.17 15.17 Z'
+        stroke-width='2' stroke='currentColor' />
+  <circle cx='8' cy='18' r='2' fill='currentColor' />
+  <circle cx='18' cy='8' r='2' fill='currentColor' />
+</svg>

--- a/src/assets/icons/make_circular.svg
+++ b/src/assets/icons/make_circular.svg
@@ -1,0 +1,5 @@
+<svg width='26' height='26' viewBox='0 0 26 26' fill='none' xmlns='http://www.w3.org/2000/svg'>
+  <circle cx='13' cy='13' r='9' stroke-width='2' stroke='currentColor' />
+  <circle cx='13' cy='13' r='2' fill='currentColor' />
+  <circle cx='13' cy='7' r='2' fill='currentColor' />
+</svg>

--- a/src/assets/icons/make_circular.svg
+++ b/src/assets/icons/make_circular.svg
@@ -1,5 +1,4 @@
 <svg width='26' height='26' viewBox='0 0 26 26' fill='none' xmlns='http://www.w3.org/2000/svg'>
   <circle cx='13' cy='13' r='9' stroke-width='2' stroke='currentColor' />
-  <circle cx='13' cy='13' r='2' fill='currentColor' />
-  <circle cx='13' cy='7' r='2' fill='currentColor' />
+  <circle cx='13' cy='13' r='3' stroke-width='2' stroke='currentColor' />
 </svg>

--- a/src/assets/icons/make_circular.svg
+++ b/src/assets/icons/make_circular.svg
@@ -1,4 +1,5 @@
 <svg width='26' height='26' viewBox='0 0 26 26' fill='none' xmlns='http://www.w3.org/2000/svg'>
   <circle cx='13' cy='13' r='9' stroke-width='2' stroke='currentColor' />
-  <circle cx='13' cy='13' r='3' stroke-width='2' stroke='currentColor' />
+  <circle cx='13' cy='13' r='2' fill='currentColor' />
+  <circle cx='13' cy='7' r='2' fill='currentColor' />
 </svg>


### PR DESCRIPTION
Two features ported from [PMKS-Refactor](https://github.com/PMKS-Web/PMKS-Refactor), reworked to this repo's standards, plus one pre-existing bug found on the way. Targets `multi-mechanism-redesign`, not `main`.

## 1. Make Circular

Right-click a link → **Make Circular** / **Make Bar**. Draws a crank as the disc it sweeps.

Offered only on a link with exactly one revolute ground pin, because that is the only centre a link can offer without being asked. Refactor's version scans for `isGrounded` and returns `''` when it finds nothing, so a coupler made circular **disappears from the canvas**; here the menu item simply isn't there. The flag is ignored rather than cleared when a link stops qualifying, so ungrounding and re-grounding a crank gets the disc back.

**Mass properties deliberately do not change.** `uniform-body.ts` states the doctrine — properties come from the joint skeleton, never the drawn outline, so that inertia can't shift because someone moved a display slider. Being drawn round is the same kind of choice. The Edit panel says so next to the two numbers it would otherwise be fair to assume had changed.

**URL:** the choice rides in the link record's leading character, which already packs root-ness and the two auto/custom flags — the record's tail is a variable-length joint-id list, so that character is the only fixed-width room. The eight legacy characters keep their exact meanings; eight digits carry the disc half. A drawing with no circular link encodes to the bytes it always did, and there's a test asserting exactly that.

## 2. Six-bar driver

New **Drive** section in the Synthesis panel: **Add Driver (Six-Bar)**, **Swap Drive Pin**, **Evaluate Poses**.

Three-position synthesis answers "what linkage passes through these poses", not "what linkage can be driven through them" — the result is usually a double-rocker with no crank to attach a motor to. The driver is the classical repair: a second ground pin, a fully rotating crank, and a coupler to the four-bar's input pin.

The sizing is closed-form and lives in `driver-dyad.ts`, not the panel. With `D` between ground pins, `R` the four-bar's crank and `Δ` the arc to cover, the driven pin's distance from the new ground is `D² + R² − 2DR·cos(θ − φ)`, which turns exactly where the driver folds straight and doubles back. Setting `coupler ± crank` to that distance's extremes puts those turning points at the ends of the arc; placing the new ground in the clear run of directions the pin never sweeps makes the distance climb the whole way across instead of reversing partway. **If a dyad is returned, it drives the linkage** — nothing is fitted or searched.

Refactor's version places the same two parts at hardcoded offsets of `0.8`, `1.75` and `0.75` model units with no check that the result drives anything. Past a swing of half a turn no placement exists at all, and that is a refusal with the angle in it rather than a worse linkage.

Both the driver and the drive pin are held as *intent* on the builder service and read at build time, because synthesis re-runs from scratch on every pose change — anything bolted on afterwards is discarded by the next nudge of a coordinate.

## 3. Pose scoring was comparing two different units (pre-existing)

Found while wiring up Evaluate Poses. The match tolerance is a length in grid units (`0.05` in the panel, `0.09` in the pass/fail check); the distances were between model coordinates, which are grid units × `MODEL_SCALE` (200). A pose therefore counted as reached only within 0.05/200 of a unit — in practice, only the pose the four-bar is built at.

Every pose but the first has been reading "no match" on linkages that pass straight through them. Measured on a three-pose four-bar here: pose 2 is reached to 0.01 units and was marked red. It is now green, and pose 3 — genuinely missed by 1.8 units, a real circuit defect — stays red.

Its own commit, so it can be taken separately.

## What isn't here

- Refactor's `path-synthesis` is a 20-line empty stub.
- Its `generateFourBar` uses the same perpendicular-bisector construction this repo already has, without the quality scoring, multi-mechanism cleanup, or collision-free id allocation — nothing to port.
- Circular links are restricted to simple links; welded compounds build their outline from sub-link paths and would need a separate answer.

## Verification

- `npm test` — **1124 pass** (1107 + 17 new: disc geometry and eligibility, URL round-trip and byte-compatibility, and seven for the dyad).
- The dyad's key test sweeps the whole arc and asserts the driven pin's reach is *strictly monotonic* — that is the proof the driver never reverses mid-swing, rather than a check that plausible numbers came back.
- `e2e/circular-link-and-driver.mjs` — **19/19** against a dev server: the context menu offers Make Circular on a crank and not on a coupler, the disc survives a share-URL round trip and animation, and the six-bar solves a full 365-frame turn, swaps pin, and tears down cleanly.
- Screenshots inspected, not just exit codes. Poses 1 and 2 render green and pose 3 red, matching the measured geometry.
- `npm run build` passes. (`edit-panel.component.scss` still warns at 4.84 kB against a 4 kB budget — it was already over before this branch; error threshold is 6 kB.)

One known console error is left in place and named in the e2e script: `Invalid SVG path number` while synthesis poses are being set up. It reproduces identically on `multi-mechanism-redesign` at b3f9e08, so it predates this work; the script fails on any error other than that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
